### PR TITLE
docs(deploy_scenarios): fix documentation link

### DIFF
--- a/deploy_scenarios/sap_bw4hana_sandbox/README.md
+++ b/deploy_scenarios/sap_bw4hana_sandbox/README.md
@@ -21,7 +21,7 @@ SAP BW/4HANA software versions:
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/README.md
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/README.md
@@ -22,7 +22,7 @@ SAP BW/4HANA software versions:
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_ecc_hana_sandbox/README.md
+++ b/deploy_scenarios/sap_ecc_hana_sandbox/README.md
@@ -21,7 +21,7 @@ EhP8, EhP7
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed/README.md
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed/README.md
@@ -22,7 +22,7 @@ EhP8
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_ecc_ibmdb2_sandbox/README.md
+++ b/deploy_scenarios/sap_ecc_ibmdb2_sandbox/README.md
@@ -22,7 +22,7 @@ EhP8
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_ecc_oracledb_sandbox/README.md
+++ b/deploy_scenarios/sap_ecc_oracledb_sandbox/README.md
@@ -22,7 +22,7 @@ EhP8
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_ecc_sapase_sandbox/README.md
+++ b/deploy_scenarios/sap_ecc_sapase_sandbox/README.md
@@ -22,7 +22,7 @@ EhP8
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/README.md
+++ b/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/README.md
@@ -22,7 +22,7 @@ EhP8
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_hana/README.md
+++ b/deploy_scenarios/sap_hana/README.md
@@ -17,7 +17,7 @@ SPS07, SPS06
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_hana_ha/README.md
+++ b/deploy_scenarios/sap_hana_ha/README.md
@@ -17,7 +17,7 @@ SPS07, SPS06
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_hana_scaleout/README.md
+++ b/deploy_scenarios/sap_hana_scaleout/README.md
@@ -17,7 +17,7 @@ SPS07, SPS06
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_ides_ecc_hana_sandbox/README.md
+++ b/deploy_scenarios/sap_ides_ecc_hana_sandbox/README.md
@@ -21,7 +21,7 @@ EhP8
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/README.md
+++ b/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/README.md
@@ -22,7 +22,7 @@ EhP8, EhP7
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_landscape_s4hana_standard/README.md
+++ b/deploy_scenarios/sap_landscape_s4hana_standard/README.md
@@ -22,7 +22,7 @@ SAP S/4HANA software versions:
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 NOTE: As this provisions and targets more than 5 hosts, it is recommended to execute the Ansible Playbook with `--forks=6` to increase execution speed, as the default forks is `5`.
 

--- a/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/README.md
+++ b/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/README.md
@@ -22,7 +22,7 @@ SAP S/4HANA software versions:
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 NOTE: As this provisions and targets more than 5 hosts, it is recommended to execute the Ansible Playbook with `--forks=6` to increase execution speed, as the default forks is `5`.
 

--- a/deploy_scenarios/sap_nwas_abap_hana_sandbox/README.md
+++ b/deploy_scenarios/sap_nwas_abap_hana_sandbox/README.md
@@ -21,7 +21,7 @@ SAP NetWeaver (ABAP) software versions:
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/README.md
+++ b/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/README.md
@@ -22,7 +22,7 @@ SAP NetWeaver (ABAP) software versions:
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/README.md
+++ b/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/README.md
@@ -22,7 +22,7 @@ SAP NetWeaver (ABAP) software versions:
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_nwas_abap_sapase_sandbox/README.md
+++ b/deploy_scenarios/sap_nwas_abap_sapase_sandbox/README.md
@@ -22,7 +22,7 @@ SAP NetWeaver (ABAP) software versions:
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/README.md
+++ b/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/README.md
@@ -22,7 +22,7 @@ SAP NetWeaver (ABAP) software versions:
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/README.md
+++ b/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/README.md
@@ -22,7 +22,7 @@ SAP NetWeaver (JAVA) software versions:
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_nwas_java_sapase_sandbox/README.md
+++ b/deploy_scenarios/sap_nwas_java_sapase_sandbox/README.md
@@ -22,7 +22,7 @@ SAP NetWeaver (JAVA) software versions:
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_s4hana_distributed/README.md
+++ b/deploy_scenarios/sap_s4hana_distributed/README.md
@@ -21,7 +21,7 @@ SAP S/4HANA software versions:
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_s4hana_distributed_ha/README.md
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/README.md
@@ -21,7 +21,7 @@ SAP S/4HANA software versions:
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 NOTE: As this provisions and targets more than 5 hosts, it is recommended to execute the Ansible Playbook with `--forks=6` to increase execution speed, as the default forks is `5`.
 

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/README.md
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/README.md
@@ -21,7 +21,7 @@ SAP S/4HANA software versions:
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 NOTE: As this provisions and targets more than 5 hosts, it is recommended to execute the Ansible Playbook with `--forks=6` to increase execution speed, as the default forks is `5`.
 

--- a/deploy_scenarios/sap_s4hana_distributed_maintplan/README.md
+++ b/deploy_scenarios/sap_s4hana_distributed_maintplan/README.md
@@ -21,7 +21,7 @@ SAP S/4HANA software versions:
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_s4hana_foundation_sandbox/README.md
+++ b/deploy_scenarios/sap_s4hana_foundation_sandbox/README.md
@@ -22,7 +22,7 @@ SAP S/4HANA software versions:
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_s4hana_foundation_standard/README.md
+++ b/deploy_scenarios/sap_s4hana_foundation_standard/README.md
@@ -22,7 +22,7 @@ SAP S/4HANA software versions:
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_s4hana_sandbox/README.md
+++ b/deploy_scenarios/sap_s4hana_sandbox/README.md
@@ -21,7 +21,7 @@ SAP S/4HANA software versions:
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_s4hana_sandbox_maintplan/README.md
+++ b/deploy_scenarios/sap_s4hana_sandbox_maintplan/README.md
@@ -21,7 +21,7 @@ SAP S/4HANA software versions:
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_s4hana_standard/README.md
+++ b/deploy_scenarios/sap_s4hana_standard/README.md
@@ -21,7 +21,7 @@ SAP S/4HANA software versions:
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_s4hana_standard_maintplan/README.md
+++ b/deploy_scenarios/sap_s4hana_standard_maintplan/README.md
@@ -21,7 +21,7 @@ SAP S/4HANA software versions:
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_solman_sapase_sandbox/README.md
+++ b/deploy_scenarios/sap_solman_sapase_sandbox/README.md
@@ -22,7 +22,7 @@ SAP Solution Manager software versions:
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 

--- a/deploy_scenarios/sap_solman_saphana_sandbox/README.md
+++ b/deploy_scenarios/sap_solman_saphana_sandbox/README.md
@@ -22,7 +22,7 @@ SAP Solution Manager software versions:
 
 ## Execution of Ansible Playbook
 
-Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../docs/README.md) for the capabilities and different execution methods.
+Prior to execution, please read the [full documentation of the Ansible Playbooks for SAP](../../docs/README.md) for the capabilities and different execution methods.
 
 ## Execution outcome
 


### PR DESCRIPTION
# Description

All the documentations reference inside the deploy-scenarios are broken, this commits should fix all of them