### PR TITLE
fix: incorrect regex for handling the hostnames

### DIFF
--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml
@@ -431,12 +431,12 @@
       ansible.builtin.set_fact:
         sap_hana_install_addhosts: |
           {%- if sap_vm_provision_calculate_sap_hana_scaleout_standby > 0 -%}
-            {%- for host in (groups['hana_primary'] | reject('search', '0') | list)[:-1] -%}
+            {%- for host in (groups['hana_primary'] | reject('search', '0$') | list)[:-1] -%}
               {{ hostvars[host]['inventory_hostname_short'] }}:role=worker:workergroup={{ sap_hana_install_workergroup }}:group={{ sap_hana_install_group }},
             {%- endfor -%}
             {{ hostvars[(groups['hana_primary'][-1])]['inventory_hostname_short'] }}:role=standby:workergroup={{ sap_hana_install_workergroup }}:group={{ sap_hana_install_group }}
           {%- elif sap_vm_provision_calculate_sap_hana_scaleout_standby == 0 -%}
-            {%- for host in (groups['hana_primary'] | reject('search', '0') | list) -%}
+            {%- for host in (groups['hana_primary'] | reject('search', '0$') | list) -%}
               {{ hostvars[host]['inventory_hostname_short'] }}:role=worker:workergroup={{ sap_hana_install_workergroup }}:group={{ sap_hana_install_group }}
             {%- endfor -%}
           {%- endif -%}

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml
@@ -431,12 +431,12 @@
       ansible.builtin.set_fact:
         sap_hana_install_addhosts: |
           {%- if sap_vm_provision_calculate_sap_hana_scaleout_standby > 0 -%}
-            {%- for host in (groups['hana_primary'] | reject('search', '0$') | list)[:-1] -%}
+            {%- for host in (groups['hana_primary'] | reject('regex', '0$') | list)[:-1] -%}
               {{ hostvars[host]['inventory_hostname_short'] }}:role=worker:workergroup={{ sap_hana_install_workergroup }}:group={{ sap_hana_install_group }},
             {%- endfor -%}
             {{ hostvars[(groups['hana_primary'][-1])]['inventory_hostname_short'] }}:role=standby:workergroup={{ sap_hana_install_workergroup }}:group={{ sap_hana_install_group }}
           {%- elif sap_vm_provision_calculate_sap_hana_scaleout_standby == 0 -%}
-            {%- for host in (groups['hana_primary'] | reject('search', '0$') | list) -%}
+            {%- for host in (groups['hana_primary'] | reject('regex', '0$') | list) -%}
               {{ hostvars[host]['inventory_hostname_short'] }}:role=worker:workergroup={{ sap_hana_install_workergroup }}:group={{ sap_hana_install_group }}
             {%- endfor -%}
           {%- endif -%}

--- a/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml
@@ -340,12 +340,12 @@
       ansible.builtin.set_fact:
         sap_hana_install_addhosts: |
           {%- if sap_vm_provision_calculate_sap_hana_scaleout_standby > 0 -%}
-            {%- for host in (groups['hana_primary'] | reject('search', '0') | list)[:-1] -%}
+            {%- for host in (groups['hana_primary'] | reject('search', '0$') | list)[:-1] -%}
               {{ hostvars[host]['inventory_hostname_short'] }}:role=worker:workergroup={{ sap_hana_install_workergroup }}:group={{ sap_hana_install_group }},
             {%- endfor -%}
             {{ hostvars[(groups['hana_primary'][-1])]['inventory_hostname_short'] }}:role=standby:workergroup={{ sap_hana_install_workergroup }}:group={{ sap_hana_install_group }}
           {%- elif sap_vm_provision_calculate_sap_hana_scaleout_standby == 0 -%}
-            {%- for host in (groups['hana_primary'] | reject('search', '0') | list) -%}
+            {%- for host in (groups['hana_primary'] | reject('search', '0$') | list) -%}
               {{ hostvars[host]['inventory_hostname_short'] }}:role=worker:workergroup={{ sap_hana_install_workergroup }}:group={{ sap_hana_install_group }}
             {%- endfor -%}
           {%- endif -%}

--- a/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml
@@ -340,12 +340,12 @@
       ansible.builtin.set_fact:
         sap_hana_install_addhosts: |
           {%- if sap_vm_provision_calculate_sap_hana_scaleout_standby > 0 -%}
-            {%- for host in (groups['hana_primary'] | reject('search', '0$') | list)[:-1] -%}
+            {%- for host in (groups['hana_primary'] | reject('regex', '0$') | list)[:-1] -%}
               {{ hostvars[host]['inventory_hostname_short'] }}:role=worker:workergroup={{ sap_hana_install_workergroup }}:group={{ sap_hana_install_group }},
             {%- endfor -%}
             {{ hostvars[(groups['hana_primary'][-1])]['inventory_hostname_short'] }}:role=standby:workergroup={{ sap_hana_install_workergroup }}:group={{ sap_hana_install_group }}
           {%- elif sap_vm_provision_calculate_sap_hana_scaleout_standby == 0 -%}
-            {%- for host in (groups['hana_primary'] | reject('search', '0$') | list) -%}
+            {%- for host in (groups['hana_primary'] | reject('regex', '0$') | list) -%}
               {{ hostvars[host]['inventory_hostname_short'] }}:role=worker:workergroup={{ sap_hana_install_workergroup }}:group={{ sap_hana_install_group }}
             {%- endfor -%}
           {%- endif -%}


### PR DESCRIPTION
Removed hardcoded reject for all hostnames containing '0'

Replaced with regex search checking for "ending with 0" instead.
```
# Before
reject('search', '0')

# After
reject('regex', '0$')
```