### PR TITLE
feat: Cleanup and Move Python dependencies to virtual environment

### DIFF
--- a/deploy_scenarios/sap_hana_ha/ansible_extravars.yml
+++ b/deploy_scenarios/sap_hana_ha/ansible_extravars.yml
@@ -50,6 +50,26 @@ sap_hana_update_etchosts: true
 # Configuration for SAP installation media detection
 # sap_install_media_detect_** variables are set for each Ansible Task to the respective host
 
+# Set Python version for sap_launchpad role execution
+# You can replace auto-detection jinja2 directly by string value.
+sap_launchpad_python: >-
+    {%- if ansible_distribution.split("_")[0] == 'SLES'
+     and (ansible_distribution_major_version == '15' and ansible_distribution_version.split('.')[1] | int >= 5
+      or ansible_distribution_major_version == '16') -%}
+      python311
+    {%- else -%}
+      python3
+    {%- endif -%}
+
+sap_launchpad_python_interpreter: >-
+    {%- if ansible_distribution.split("_")[0] == 'SLES'
+     and (ansible_distribution_major_version == '15' and ansible_distribution_version.split('.')[1] | int >= 5
+      or ansible_distribution_major_version == '16') -%}
+      python3.11
+    {%- else -%}
+      python3
+    {%- endif -%}
+sap_launchpad_venv: /opt/sap_launchpad/venv
 
 
 ####

--- a/deploy_scenarios/sap_hana_ha/ansible_extravars.yml
+++ b/deploy_scenarios/sap_hana_ha/ansible_extravars.yml
@@ -69,7 +69,6 @@ sap_launchpad_python_interpreter: >-
     {%- else -%}
       python3
     {%- endif -%}
-sap_launchpad_venv: /opt/sap_launchpad/venv
 
 
 ####

--- a/deploy_scenarios/sap_hana_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana_ha/ansible_playbook.yml
@@ -153,7 +153,13 @@
           - "{{ sap_launchpad_python }}-pip"
         state: present
 
-    - name: Install Python modules to virtual environment
+    - name: Create temporary directory for Python Virtual Environment
+      ansible.builtin.tempfile:
+        state: directory
+        suffix: _sap_launchpad_venv
+      register: sap_launchpad_temp_venv
+
+    - name: Install Python modules to Python Virtual Environment
       ansible.builtin.pip:
         name:
           - wheel
@@ -161,7 +167,7 @@
           - requests
           - beautifulsoup4
           - lxml
-        virtualenv: "{{ sap_launchpad_venv }}"
+        virtualenv: "{{ sap_launchpad_temp_venv.path }}"
         virtualenv_command: "{{ sap_launchpad_python_interpreter }} -m venv"
 
 
@@ -197,7 +203,12 @@
       retries: 1
       until: download_task is not failed
       vars:
-        ansible_python_interpreter: "{{ sap_launchpad_venv ~ '/bin/' ~ sap_launchpad_python_interpreter }}"
+        ansible_python_interpreter: "{{ sap_launchpad_temp_venv.path ~ '/bin/' ~ sap_launchpad_python_interpreter }}"
+
+    - name: Remove temporary Python Virtual Environment
+      ansible.builtin.file:
+        path: "{{ sap_launchpad_temp_venv.path }}"
+        state: absent
 
     - name: Find SAP HANA installation media
       ansible.builtin.find:

--- a/deploy_scenarios/sap_hana_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana_ha/ansible_playbook.yml
@@ -2,7 +2,7 @@
 # Ansible Playbook for SAP HANA Scale-Up (Performance Optimized)
 
 # Use include_role / include_tasks inside Ansible Task block, instead of using roles declaration or Task block with import_roles.
-# This ensures Ansible Roles, and the tasks within, will be parsed in sequence instead of parsing at Playbook initialisation.
+# This ensures Ansible Roles, and the tasks within, will be parsed in sequence instead of parsing at Playbook initialization.
 
 
 #### Begin Infrastructure-as-Code provisioning ####
@@ -129,7 +129,6 @@
         state: present
 
 
-
 #### Begin downloading SAP software installation media to hosts ####
 
 - name: Ansible Play for preparing downloads of SAP Software installation media
@@ -149,30 +148,21 @@
 
     - name: Install Python package manager pip3 to system Python
       ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
         name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
+          - "{{ sap_launchpad_python }}"
+          - "{{ sap_launchpad_python }}-pip"
         state: present
 
-    - name: Install Python dependency wheel to system Python
+    - name: Install Python modules to virtual environment
       ansible.builtin.pip:
         name:
           - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
           - urllib3
           - requests
           - beautifulsoup4
           - lxml
-
+        virtualenv: "{{ sap_launchpad_venv }}"
+        virtualenv_command: "{{ sap_launchpad_python_interpreter }} -m venv"
 
 
 - name: Ansible Play for downloading SAP HANA installation media
@@ -206,7 +196,8 @@
       register: download_task
       retries: 1
       until: download_task is not failed
-
+      vars:
+        ansible_python_interpreter: "{{ sap_launchpad_venv ~ '/bin/' ~ sap_launchpad_python_interpreter }}"
 
     - name: Find SAP HANA installation media
       ansible.builtin.find:
@@ -289,7 +280,7 @@
 
 
 
-- name: Ansible Play for appending temporary Virtual IP (VIP) after preconfiguration and reboot of hosts
+- name: Ansible Play for appending temporary Virtual IP (VIP) after pre-configuration and reboot of hosts
   hosts: hana_primary, hana_secondary
   become: true
   any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts


### PR DESCRIPTION
## Proposal for `sap_hana_ha` scenario before working on others

### Description

- Remove packages that are not needed
- Install pip modules into virtual environment
- Execute `sap_launchpad` with virtual environment
- Create new python inputs in extravars for python version selection (ansible interpreter is Control node specific and cannot be used)