### PR TITLE
all: Replace sap_launchpad tasks with new role sap_software_download

### DIFF
--- a/deploy_scenarios/sap_bw4hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_bw4hana_sandbox/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -115,49 +111,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: hana_primary
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading SAP BW/4HANA installation media
   hosts: hana_primary
   become: true
@@ -165,32 +118,25 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list_bw4hana_install
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_bw4hana_install: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list_bw4hana_install
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_bw4hana_install: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media for SAP HANA and SAP NetWeaver for hosting SAP BW/4HANA
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list_bw4hana_install }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
 

--- a/deploy_scenarios/sap_bw4hana_sandbox/ansible_requirements.yml
+++ b/deploy_scenarios/sap_bw4hana_sandbox/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml
@@ -46,9 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
 
   tasks:
 
@@ -170,49 +167,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: hana_primary, nwas_pas
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading SAP BW/4HANA installation media
   hosts: nwas_pas
   become: true
@@ -220,32 +174,25 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list_bw4hana_install
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_bw4hana_install: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list_bw4hana_install
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_bw4hana_install: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media for SAP HANA and SAP NetWeaver for hosting SAP BW/4HANA
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list_bw4hana_install }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
     - name: Find SAP HANA installation media

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_requirements.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_ecc_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_hana_sandbox/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -115,49 +111,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: hana_primary
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading SAP ECC on HANA installation media
   hosts: hana_primary
   become: true
@@ -165,32 +118,25 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list_ecc_hana_install
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_ecc_hana_install: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list_ecc_hana_install
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_ecc_hana_install: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media for SAP HANA and SAP NetWeaver for hosting SAP ECC on HANA
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list_ecc_hana_install }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
 

--- a/deploy_scenarios/sap_ecc_hana_sandbox/ansible_requirements.yml
+++ b/deploy_scenarios/sap_ecc_hana_sandbox/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -130,49 +126,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: nwas_pas
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading installation media
   hosts: nwas_pas
   become: true
@@ -180,32 +133,25 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_installation_media'].softwarecenter_search_list_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_installation_media'].softwarecenter_search_list_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_installation_media']
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
     - name: Find SAP NetWeaver ASCS installation media

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_requirements.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -129,49 +125,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: nwas_pas
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading installation media
   hosts: nwas_pas
   become: true
@@ -179,32 +132,25 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_installation_media'].softwarecenter_search_list_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_installation_media'].softwarecenter_search_list_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_installation_media']
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
     - name: Find SAP NetWeaver ASCS installation media

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_requirements.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -115,49 +111,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: nwas_pas
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading installation media
   hosts: nwas_pas
   become: true
@@ -165,32 +118,25 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media for IBM Db2 and SAP ECC
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
 

--- a/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_requirements.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -115,49 +111,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: nwas_pas
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading installation media
   hosts: nwas_pas
   become: true
@@ -165,32 +118,25 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media for Oracle DB and SAP NetWeaver
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
 

--- a/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_requirements.yml
+++ b/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -115,49 +111,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: nwas_pas
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading installation media
   hosts: nwas_pas
   become: true
@@ -165,32 +118,25 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media for SAP ASE and SAP NetWeaver
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
 

--- a/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_requirements.yml
+++ b/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -115,49 +111,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: nwas_pas
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading installation media
   hosts: nwas_pas
   become: true
@@ -165,32 +118,25 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media for SAP MaxDB and SAP NetWeaver
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
 

--- a/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_requirements.yml
+++ b/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_hana/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -127,49 +123,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: hana_primary
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading SAP HANA installation media
   hosts: hana_primary
   become: true
@@ -177,30 +130,25 @@
   max_fail_percentage: 0
   tasks:
 
-    - name: Set fact x86_64 softwarecenter_search_list_saphana
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_hana_install_media_dictionary[sap_hana_product_input].softwarecenter_search_list_saphana_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    - name: Set fact ppc64le softwarecenter_search_list_saphana
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_hana_install_media_dictionary[sap_hana_product_input].softwarecenter_search_list_saphana_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download SAP HANA Database Server installation media
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_hana_install_media_dictionary[sap_hana_product_input]
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
 

--- a/deploy_scenarios/sap_hana/ansible_requirements.yml
+++ b/deploy_scenarios/sap_hana/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_hana_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana_ha/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -132,49 +128,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: hana_primary
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading SAP HANA installation media
   hosts: hana_primary
   become: true
@@ -182,30 +135,25 @@
   max_fail_percentage: 0
   tasks:
 
-    - name: Set fact x86_64 softwarecenter_search_list_saphana
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_hana_install_media_dictionary[sap_hana_product_input].softwarecenter_search_list_saphana_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    - name: Set fact ppc64le softwarecenter_search_list_saphana
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_hana_install_media_dictionary[sap_hana_product_input].softwarecenter_search_list_saphana_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download SAP HANA Database Server installation media
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_hana_install_media_dictionary[sap_hana_product_input]
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
     - name: Find SAP HANA installation media

--- a/deploy_scenarios/sap_hana_ha/ansible_requirements.yml
+++ b/deploy_scenarios/sap_hana_ha/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml
@@ -46,9 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
 
   tasks:
 
@@ -169,49 +166,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: hana_primary
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading SAP HANA installation media
   hosts: hana_primary
   become: true
@@ -219,30 +173,25 @@
   max_fail_percentage: 0
   tasks:
 
-    - name: Set fact x86_64 softwarecenter_search_list_saphana
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_hana_install_media_dictionary[sap_hana_product_input].softwarecenter_search_list_saphana_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    - name: Set fact ppc64le softwarecenter_search_list_saphana
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_hana_install_media_dictionary[sap_hana_product_input].softwarecenter_search_list_saphana_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download SAP HANA Database Server installation media
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_hana_install_media_dictionary[sap_hana_product_input]
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
 

--- a/deploy_scenarios/sap_hana_scaleout/ansible_requirements.yml
+++ b/deploy_scenarios/sap_hana_scaleout/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -115,49 +111,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: hana_primary
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading SAP ECC on HANA installation media
   hosts: hana_primary
   become: true
@@ -165,32 +118,25 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list_ecc_hana_install
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_ecc_hana_install: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list_ecc_hana_install
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_ecc_hana_install: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media for SAP HANA and SAP NetWeaver for hosting SAP ECC on HANA
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list_ecc_hana_install }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
 

--- a/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_requirements.yml
+++ b/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -115,49 +111,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: nwas_pas
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading installation media
   hosts: nwas_pas
   become: true
@@ -165,32 +118,25 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media for IBM Db2 and SAP ECC
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
 

--- a/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_requirements.yml
+++ b/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_landscape_s4hana_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -130,49 +126,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: project_dev_nwas_pas
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading SAP S/4HANA installation media
   hosts: project_dev_nwas_pas
   become: true
@@ -180,32 +133,25 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list_s4hana_install
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_s4hana_install: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_installation_media'].softwarecenter_search_list_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list_s4hana_install
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_s4hana_install: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_installation_media'].softwarecenter_search_list_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media for SAP HANA and SAP NetWeaver for hosting SAP S/4HANA
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list_s4hana_install }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_installation_media']
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
     - name: Find SAP HANA installation media

--- a/deploy_scenarios/sap_landscape_s4hana_standard/ansible_requirements.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -130,49 +126,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: project_dev_nwas_pas
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading SAP S/4HANA installation media
   hosts: project_dev_nwas_pas
   become: true
@@ -180,64 +133,26 @@
   max_fail_percentage: 0
   tasks:
 
-    - name: Set fact x86_64 softwarecenter_search_list_sapcar
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_sapcar: "{{ softwarecenter_search_list_sapcar_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    - name: Set fact ppc64le softwarecenter_search_list_sapcar
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_sapcar: "{{ softwarecenter_search_list_sapcar_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download SAPCAR
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list_sapcar }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
-
-
-# Use task block to call Ansible Module
-    - name: Execute Ansible Module with system Python to download SAP Maintenance Planner Stack XML for the SAP S/4HANA installation
-      community.sap_launchpad.maintenance_planner_stack_xml_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        transaction_name: "{{ sap_maintenance_planner_transaction_name }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-
-
-# Use task block to call Ansible Module
-    - name: Execute Ansible Module with system Python to get installation files list from SAP Maintenance Planner for an SAP S/4HANA installation
-      community.sap_launchpad.maintenance_planner_files:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        transaction_name: "{{ sap_maintenance_planner_transaction_name }}"
-      register: sap_maintenance_planner_basket_register
-
-
-# Use task block to call Ansible Module
-    - name: Execute Ansible Module with system Python to download files returned from SAP Maintenance Planner for an SAP S/4HANA installation
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        download_link: "{{ item.DirectLink }}"
-        download_filename: "{{ item.Filename }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ sap_maintenance_planner_basket_register.download_basket }}"
-      loop_control:
-        label: "{{ item.Filename }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ softwarecenter_search_list_sapcar_x86_64
+          if ansible_architecture == 'x86_64' else softwarecenter_search_list_sapcar_ppc64le }}"
+        sap_software_download_mp_transaction: "{{ sap_maintenance_planner_transaction_name }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
     - name: Find SAP HANA installation media
       ansible.builtin.find:

--- a/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_requirements.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -115,49 +111,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: hana_primary
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading installation media
   hosts: hana_primary
   become: true
@@ -165,32 +118,25 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media for SAP HANA and SAP NetWeaver
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
 

--- a/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_requirements.yml
+++ b/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -115,49 +111,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: nwas_pas
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading installation media
   hosts: nwas_pas
   become: true
@@ -165,32 +118,25 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media for IBM Db2 and SAP NetWeaver
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
 

--- a/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_requirements.yml
+++ b/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -115,49 +111,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: nwas_pas
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading installation media
   hosts: nwas_pas
   become: true
@@ -165,32 +118,25 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media for Oracle DB and SAP NetWeaver
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
 

--- a/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_requirements.yml
+++ b/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -115,49 +111,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: nwas_pas
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading installation media
   hosts: nwas_pas
   become: true
@@ -165,32 +118,25 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media for SAP ASE and SAP NetWeaver
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
 

--- a/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_requirements.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -115,49 +111,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: nwas_pas
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading installation media
   hosts: nwas_pas
   become: true
@@ -165,32 +118,25 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media for SAP MaxDB and SAP NetWeaver
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
 

--- a/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_requirements.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -115,49 +111,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: nwas_pas
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading installation media
   hosts: nwas_pas
   become: true
@@ -165,32 +118,25 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media for IBM Db2 and SAP NetWeaver (JAVA)
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
 

--- a/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_requirements.yml
+++ b/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -115,49 +111,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: nwas_pas
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading installation media
   hosts: nwas_pas
   become: true
@@ -165,32 +118,25 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media for SAP ASE and SAP NetWeaver (JAVA)
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
 

--- a/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_requirements.yml
+++ b/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_s4hana_distributed/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -130,49 +126,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: nwas_pas
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading SAP S/4HANA installation media
   hosts: nwas_pas
   become: true
@@ -180,32 +133,25 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list_s4hana_install
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_s4hana_install: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_installation_media'].softwarecenter_search_list_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list_s4hana_install
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_s4hana_install: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_installation_media'].softwarecenter_search_list_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media for SAP HANA and SAP NetWeaver for hosting SAP S/4HANA
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list_s4hana_install }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_installation_media']
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
     - name: Find SAP HANA installation media

--- a/deploy_scenarios/sap_s4hana_distributed/ansible_requirements.yml
+++ b/deploy_scenarios/sap_s4hana_distributed/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_s4hana_distributed_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -135,49 +131,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: nwas_pas
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading SAP S/4HANA installation media
   hosts: nwas_pas
   become: true
@@ -185,32 +138,25 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list_s4hana_install
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_s4hana_install: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_installation_media'].softwarecenter_search_list_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list_s4hana_install
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_s4hana_install: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_installation_media'].softwarecenter_search_list_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media for SAP HANA and SAP NetWeaver for hosting SAP S/4HANA
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list_s4hana_install }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_installation_media']
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
     - name: Find SAP HANA installation media

--- a/deploy_scenarios/sap_s4hana_distributed_ha/ansible_requirements.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -135,49 +131,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: nwas_pas
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading SAP S/4HANA installation media
   hosts: nwas_pas
   become: true
@@ -185,64 +138,27 @@
   max_fail_percentage: 0
   tasks:
 
-    - name: Set fact x86_64 softwarecenter_search_list_sapcar
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_sapcar: "{{ softwarecenter_search_list_sapcar_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    - name: Set fact ppc64le softwarecenter_search_list_sapcar
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_sapcar: "{{ softwarecenter_search_list_sapcar_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ softwarecenter_search_list_sapcar_x86_64
+          if ansible_architecture == 'x86_64' else softwarecenter_search_list_sapcar_ppc64le }}"
+        sap_software_download_mp_transaction: "{{ sap_maintenance_planner_transaction_name }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
-    - name: Execute Ansible Module with system Python to download SAPCAR
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list_sapcar }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
-
-
-# Use task block to call Ansible Module
-    - name: Execute Ansible Module with system Python to download SAP Maintenance Planner Stack XML for the SAP S/4HANA installation
-      community.sap_launchpad.maintenance_planner_stack_xml_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        transaction_name: "{{ sap_maintenance_planner_transaction_name }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-
-
-# Use task block to call Ansible Module
-    - name: Execute Ansible Module with system Python to get installation files list from SAP Maintenance Planner for an SAP S/4HANA installation
-      community.sap_launchpad.maintenance_planner_files:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        transaction_name: "{{ sap_maintenance_planner_transaction_name }}"
-      register: sap_maintenance_planner_basket_register
-
-
-# Use task block to call Ansible Module
-    - name: Execute Ansible Module with system Python to download files returned from SAP Maintenance Planner for an SAP S/4HANA installation
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        download_link: "{{ item.DirectLink }}"
-        download_filename: "{{ item.Filename }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ sap_maintenance_planner_basket_register.download_basket }}"
-      loop_control:
-        label: "{{ item.Filename }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
 
     - name: Find SAP HANA installation media
       ansible.builtin.find:

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_requirements.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -130,49 +126,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: nwas_pas
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading SAP S/4HANA installation media
   hosts: nwas_pas
   become: true
@@ -180,64 +133,27 @@
   max_fail_percentage: 0
   tasks:
 
-    - name: Set fact x86_64 softwarecenter_search_list_sapcar
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_sapcar: "{{ softwarecenter_search_list_sapcar_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    - name: Set fact ppc64le softwarecenter_search_list_sapcar
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_sapcar: "{{ softwarecenter_search_list_sapcar_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ softwarecenter_search_list_sapcar_x86_64
+          if ansible_architecture == 'x86_64' else softwarecenter_search_list_sapcar_ppc64le }}"
+        sap_software_download_mp_transaction: "{{ sap_maintenance_planner_transaction_name }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
-    - name: Execute Ansible Module with system Python to download SAPCAR
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list_sapcar }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
-
-
-# Use task block to call Ansible Module
-    - name: Execute Ansible Module with system Python to download SAP Maintenance Planner Stack XML for the SAP S/4HANA installation
-      community.sap_launchpad.maintenance_planner_stack_xml_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        transaction_name: "{{ sap_maintenance_planner_transaction_name }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-
-
-# Use task block to call Ansible Module
-    - name: Execute Ansible Module with system Python to get installation files list from SAP Maintenance Planner for an SAP S/4HANA installation
-      community.sap_launchpad.maintenance_planner_files:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        transaction_name: "{{ sap_maintenance_planner_transaction_name }}"
-      register: sap_maintenance_planner_basket_register
-
-
-# Use task block to call Ansible Module
-    - name: Execute Ansible Module with system Python to download files returned from SAP Maintenance Planner for an SAP S/4HANA installation
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        download_link: "{{ item.DirectLink }}"
-        download_filename: "{{ item.Filename }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ sap_maintenance_planner_basket_register.download_basket }}"
-      loop_control:
-        label: "{{ item.Filename }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
 
     - name: Find SAP HANA installation media
       ansible.builtin.find:

--- a/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_requirements.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -115,49 +111,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: hana_primary
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading SAP S/4HANA installation media
   hosts: hana_primary
   become: true
@@ -165,32 +118,25 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list_s4hana_install
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_s4hana_install: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list_s4hana_install
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_s4hana_install: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media for SAP HANA and SAP NetWeaver for hosting SAP S/4HANA
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list_s4hana_install }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
 

--- a/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_requirements.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_s4hana_foundation_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_standard/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -130,49 +126,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: hana_primary, nwas_pas
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading SAP HANA installation media
   hosts: hana_primary
   become: true
@@ -180,32 +133,25 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list_hana_install
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_hana_install: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_saphana_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list_hana_install
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_hana_install: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_saphana_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media for SAP HANA
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list_hana_install }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
 

--- a/deploy_scenarios/sap_s4hana_foundation_standard/ansible_requirements.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_standard/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_s4hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -115,49 +111,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: hana_primary
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading SAP S/4HANA installation media
   hosts: hana_primary
   become: true
@@ -165,32 +118,25 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list_s4hana_install
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_s4hana_install: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list_s4hana_install
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_s4hana_install: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media for SAP HANA and SAP NetWeaver for hosting SAP S/4HANA
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list_s4hana_install }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
 

--- a/deploy_scenarios/sap_s4hana_sandbox/ansible_requirements.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -115,49 +111,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: hana_primary
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading SAP S/4HANA installation media
   hosts: hana_primary
   become: true
@@ -165,64 +118,26 @@
   max_fail_percentage: 0
   tasks:
 
-    - name: Set fact x86_64 softwarecenter_search_list_sapcar
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_sapcar: "{{ softwarecenter_search_list_sapcar_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    - name: Set fact ppc64le softwarecenter_search_list_sapcar
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_sapcar: "{{ softwarecenter_search_list_sapcar_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download SAPCAR
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list_sapcar }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
-
-
-# Use task block to call Ansible Module
-    - name: Execute Ansible Module with system Python to download SAP Maintenance Planner Stack XML for the SAP S/4HANA installation
-      community.sap_launchpad.maintenance_planner_stack_xml_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        transaction_name: "{{ sap_maintenance_planner_transaction_name }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-
-
-# Use task block to call Ansible Module
-    - name: Execute Ansible Module with system Python to get installation files list from SAP Maintenance Planner for an SAP S/4HANA installation
-      community.sap_launchpad.maintenance_planner_files:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        transaction_name: "{{ sap_maintenance_planner_transaction_name }}"
-      register: sap_maintenance_planner_basket_register
-
-
-# Use task block to call Ansible Module
-    - name: Execute Ansible Module with system Python to download files returned from SAP Maintenance Planner for an SAP S/4HANA installation
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        download_link: "{{ item.DirectLink }}"
-        download_filename: "{{ item.Filename }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ sap_maintenance_planner_basket_register.download_basket }}"
-      loop_control:
-        label: "{{ item.Filename }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ softwarecenter_search_list_sapcar_x86_64
+          if ansible_architecture == 'x86_64' else softwarecenter_search_list_sapcar_ppc64le }}"
+        sap_software_download_mp_transaction: "{{ sap_maintenance_planner_transaction_name }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
 #### Begin SAP software hosts preparation ####

--- a/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_requirements.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_s4hana_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_standard/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -130,49 +126,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: hana_primary, nwas_pas
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading SAP HANA installation media
   hosts: hana_primary
   become: true
@@ -180,32 +133,25 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list_hana_install
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_hana_install: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_saphana_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list_hana_install
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_hana_install: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input].softwarecenter_search_list_saphana_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media for SAP HANA
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list_hana_install }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input]
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
 

--- a/deploy_scenarios/sap_s4hana_standard/ansible_requirements.yml
+++ b/deploy_scenarios/sap_s4hana_standard/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -130,49 +126,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: nwas_pas
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading SAP S/4HANA installation media
   hosts: nwas_pas
   become: true
@@ -180,64 +133,27 @@
   max_fail_percentage: 0
   tasks:
 
-    - name: Set fact x86_64 softwarecenter_search_list_sapcar
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_sapcar: "{{ softwarecenter_search_list_sapcar_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    - name: Set fact ppc64le softwarecenter_search_list_sapcar
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_sapcar: "{{ softwarecenter_search_list_sapcar_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{ softwarecenter_search_list_sapcar_x86_64
+          if ansible_architecture == 'x86_64' else softwarecenter_search_list_sapcar_ppc64le }}"
+        sap_software_download_mp_transaction: "{{ sap_maintenance_planner_transaction_name }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
-    - name: Execute Ansible Module with system Python to download SAPCAR
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list_sapcar }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
-
-
-# Use task block to call Ansible Module
-    - name: Execute Ansible Module with system Python to download SAP Maintenance Planner Stack XML for the SAP S/4HANA installation
-      community.sap_launchpad.maintenance_planner_stack_xml_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        transaction_name: "{{ sap_maintenance_planner_transaction_name }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-
-
-# Use task block to call Ansible Module
-    - name: Execute Ansible Module with system Python to get installation files list from SAP Maintenance Planner for an SAP S/4HANA installation
-      community.sap_launchpad.maintenance_planner_files:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        transaction_name: "{{ sap_maintenance_planner_transaction_name }}"
-      register: sap_maintenance_planner_basket_register
-
-
-# Use task block to call Ansible Module
-    - name: Execute Ansible Module with system Python to download files returned from SAP Maintenance Planner for an SAP S/4HANA installation
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        download_link: "{{ item.DirectLink }}"
-        download_filename: "{{ item.Filename }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ sap_maintenance_planner_basket_register.download_basket }}"
-      loop_control:
-        label: "{{ item.Filename }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
 
     - name: Find SAP HANA installation media
       ansible.builtin.find:

--- a/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_requirements.yml
+++ b/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_solman_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_solman_sapase_sandbox/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -133,49 +129,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: nwas_pas
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading installation media
   hosts: nwas_pas
   become: true
@@ -183,35 +136,28 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_solman_install_abap: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_abap'].softwarecenter_search_list_x86_64 }}"
-        softwarecenter_search_list_solman_install_java: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_java'].softwarecenter_search_list_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_solman_install_abap: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_abap'].softwarecenter_search_list_ppc64le }}"
-        softwarecenter_search_list_solman_install_java: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_java'].softwarecenter_search_list_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media for SAP ASE and SAP NetWeaver
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list_solman_install_abap + softwarecenter_search_list_solman_install_java | flatten }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
-
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{
+          sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_abap']
+            ['softwarecenter_search_list_saphana_' ~ ansible_architecture]
+          + sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_java']
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] | flatten }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
 #### Begin SAP software hosts preparation ####

--- a/deploy_scenarios/sap_solman_sapase_sandbox/ansible_requirements.yml
+++ b/deploy_scenarios/sap_solman_sapase_sandbox/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0

--- a/deploy_scenarios/sap_solman_saphana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_solman_saphana_sandbox/ansible_playbook.yml
@@ -46,10 +46,6 @@
         playbook_enable_default_vars_sap: "{{ playbook_enable_default_vars_sap_register.user_input }}"
       when: playbook_enable_interactive_prompts
 
-    - name: Playbook Interactive - Trigger prompts for VM provisioning via {{ sap_vm_provision_iac_type }}
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/interactive/ansible_tasks_control_inputs.yml"
-      when: playbook_enable_interactive_prompts
-
 
 #### Provision VM ####
 
@@ -134,49 +130,6 @@
 
 #### Begin downloading SAP software installation media to hosts ####
 
-- name: Ansible Play for preparing downloads of SAP Software installation media
-  hosts: hana_primary
-  become: true
-  any_errors_fatal: true # https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Create directories if does not exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
-      loop:
-        - "{{ sap_install_media_detect_source_directory }}"
-
-    - name: Install Python package manager pip3 to system Python
-      ansible.builtin.package:
-        name: python3-pip
-        state: present
-
-    - name: Ensure OS Packages for lxml are installed
-      ansible.builtin.package:
-        name:
-          - python3-lxml
-          - libxslt-devel
-          - libxml2-devel
-        state: present
-
-    - name: Install Python dependency wheel to system Python
-      ansible.builtin.pip:
-        name:
-          - wheel
-
-    - name: Install Python dependencies for Ansible Modules to system Python
-      ansible.builtin.pip:
-        name:
-          - urllib3
-          - requests
-          - beautifulsoup4
-          - lxml
-
-
-
 - name: Ansible Play for downloading installation media
   hosts: hana_primary
   become: true
@@ -184,34 +137,28 @@
   max_fail_percentage: 0
   tasks:
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact x86_64 softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_solman_install_abap: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_abap'].softwarecenter_search_list_x86_64 }}"
-        softwarecenter_search_list_solman_install_java: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_java'].softwarecenter_search_list_x86_64 }}"
-      when:
-        - ansible_architecture == "x86_64"
+    # SAP software download will only occur if the 'community.sap_launchpad' collection is installed.
+    # Playbook will continue without the collection, assuming SAP software is already available.
+    - name: Check availability of sap_launchpad collection on execution node
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection list
+      register: sap_playbook_collection_list_output
 
-    # Set facts based on the install dictionary and the default template selected
-    - name: Set fact ppc64le softwarecenter_search_list
-      ansible.builtin.set_fact:
-        softwarecenter_search_list_solman_install_abap: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_abap'].softwarecenter_search_list_ppc64le }}"
-        softwarecenter_search_list_solman_install_java: "{{ sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_java'].softwarecenter_search_list_ppc64le }}"
-      when:
-        - ansible_architecture == "ppc64le"
-
-    - name: Execute Ansible Module with system Python to download installation media for SAP ASE and SAP NetWeaver
-      community.sap_launchpad.software_center_download:
-        suser_id: "{{ sap_id_user }}"
-        suser_password: "{{ sap_id_user_password }}"
-        softwarecenter_search_query: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
-      loop: "{{ softwarecenter_search_list_solman_install_abap + softwarecenter_search_list_solman_install_java | flatten }}"
-      loop_control:
-        label: "{{ item }} : {{ download_task.msg }}"
-      register: download_task
-      retries: 1
-      until: download_task is not failed
+    - name: Execute Ansible Role sap_software_download
+      ansible.builtin.include_role:
+        name: community.sap_launchpad.sap_software_download
+      vars:
+        sap_software_download_suser_id: "{{ sap_id_user }}"
+        sap_software_download_suser_password: "{{ sap_id_user_password }}"
+        sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
+        sap_software_download_deduplicate: first
+        sap_software_download_files: "{{
+          sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_abap']
+            ['softwarecenter_search_list_saphana_' ~ ansible_architecture]
+          + sap_swpm_templates_install_dictionary[sap_swpm_templates_product_input_prefix + '_java']
+          ['softwarecenter_search_list_saphana_' ~ ansible_architecture] | flatten }}"
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
 
 
 

--- a/deploy_scenarios/sap_solman_saphana_sandbox/ansible_requirements.yml
+++ b/deploy_scenarios/sap_solman_saphana_sandbox/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.1.1
+    version: 1.2.0
   - name: community.sap_infrastructure
     type: galaxy
     version: 1.1.0


### PR DESCRIPTION
## Description
PR continues from https://github.com/sap-linuxlab/ansible.playbooks_for_sap/pull/52, by replacing tasks related to `sap_launchpad` role and its prerequisites by new role `sap_launchpad.sap_download_software` https://github.com/sap-linuxlab/community.sap_launchpad/pull/32.

This also includes removal of `include_tasks` for Interactive file that does not exist.

`ansible-lint` is almost clear with this removal:
```console
risky-shell-pipe: Shells that use pipes should set the pipefail option.
deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_playbook.yml:739
```

## Redesign details
Changes are based on https://github.com/sap-linuxlab/ansible.playbooks_for_sap/pull/45