### PR TITLE
all: Default SAP HANA master password and readme update explaining S-user

### DIFF
--- a/deploy_scenarios/sap_bw4hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_bw4hana_sandbox/ansible_extravars.yml
@@ -49,7 +49,7 @@ sap_netweaver_preconfigure_fail_if_not_enough_swap_space_configured: false  # Wh
 #### SAP HANA Database Server installation ####
 # SAP HANA Master password
 sap_hana_install_use_master_password: "y"  # Use a master password for SAP HANA installation (y/n) (String).
-sap_hana_install_master_password: "ENTER_STRING_VALUE_HERE"  # The master password for SAP HANA (String).
+sap_hana_install_master_password: "NewPass$321"  # The master password for SAP HANA (String).
 
 # Dynamic assignment of SAP HANA variables
 sap_hana_sid: "{{ sap_system_hana_db_sid }}"

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_extravars.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_extravars.yml
@@ -57,7 +57,7 @@ sap_netweaver_preconfigure_saptune_solution: 'S4HANA-APPSERVER'  # SUSE saptune 
 #### SAP HANA Database Server installation ####
 # SAP HANA Master password
 sap_hana_install_use_master_password: "y"  # Use a master password for SAP HANA installation (y/n) (String).
-sap_hana_install_master_password: "ENTER_STRING_VALUE_HERE"  # The master password for SAP HANA (String).
+sap_hana_install_master_password: "NewPass$321"  # The master password for SAP HANA (String).
 
 # SAP HANA Scale-Out variables for role sap_Hana_install
 sap_hana_install_new_system: true  # Set to 'false', when adding hosts using sap_hana_install_addhosts

--- a/deploy_scenarios/sap_ecc_hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_hana_sandbox/ansible_extravars.yml
@@ -49,7 +49,7 @@ sap_netweaver_preconfigure_fail_if_not_enough_swap_space_configured: false  # Wh
 #### SAP HANA Database Server installation ####
 # SAP HANA Master password
 sap_hana_install_use_master_password: "y"  # Use a master password for SAP HANA installation (y/n) (String).
-sap_hana_install_master_password: "ENTER_STRING_VALUE_HERE"  # The master password for SAP HANA (String).
+sap_hana_install_master_password: "NewPass$321"  # The master password for SAP HANA (String).
 
 # Dynamic assignment of SAP HANA variables
 sap_hana_sid: "{{ sap_system_hana_db_sid }}"
@@ -123,6 +123,10 @@ sap_software_install_dictionary:
 
   # SAP Business Suite 7i 2016 > EHP8 for SAP ERP 6.0 ABAP
   # uses SAP NetWeaver 7.5
+
+  # Product Availability Matrix for SAP ECC 6.0 EhP8, SAP HANA, x86_64
+  # SAP HANA DATABASE 2.0 [>= SP059] and SAP KERNEL 7.54 64-BIT UNICODE
+  # https://userapps.support.sap.com/sap/support/pam?hash=s%3DSAP%2520ERP%25206.0%26pvnr%3D73555000100900000247%26pt=t%7CPLTFRM%26fclfilter=G1%7CSAP%20HANA%20DATABASE%3BG2%7CLINUX%20ON%20X86_64
   sap_ecc6_ehp8_hana_sandbox:
 
     # SWPM product catalog ID for the installation (String).

--- a/deploy_scenarios/sap_ecc_hana_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_ecc_hana_sandbox/optional/ansible_extravars_interactive.yml
@@ -34,6 +34,10 @@ sap_software_install_dictionary:
 
   # SAP Business Suite 7i 2016 > EHP8 for SAP ERP 6.0 ABAP
   # uses SAP NetWeaver 7.5
+
+  # Product Availability Matrix for SAP ECC 6.0 EhP8, SAP HANA, x86_64
+  # SAP HANA DATABASE 2.0 [>= SP059] and SAP KERNEL 7.54 64-BIT UNICODE
+  # https://userapps.support.sap.com/sap/support/pam?hash=s%3DSAP%2520ERP%25206.0%26pvnr%3D73555000100900000247%26pt=t%7CPLTFRM%26fclfilter=G1%7CSAP%20HANA%20DATABASE%3BG2%7CLINUX%20ON%20X86_64
   sap_ecc6_ehp8_hana_sandbox:
 
     # SWPM product catalog ID for the installation (String).

--- a/deploy_scenarios/sap_hana/ansible_extravars.yml
+++ b/deploy_scenarios/sap_hana/ansible_extravars.yml
@@ -44,7 +44,7 @@ sap_hana_preconfigure_saptune_solution: 'HANA'  # SUSE saptune solution to apply
 #### SAP HANA Database Server installation ####
 # SAP HANA Master password
 sap_hana_install_use_master_password: "y"  # Use a master password for SAP HANA installation (y/n) (String).
-sap_hana_install_master_password: "ENTER_STRING_VALUE_HERE"  # The master password for SAP HANA (String).
+sap_hana_install_master_password: "NewPass$321"  # The master password for SAP HANA (String).
 
 # Dynamic assignment of SAP HANA variables
 sap_hana_sid: "{{ sap_system_hana_db_sid }}"

--- a/deploy_scenarios/sap_hana/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana/ansible_playbook.yml
@@ -106,19 +106,6 @@
       when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
 
-- name: Ansible Play for ensuring rsync on all hosts
-  hosts: hana_primary
-  become: true
-  any_errors_fatal: true
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Install rsync
-      ansible.builtin.package:
-        name: rsync
-        state: present
-
-
 #### Begin downloading SAP software installation media to hosts ####
 - name: Ansible Play for downloading SAP HANA installation media
   hosts: hana_primary

--- a/deploy_scenarios/sap_hana_ha/ansible_extravars.yml
+++ b/deploy_scenarios/sap_hana_ha/ansible_extravars.yml
@@ -44,7 +44,7 @@ sap_hana_preconfigure_saptune_solution: 'HANA'  # SUSE saptune solution to apply
 #### SAP HANA Database Server installation ####
 # SAP HANA Master password
 sap_hana_install_use_master_password: "y"  # Use a master password for SAP HANA installation (y/n) (String).
-sap_hana_install_master_password: "ENTER_STRING_VALUE_HERE"  # The master password for SAP HANA (String).
+sap_hana_install_master_password: "NewPass$321"  # The master password for SAP HANA (String).
 
 # Dynamic assignment of SAP HANA variables
 sap_hana_sid: "{{ sap_system_hana_db_sid }}"

--- a/deploy_scenarios/sap_hana_scaleout/ansible_extravars.yml
+++ b/deploy_scenarios/sap_hana_scaleout/ansible_extravars.yml
@@ -49,7 +49,7 @@ sap_hana_preconfigure_saptune_solution: 'HANA'  # SUSE saptune solution to apply
 #### SAP HANA Database Server installation ####
 # SAP HANA Master password
 sap_hana_install_use_master_password: "y"  # Use a master password for SAP HANA installation (y/n) (String).
-sap_hana_install_master_password: "ENTER_STRING_VALUE_HERE"  # The master password for SAP HANA (String).
+sap_hana_install_master_password: "NewPass$321"  # The master password for SAP HANA (String).
 
 # SAP HANA Scale-Out variables for role sap_Hana_install
 sap_hana_install_new_system: true  # Set to 'false', when adding hosts using sap_hana_install_addhosts

--- a/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_extravars.yml
@@ -49,7 +49,7 @@ sap_netweaver_preconfigure_fail_if_not_enough_swap_space_configured: false  # Wh
 #### SAP HANA Database Server installation ####
 # SAP HANA Master password
 sap_hana_install_use_master_password: "y"  # Use a master password for SAP HANA installation (y/n) (String).
-sap_hana_install_master_password: "ENTER_STRING_VALUE_HERE"  # The master password for SAP HANA (String).
+sap_hana_install_master_password: "NewPass$321"  # The master password for SAP HANA (String).
 
 # Dynamic assignment of SAP HANA variables
 sap_hana_sid: "{{ sap_system_hana_db_sid }}"

--- a/deploy_scenarios/sap_landscape_s4hana_standard/ansible_extravars.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard/ansible_extravars.yml
@@ -48,7 +48,7 @@ sap_netweaver_preconfigure_saptune_solution: 'S4HANA-APPSERVER'  # SUSE saptune 
 #### SAP HANA Database Server installation ####
 # SAP HANA Master password
 sap_hana_install_use_master_password: "y"  # Use a master password for SAP HANA installation (y/n) (String).
-sap_hana_install_master_password: "ENTER_STRING_VALUE_HERE"  # The master password for SAP HANA (String).
+sap_hana_install_master_password: "NewPass$321"  # The master password for SAP HANA (String).
 
 #### SAP HANA Database Server installation - Optional variables ####
 ## SAP HANA log mode (set to overwrite for Sandbox only, HA cannot use overwrite) (String)

--- a/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_extravars.yml
@@ -51,7 +51,7 @@ sap_netweaver_preconfigure_saptune_solution: 'S4HANA-APPSERVER'  # SUSE saptune 
 #### SAP HANA Database Server installation ####
 # SAP HANA Master password
 sap_hana_install_use_master_password: "y"  # Use a master password for SAP HANA installation (y/n) (String).
-sap_hana_install_master_password: "ENTER_STRING_VALUE_HERE"  # The master password for SAP HANA (String).
+sap_hana_install_master_password: "NewPass$321"  # The master password for SAP HANA (String).
 
 #### SAP HANA Database Server installation - Optional variables ####
 ## SAP HANA log mode (set to overwrite for Sandbox only, HA cannot use overwrite) (String)

--- a/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_extravars.yml
@@ -49,7 +49,7 @@ sap_netweaver_preconfigure_fail_if_not_enough_swap_space_configured: false  # Wh
 #### SAP HANA Database Server installation ####
 # SAP HANA Master password
 sap_hana_install_use_master_password: "y"  # Use a master password for SAP HANA installation (y/n) (String).
-sap_hana_install_master_password: "ENTER_STRING_VALUE_HERE"  # The master password for SAP HANA (String).
+sap_hana_install_master_password: "NewPass$321"  # The master password for SAP HANA (String).
 
 # Dynamic assignment of SAP HANA variables
 sap_hana_sid: "{{ sap_system_hana_db_sid }}"

--- a/deploy_scenarios/sap_s4hana_distributed/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_distributed/ansible_extravars.yml
@@ -53,7 +53,7 @@ sap_netweaver_preconfigure_saptune_solution: 'S4HANA-APPSERVER'  # SUSE saptune 
 #### SAP HANA Database Server installation ####
 # SAP HANA Master password
 sap_hana_install_use_master_password: "y"  # Use a master password for SAP HANA installation (y/n) (String).
-sap_hana_install_master_password: "ENTER_STRING_VALUE_HERE"  # The master password for SAP HANA (String).
+sap_hana_install_master_password: "NewPass$321"  # The master password for SAP HANA (String).
 
 # Dynamic assignment of SAP HANA variables
 sap_hana_sid: "{{ sap_system_hana_db_sid }}"

--- a/deploy_scenarios/sap_s4hana_distributed_ha/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/ansible_extravars.yml
@@ -54,7 +54,7 @@ sap_netweaver_preconfigure_saptune_solution: 'S4HANA-APPSERVER'  # SUSE saptune 
 #### SAP HANA Database Server installation ####
 # SAP HANA Master password
 sap_hana_install_use_master_password: "y"  # Use a master password for SAP HANA installation (y/n) (String).
-sap_hana_install_master_password: "ENTER_STRING_VALUE_HERE"  # The master password for SAP HANA (String).
+sap_hana_install_master_password: "NewPass$321"  # The master password for SAP HANA (String).
 
 # Dynamic assignment of SAP HANA variables
 sap_hana_sid: "{{ sap_system_hana_db_sid }}"

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_extravars.yml
@@ -57,7 +57,7 @@ sap_netweaver_preconfigure_saptune_solution: 'S4HANA-APPSERVER'  # SUSE saptune 
 #### SAP HANA Database Server installation ####
 # SAP HANA Master password
 sap_hana_install_use_master_password: "y"  # Use a master password for SAP HANA installation (y/n) (String).
-sap_hana_install_master_password: "ENTER_STRING_VALUE_HERE"  # The master password for SAP HANA (String).
+sap_hana_install_master_password: "NewPass$321"  # The master password for SAP HANA (String).
 
 # Dynamic assignment of SAP HANA variables
 sap_hana_sid: "{{ sap_system_hana_db_sid }}"

--- a/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_extravars.yml
@@ -56,7 +56,7 @@ sap_netweaver_preconfigure_saptune_solution: 'S4HANA-APPSERVER'  # SUSE saptune 
 #### SAP HANA Database Server installation ####
 # SAP HANA Master password
 sap_hana_install_use_master_password: "y"  # Use a master password for SAP HANA installation (y/n) (String).
-sap_hana_install_master_password: "ENTER_STRING_VALUE_HERE"  # The master password for SAP HANA (String).
+sap_hana_install_master_password: "NewPass$321"  # The master password for SAP HANA (String).
 
 # Dynamic assignment of SAP HANA variables
 sap_hana_sid: "{{ sap_system_hana_db_sid }}"

--- a/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_extravars.yml
@@ -49,7 +49,7 @@ sap_netweaver_preconfigure_fail_if_not_enough_swap_space_configured: false  # Wh
 #### SAP HANA Database Server installation ####
 # SAP HANA Master password
 sap_hana_install_use_master_password: "y"  # Use a master password for SAP HANA installation (y/n) (String).
-sap_hana_install_master_password: "ENTER_STRING_VALUE_HERE"  # The master password for SAP HANA (String).
+sap_hana_install_master_password: "NewPass$321"  # The master password for SAP HANA (String).
 
 # Dynamic assignment of SAP HANA variables
 sap_hana_sid: "{{ sap_system_hana_db_sid }}"

--- a/deploy_scenarios/sap_s4hana_foundation_standard/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_standard/ansible_extravars.yml
@@ -52,7 +52,7 @@ sap_netweaver_preconfigure_saptune_solution: 'S4HANA-APPSERVER'  # SUSE saptune 
 #### SAP HANA Database Server installation ####
 # SAP HANA Master password
 sap_hana_install_use_master_password: "y"  # Use a master password for SAP HANA installation (y/n) (String).
-sap_hana_install_master_password: "ENTER_STRING_VALUE_HERE"  # The master password for SAP HANA (String).
+sap_hana_install_master_password: "NewPass$321"  # The master password for SAP HANA (String).
 
 # Dynamic assignment of SAP HANA variables
 sap_hana_sid: "{{ sap_system_hana_db_sid }}"

--- a/deploy_scenarios/sap_s4hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox/ansible_extravars.yml
@@ -49,7 +49,7 @@ sap_netweaver_preconfigure_fail_if_not_enough_swap_space_configured: false  # Wh
 #### SAP HANA Database Server installation ####
 # SAP HANA Master password
 sap_hana_install_use_master_password: "y"  # Use a master password for SAP HANA installation (y/n) (String).
-sap_hana_install_master_password: "ENTER_STRING_VALUE_HERE"  # The master password for SAP HANA (String).
+sap_hana_install_master_password: "NewPass$321"  # The master password for SAP HANA (String).
 
 # Dynamic assignment of SAP HANA variables
 sap_hana_sid: "{{ sap_system_hana_db_sid }}"

--- a/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_extravars.yml
@@ -52,7 +52,7 @@ sap_netweaver_preconfigure_fail_if_not_enough_swap_space_configured: false  # Wh
 #### SAP HANA Database Server installation ####
 # SAP HANA Master password
 sap_hana_install_use_master_password: "y"  # Use a master password for SAP HANA installation (y/n) (String).
-sap_hana_install_master_password: "ENTER_STRING_VALUE_HERE"  # The master password for SAP HANA (String).
+sap_hana_install_master_password: "NewPass$321"  # The master password for SAP HANA (String).
 
 # Dynamic assignment of SAP HANA variables
 sap_hana_sid: "{{ sap_system_hana_db_sid }}"

--- a/deploy_scenarios/sap_s4hana_standard/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_standard/ansible_extravars.yml
@@ -52,7 +52,7 @@ sap_netweaver_preconfigure_saptune_solution: 'S4HANA-APPSERVER'  # SUSE saptune 
 #### SAP HANA Database Server installation ####
 # SAP HANA Master password
 sap_hana_install_use_master_password: "y"  # Use a master password for SAP HANA installation (y/n) (String).
-sap_hana_install_master_password: "ENTER_STRING_VALUE_HERE"  # The master password for SAP HANA (String).
+sap_hana_install_master_password: "NewPass$321"  # The master password for SAP HANA (String).
 
 # Dynamic assignment of SAP HANA variables
 sap_hana_sid: "{{ sap_system_hana_db_sid }}"

--- a/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_extravars.yml
@@ -55,7 +55,7 @@ sap_netweaver_preconfigure_saptune_solution: 'S4HANA-APPSERVER'  # SUSE saptune 
 #### SAP HANA Database Server installation ####
 # SAP HANA Master password
 sap_hana_install_use_master_password: "y"  # Use a master password for SAP HANA installation (y/n) (String).
-sap_hana_install_master_password: "ENTER_STRING_VALUE_HERE"  # The master password for SAP HANA (String).
+sap_hana_install_master_password: "NewPass$321"  # The master password for SAP HANA (String).
 
 # Dynamic assignment of SAP HANA variables
 sap_hana_sid: "{{ sap_system_hana_db_sid }}"

--- a/deploy_scenarios/sap_solman_saphana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_solman_saphana_sandbox/ansible_extravars.yml
@@ -52,7 +52,7 @@ sap_hana_preconfigure_update: true  # Whether to update the system during pre-co
 #### SAP HANA Database Server installation ####
 # SAP HANA Master password
 sap_hana_install_use_master_password: "y"  # Use a master password for SAP HANA installation (y/n) (String).
-sap_hana_install_master_password: "ENTER_STRING_VALUE_HERE"  # The master password for SAP HANA (String).
+sap_hana_install_master_password: "NewPass$321"  # The master password for SAP HANA (String).
 
 # Dynamic assignment of SAP HANA variables
 sap_hana_sid: "{{ sap_system_hana_db_sid }}"

--- a/docs/README.md
+++ b/docs/README.md
@@ -143,17 +143,18 @@ bin_ansible_callbacks = True
 ```
 
 ### Preparations - SAP User ID credentials (Optional)
-The download of the SAP Installation Media Software from SAP will be executed if `community.sap_launchpad` Ansible Collection is available on Execution Node. 
+The download of the SAP Installation Media Software from SAP to the target host, will be executed if the `community.sap_launchpad` Ansible Collection is installed on Ansible Control Node (i.e. where Ansible is executed from, such as a laptop or AWX etc).  
 
-The software must be obtained from SAP directly, and requires valid license agreements with SAP in order to access these files.
+The SAP software files must be obtained from SAP directly, and requires valid license agreements with SAP in order to access these files.  
 
-An SAP Company Number (SCN) contains one or more Installation Number/s, providing licenses for specified SAP Software. When an SAP User ID is created within the SAP Customer Number (SCN), the administrator must provide SAP Download authorizations for the SAP User ID.
+An SAP Company Number (SCN) contains one or more Installation Number/s, providing licenses for specified SAP Software. When an SAP User ID is created within the SAP Customer Number (SCN), the administrator must provide SAP Download authorizations for the SAP User ID.  
 
-When an SAP User ID (e.g. S-User) is enabled with and part of an SAP Universal ID, then the `sap_launchpad` Ansible Collection **must** use:
-- the SAP User ID
-- the password for login with the SAP Universal ID
+Login credentials for the SAP User ID (e.g. S-User) have two login approaches:  
+- **SAP Universal ID**: an email address is assigned many SAP User IDs. Select the SAP User ID, and use the password of the SAP Universal ID.
+   - Do **NOT** use the SAP User ID legacy `Account Password` from the [SAP Universal ID Account Manager](https://account.sap.com/manage/accounts).
+- **Legacy**: an SAP User ID is isolated. Use the SAP User ID and the associated password.
 
-In addition, if a SAP Universal ID is used then the recommendation is to check and reset the SAP User ID ‘Account Password’ in the [SAP Universal ID Account Manager](https://account.sap.com/manage/accounts), which will help to avoid any potential conflicts.
+For further information regarding connection errors, please see the FAQ section [Errors with prefix 'SAP SSO authentication failed - '](./docs/FAQ.md#errors-with-prefix-sap-sso-authentication-failed---).
 
 **NOTE: The `community.sap_launchpad` Ansible Collection supports only S-Users without Multi Factor Authentication.**
 


### PR DESCRIPTION
## Changes
- Default value for `sap_hana_install_master_password` to align it with other predefined password variables.
- Update Readme to explain S-user specific for Universal ID.
- Add ECC EH8 PAM Matrix link for `sap_ecc_hana_sandbox` scenario.