### PR TITLE
all: Update existing hosts extravars, Azure comments, inventory comments

### DIFF
--- a/common_fragments/vars/platform_vars_aws_ec2_vs.yml
+++ b/common_fragments/vars/platform_vars_aws_ec2_vs.yml
@@ -6,8 +6,8 @@ sap_vm_provision_bastion_ssh_port: "ENTER_STRING_VALUE_HERE"  # Bastion user pas
 
 # Variables required for sap_vm_provision_iac_type=ansible
 sap_vm_provision_bastion_public_ip: "ENTER_STRING_VALUE_HERE"  # Public IP of the bastion server (String).
-sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion private SSH key on execution node (String).
-sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion private host key on execution node (String).
+sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion server's SSH private key on the execution node (String).
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to target host's SSH private key on the execution node (String).
 
 #### Infrastructure platform variables ####
 sap_vm_provision_iac_platform: "aws_ec2_vs"  # Name of the provisioning platform (String).

--- a/common_fragments/vars/platform_vars_gcp_ce_vm.yml
+++ b/common_fragments/vars/platform_vars_gcp_ce_vm.yml
@@ -6,8 +6,8 @@ sap_vm_provision_bastion_ssh_port: "ENTER_STRING_VALUE_HERE"  # Bastion user pas
 
 # Variables required for sap_vm_provision_iac_type=ansible
 sap_vm_provision_bastion_public_ip: "ENTER_STRING_VALUE_HERE"  # Public IP of the bastion server (String).
-sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion private SSH key on execution node (String).
-sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion private host key on execution node (String).
+sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion server's SSH private key on the execution node (String).
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to target host's SSH private key on the execution node (String).
 sap_vm_provision_ssh_host_public_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion public host key on execution node (String).
 
 #### Infrastructure platform variables ####

--- a/common_fragments/vars/platform_vars_ibmcloud_powervs.yml
+++ b/common_fragments/vars/platform_vars_ibmcloud_powervs.yml
@@ -6,8 +6,8 @@ sap_vm_provision_bastion_ssh_port: "ENTER_STRING_VALUE_HERE"  # Bastion user pas
 
 # Variables required for sap_vm_provision_iac_type=ansible
 sap_vm_provision_bastion_public_ip: "ENTER_STRING_VALUE_HERE"  # Public IP of the bastion server (String).
-sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion private SSH key on execution node (String).
-sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion private host key on execution node (String).
+sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion server's SSH private key on the execution node (String).
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to target host's SSH private key on the execution node (String).
 
 #### Infrastructure platform variables ####
 sap_vm_provision_iac_platform: "ibmcloud_powervs"  # Name of the provisioning platform (String).

--- a/common_fragments/vars/platform_vars_ibmcloud_vs.yml
+++ b/common_fragments/vars/platform_vars_ibmcloud_vs.yml
@@ -6,8 +6,8 @@ sap_vm_provision_bastion_ssh_port: "ENTER_STRING_VALUE_HERE"  # Bastion user pas
 
 # Variables required for sap_vm_provision_iac_type=ansible
 sap_vm_provision_bastion_public_ip: "ENTER_STRING_VALUE_HERE"  # Public IP of the bastion server (String).
-sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion private SSH key on execution node (String).
-sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion private host key on execution node (String).
+sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion server's SSH private key on the execution node (String).
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to target host's SSH private key on the execution node (String).
 
 #### Infrastructure platform variables ####
 sap_vm_provision_iac_platform: "ibmcloud_vs"  # Name of the provisioning platform (String).

--- a/common_fragments/vars/platform_vars_ibmpowervm_vm.yml
+++ b/common_fragments/vars/platform_vars_ibmpowervm_vm.yml
@@ -6,8 +6,8 @@ sap_vm_provision_bastion_ssh_port: "ENTER_STRING_VALUE_HERE"  # Bastion user pas
 
 # Variables required for sap_vm_provision_iac_type=ansible
 sap_vm_provision_bastion_public_ip: "ENTER_STRING_VALUE_HERE"  # Public IP of the bastion server (String).
-sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion private SSH key on execution node (String).
-sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion private host key on execution node (String).
+sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion server's SSH private key on the execution node (String).
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to target host's SSH private key on the execution node (String).
 sap_vm_provision_ssh_host_public_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion public host key on execution node (String).
 
 #### Infrastructure platform variables ####

--- a/common_fragments/vars/platform_vars_kubevirt_vm.yml
+++ b/common_fragments/vars/platform_vars_kubevirt_vm.yml
@@ -6,8 +6,8 @@ sap_vm_provision_bastion_ssh_port: "ENTER_STRING_VALUE_HERE"  # Bastion user pas
 
 # Variables required for sap_vm_provision_iac_type=ansible
 sap_vm_provision_bastion_public_ip: "ENTER_STRING_VALUE_HERE"  # Public IP of the bastion server (String).
-sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion private SSH key on execution node (String).
-sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion private host key on execution node (String).
+sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion server's SSH private key on the execution node (String).
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to target host's SSH private key on the execution node (String).
 
 #### Infrastructure platform variables ####
 sap_vm_provision_iac_platform: "kubevirt_vm"  # Name of the provisioning platform (String).

--- a/common_fragments/vars/platform_vars_msazure_vm.yml
+++ b/common_fragments/vars/platform_vars_msazure_vm.yml
@@ -6,8 +6,8 @@ sap_vm_provision_bastion_ssh_port: "ENTER_STRING_VALUE_HERE"  # Bastion user pas
 
 # Variables required for sap_vm_provision_iac_type=ansible
 sap_vm_provision_bastion_public_ip: "ENTER_STRING_VALUE_HERE"  # Public IP of the bastion server (String).
-sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion private SSH key on execution node (String).
-sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion private host key on execution node (String).
+sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion server's SSH private key on the execution node (String).
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to target host's SSH private key on the execution node (String).
 
 #### Infrastructure platform variables ####
 sap_vm_provision_iac_platform: "msazure_vm"  # Name of the provisioning platform (String).

--- a/common_fragments/vars/platform_vars_msazure_vm.yml
+++ b/common_fragments/vars/platform_vars_msazure_vm.yml
@@ -26,7 +26,7 @@ sap_vm_provision_msazure_vnet_subnet_name: "ENTER_STRING_VALUE_HERE" # Virtual N
 sap_vm_provision_msazure_vm_host_os_image: "ENTER_STRING_VALUE_HERE"
 
 # Variables required for sap_vm_provision_iac_type=ansible
-sap_vm_provision_msazure_key_pair_name_ssh_host_public_key: ""  # SSH key pair name (String).
+sap_vm_provision_msazure_key_pair_name_ssh_host_public_key: "ENTER_STRING_VALUE_HERE"  # SSH key pair name (String).
 sap_vm_provision_msazure_private_dns_resource_group_name: "" # optional, default use of sap_vm_provision_msazure_resource_group_name
 
 # Variables required for sap_vm_provision_iac_type=ansible_to_terraform

--- a/common_fragments/vars/platform_vars_ovirt_vm.yml
+++ b/common_fragments/vars/platform_vars_ovirt_vm.yml
@@ -6,8 +6,8 @@ sap_vm_provision_bastion_ssh_port: "ENTER_STRING_VALUE_HERE"  # Bastion user pas
 
 # Variables required for sap_vm_provision_iac_type=ansible
 sap_vm_provision_bastion_public_ip: "ENTER_STRING_VALUE_HERE"  # Public IP of the bastion server (String).
-sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion private SSH key on execution node (String).
-sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion private host key on execution node (String).
+sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion server's SSH private key on the execution node (String).
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to target host's SSH private key on the execution node (String).
 
 #### Infrastructure platform variables ####
 sap_vm_provision_iac_platform: "ovirt_vm"  # Name of the provisioning platform (String).

--- a/common_fragments/vars/platform_vars_vmware_vm.yml
+++ b/common_fragments/vars/platform_vars_vmware_vm.yml
@@ -6,8 +6,8 @@ sap_vm_provision_bastion_ssh_port: "ENTER_STRING_VALUE_HERE"  # Bastion user pas
 
 # Variables required for sap_vm_provision_iac_type=ansible
 sap_vm_provision_bastion_public_ip: "ENTER_STRING_VALUE_HERE"  # Public IP of the bastion server (String).
-sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion private SSH key on execution node (String).
-sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion private host key on execution node (String).
+sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion server's SSH private key on the execution node (String).
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to target host's SSH private key on the execution node (String).
 sap_vm_provision_ssh_host_public_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion public host key on execution node (String).
 
 #### Infrastructure platform variables ####

--- a/deploy_scenarios/sap_bw4hana_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_bw4hana_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -15,18 +15,6 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"

--- a/deploy_scenarios/sap_bw4hana_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_bw4hana_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -14,6 +14,10 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]

--- a/deploy_scenarios/sap_bw4hana_sandbox/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_bw4hana_sandbox/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 hana_primary:
   hosts:

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/optional/ansible_extravars_existing_hosts.yml
@@ -14,12 +14,16 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
 
-# SAP HANA Variables
+# Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true
 
 # Define the NFS mount points for HANA data, log, and shared directories (String).

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/optional/ansible_extravars_existing_hosts.yml
@@ -15,21 +15,12 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
+
+# SAP HANA Variables
+sap_hana_install_update_firewall: true
 
 # Define the NFS mount points for HANA data, log, and shared directories (String).
 sap_vm_provision_nfs_mount_point_hana_data: "ENTER_STRING_VALUE_HERE"

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 hana_primary:
   hosts:

--- a/deploy_scenarios/sap_ecc_hana_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ecc_hana_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -15,18 +15,6 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"

--- a/deploy_scenarios/sap_ecc_hana_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ecc_hana_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -14,6 +14,10 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]

--- a/deploy_scenarios/sap_ecc_hana_sandbox/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_ecc_hana_sandbox/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 hana_primary:
   hosts:

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed/optional/ansible_extravars_existing_hosts.yml
@@ -15,18 +15,6 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed/optional/ansible_extravars_existing_hosts.yml
@@ -14,6 +14,10 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 anydb_primary:
   hosts:

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/optional/ansible_extravars_existing_hosts.yml
@@ -15,18 +15,6 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/optional/ansible_extravars_existing_hosts.yml
@@ -14,6 +14,10 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 anydb_primary:
   hosts:

--- a/deploy_scenarios/sap_ecc_ibmdb2_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -15,18 +15,6 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"

--- a/deploy_scenarios/sap_ecc_ibmdb2_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -14,6 +14,10 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]

--- a/deploy_scenarios/sap_ecc_ibmdb2_sandbox/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_sandbox/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 nwas_pas:
   hosts:

--- a/deploy_scenarios/sap_ecc_oracledb_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ecc_oracledb_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -15,18 +15,6 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"

--- a/deploy_scenarios/sap_ecc_oracledb_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ecc_oracledb_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -14,6 +14,10 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]

--- a/deploy_scenarios/sap_ecc_oracledb_sandbox/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_ecc_oracledb_sandbox/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 nwas_pas:
   hosts:

--- a/deploy_scenarios/sap_ecc_sapase_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ecc_sapase_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -15,18 +15,6 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"

--- a/deploy_scenarios/sap_ecc_sapase_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ecc_sapase_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -14,6 +14,10 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]

--- a/deploy_scenarios/sap_ecc_sapase_sandbox/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_ecc_sapase_sandbox/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 nwas_pas:
   hosts:

--- a/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -15,18 +15,6 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"

--- a/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -14,6 +14,10 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]

--- a/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 nwas_pas:
   hosts:

--- a/deploy_scenarios/sap_hana/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_hana/optional/ansible_extravars_existing_hosts.yml
@@ -15,21 +15,12 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
+
+# SAP HANA Variables
+sap_hana_install_update_firewall: true
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_hana/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_hana/optional/ansible_extravars_existing_hosts.yml
@@ -14,12 +14,16 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
 
-# SAP HANA Variables
+# Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true
 
 

--- a/deploy_scenarios/sap_hana/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_hana/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 hana_primary:
   hosts:

--- a/deploy_scenarios/sap_hana_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana_ha/ansible_playbook.yml
@@ -178,10 +178,6 @@
   max_fail_percentage: 0
   tasks:
 
-    - name: Set var of files list from SAP HANA primary, using lookup from Ansible hostvars with key as SAP HANA primary
-      ansible.builtin.set_fact:
-        sap_hana_install_media_files_list: "{{ hostvars[sap_vm_provision_dynamic_inventory_hana_primary_hostname].sap_hana_install_media_files.files | map(attribute='path') | list }}"
-
     - name: Transfer SAP HANA installation media to SAP HANA Primary and SAP HANA Secondary
       delegate_to: "{{ software_source_ip }}"
       remote_user: "root"

--- a/deploy_scenarios/sap_hana_ha/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_hana_ha/optional/ansible_extravars_existing_hosts.yml
@@ -15,21 +15,16 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
+
+# SAP HANA Variables
+sap_hana_install_update_firewall: true
+
+### High Availability variables ###
+sap_vm_temp_vip_hana_primary: "{{ sap_vm_provision_ha_vip_hana_primary }}"
+sap_ha_pacemaker_cluster_vip_hana_primary_ip_address: "{{ sap_vm_provision_ha_vip_hana_primary }}"
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_hana_ha/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_hana_ha/optional/ansible_extravars_existing_hosts.yml
@@ -14,12 +14,16 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
 
-# SAP HANA Variables
+# Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true
 
 ### High Availability variables ###

--- a/deploy_scenarios/sap_hana_ha/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_hana_ha/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 hana_primary:
   hosts:

--- a/deploy_scenarios/sap_hana_scaleout/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_hana_scaleout/optional/ansible_extravars_existing_hosts.yml
@@ -14,12 +14,16 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
 
-# SAP HANA Variables
+# Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true
 
 # Define the NFS mount points for HANA data, log, and shared directories (String).

--- a/deploy_scenarios/sap_hana_scaleout/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_hana_scaleout/optional/ansible_extravars_existing_hosts.yml
@@ -15,21 +15,12 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
+
+# SAP HANA Variables
+sap_hana_install_update_firewall: true
 
 # Define the NFS mount points for HANA data, log, and shared directories (String).
 sap_vm_provision_nfs_mount_point_hana_data: "ENTER_STRING_VALUE_HERE"

--- a/deploy_scenarios/sap_hana_scaleout/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_hana_scaleout/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 hana_primary:
   hosts:

--- a/deploy_scenarios/sap_ides_ecc_hana_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ides_ecc_hana_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -15,18 +15,6 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"

--- a/deploy_scenarios/sap_ides_ecc_hana_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ides_ecc_hana_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -14,6 +14,10 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]

--- a/deploy_scenarios/sap_ides_ecc_hana_sandbox/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_ides_ecc_hana_sandbox/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 hana_primary:
   hosts:

--- a/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -15,18 +15,6 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"

--- a/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -14,6 +14,10 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]

--- a/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 nwas_pas:
   hosts:

--- a/deploy_scenarios/sap_landscape_s4hana_standard/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard/optional/ansible_extravars_existing_hosts.yml
@@ -15,21 +15,12 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
+
+# SAP HANA Variables
+sap_hana_install_update_firewall: true
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_landscape_s4hana_standard/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard/optional/ansible_extravars_existing_hosts.yml
@@ -14,12 +14,16 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
 
-# SAP HANA Variables
+# Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true
 
 

--- a/deploy_scenarios/sap_landscape_s4hana_standard/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 hana_primary:
   hosts:

--- a/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/optional/ansible_extravars_existing_hosts.yml
@@ -15,21 +15,12 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
+
+# SAP HANA Variables
+sap_hana_install_update_firewall: true
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/optional/ansible_extravars_existing_hosts.yml
@@ -14,12 +14,16 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
 
-# SAP HANA Variables
+# Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true
 
 

--- a/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 hana_primary:
   hosts:

--- a/deploy_scenarios/sap_nwas_abap_hana_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_nwas_abap_hana_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -15,18 +15,6 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"

--- a/deploy_scenarios/sap_nwas_abap_hana_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_nwas_abap_hana_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -14,6 +14,10 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]

--- a/deploy_scenarios/sap_nwas_abap_hana_sandbox/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_nwas_abap_hana_sandbox/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 hana_primary:
   hosts:

--- a/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -15,18 +15,6 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"

--- a/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -14,6 +14,10 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]

--- a/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 nwas_pas:
   hosts:

--- a/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -15,18 +15,6 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"

--- a/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -14,6 +14,10 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]

--- a/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 nwas_pas:
   hosts:

--- a/deploy_scenarios/sap_nwas_abap_sapase_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapase_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -15,18 +15,6 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"

--- a/deploy_scenarios/sap_nwas_abap_sapase_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapase_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -14,6 +14,10 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]

--- a/deploy_scenarios/sap_nwas_abap_sapase_sandbox/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapase_sandbox/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 nwas_pas:
   hosts:

--- a/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -15,18 +15,6 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"

--- a/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -14,6 +14,10 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]

--- a/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 nwas_pas:
   hosts:

--- a/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -15,18 +15,6 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"

--- a/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -14,6 +14,10 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]

--- a/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 nwas_pas:
   hosts:

--- a/deploy_scenarios/sap_nwas_java_sapase_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_nwas_java_sapase_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -15,18 +15,6 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"

--- a/deploy_scenarios/sap_nwas_java_sapase_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_nwas_java_sapase_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -14,6 +14,10 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]

--- a/deploy_scenarios/sap_nwas_java_sapase_sandbox/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_nwas_java_sapase_sandbox/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 nwas_pas:
   hosts:

--- a/deploy_scenarios/sap_s4hana_distributed/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_distributed/optional/ansible_extravars_existing_hosts.yml
@@ -14,12 +14,16 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
 
-# SAP HANA Variables
+# Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true
 
 # Define the NFS mount point (String).

--- a/deploy_scenarios/sap_s4hana_distributed/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_distributed/optional/ansible_extravars_existing_hosts.yml
@@ -15,21 +15,12 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
+
+# SAP HANA Variables
+sap_hana_install_update_firewall: true
 
 # Define the NFS mount point (String).
 sap_vm_provision_nfs_mount_point: "ENTER_STRING_VALUE_HERE"

--- a/deploy_scenarios/sap_s4hana_distributed/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_s4hana_distributed/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 hana_primary:
   hosts:

--- a/deploy_scenarios/sap_s4hana_distributed_ha/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/optional/ansible_extravars_existing_hosts.yml
@@ -14,12 +14,16 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
 
-# SAP HANA Variables
+# Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true
 
 # Define the NFS mount point (String).

--- a/deploy_scenarios/sap_s4hana_distributed_ha/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/optional/ansible_extravars_existing_hosts.yml
@@ -15,21 +15,12 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
+
+# SAP HANA Variables
+sap_hana_install_update_firewall: true
 
 # Define the NFS mount point (String).
 sap_vm_provision_nfs_mount_point: "ENTER_STRING_VALUE_HERE"

--- a/deploy_scenarios/sap_s4hana_distributed_ha/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 hana_primary:
   hosts:

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/optional/ansible_extravars_existing_hosts.yml
@@ -14,12 +14,16 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
 
-# SAP HANA Variables
+# Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true
 
 # Define the NFS mount point (String).

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/optional/ansible_extravars_existing_hosts.yml
@@ -15,21 +15,12 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
+
+# SAP HANA Variables
+sap_hana_install_update_firewall: true
 
 # Define the NFS mount point (String).
 sap_vm_provision_nfs_mount_point: "ENTER_STRING_VALUE_HERE"

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 hana_primary:
   hosts:

--- a/deploy_scenarios/sap_s4hana_distributed_maintplan/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_maintplan/optional/ansible_extravars_existing_hosts.yml
@@ -14,12 +14,16 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
 
-# SAP HANA Variables
+# Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true
 
 # Define the NFS mount point (String).

--- a/deploy_scenarios/sap_s4hana_distributed_maintplan/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_maintplan/optional/ansible_extravars_existing_hosts.yml
@@ -15,21 +15,12 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
+
+# SAP HANA Variables
+sap_hana_install_update_firewall: true
 
 # Define the NFS mount point (String).
 sap_vm_provision_nfs_mount_point: "ENTER_STRING_VALUE_HERE"

--- a/deploy_scenarios/sap_s4hana_distributed_maintplan/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_maintplan/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 hana_primary:
   hosts:

--- a/deploy_scenarios/sap_s4hana_foundation_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -15,21 +15,12 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
+
+# SAP HANA Variables
+sap_hana_install_update_firewall: true
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_s4hana_foundation_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -14,12 +14,16 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
 
-# SAP HANA Variables
+# Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true
 
 

--- a/deploy_scenarios/sap_s4hana_foundation_sandbox/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_sandbox/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 hana_primary:
   hosts:

--- a/deploy_scenarios/sap_s4hana_foundation_standard/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_standard/optional/ansible_extravars_existing_hosts.yml
@@ -15,21 +15,12 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
+
+# SAP HANA Variables
+sap_hana_install_update_firewall: true
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_s4hana_foundation_standard/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_standard/optional/ansible_extravars_existing_hosts.yml
@@ -14,12 +14,16 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
 
-# SAP HANA Variables
+# Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true
 
 

--- a/deploy_scenarios/sap_s4hana_foundation_standard/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_standard/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 hana_primary:
   hosts:

--- a/deploy_scenarios/sap_s4hana_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -15,18 +15,6 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"

--- a/deploy_scenarios/sap_s4hana_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -14,6 +14,10 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]

--- a/deploy_scenarios/sap_s4hana_sandbox/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 hana_primary:
   hosts:

--- a/deploy_scenarios/sap_s4hana_sandbox_maintplan/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_maintplan/optional/ansible_extravars_existing_hosts.yml
@@ -15,18 +15,6 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"

--- a/deploy_scenarios/sap_s4hana_sandbox_maintplan/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_maintplan/optional/ansible_extravars_existing_hosts.yml
@@ -14,6 +14,10 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]

--- a/deploy_scenarios/sap_s4hana_sandbox_maintplan/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_maintplan/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 hana_primary:
   hosts:

--- a/deploy_scenarios/sap_s4hana_standard/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_standard/optional/ansible_extravars_existing_hosts.yml
@@ -15,21 +15,12 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
+
+# SAP HANA Variables
+sap_hana_install_update_firewall: true
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_s4hana_standard/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_standard/optional/ansible_extravars_existing_hosts.yml
@@ -14,12 +14,16 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
 
-# SAP HANA Variables
+# Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true
 
 

--- a/deploy_scenarios/sap_s4hana_standard/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_s4hana_standard/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 hana_primary:
   hosts:

--- a/deploy_scenarios/sap_s4hana_standard_maintplan/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_standard_maintplan/optional/ansible_extravars_existing_hosts.yml
@@ -15,21 +15,12 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
+
+# SAP HANA Variables
+sap_hana_install_update_firewall: true
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_s4hana_standard_maintplan/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_standard_maintplan/optional/ansible_extravars_existing_hosts.yml
@@ -14,12 +14,16 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
 
-# SAP HANA Variables
+# Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true
 
 

--- a/deploy_scenarios/sap_s4hana_standard_maintplan/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_s4hana_standard_maintplan/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 hana_primary:
   hosts:

--- a/deploy_scenarios/sap_solman_sapase_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_solman_sapase_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -14,6 +14,10 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]

--- a/deploy_scenarios/sap_solman_sapase_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_solman_sapase_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -15,10 +15,6 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"

--- a/deploy_scenarios/sap_solman_sapase_sandbox/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_solman_sapase_sandbox/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 nwas_pas:
   hosts:

--- a/deploy_scenarios/sap_solman_saphana_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_solman_saphana_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -14,6 +14,10 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]

--- a/deploy_scenarios/sap_solman_saphana_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_solman_saphana_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -15,10 +15,6 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"

--- a/deploy_scenarios/sap_solman_saphana_sandbox/optional/ansible_inventory_noninteractive.yml
+++ b/deploy_scenarios/sap_solman_saphana_sandbox/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 nwas_pas:
   hosts:

--- a/docs/README.md
+++ b/docs/README.md
@@ -360,11 +360,18 @@ export AZ_CLIENT_ID=$(az ad app create --display-name ansible-terraform | jq .ap
 # Create Azure Service Principal, instantiation of Azure Application
 export AZ_SERVICE_PRINCIPAL_ID=$(az ad sp create --id $AZ_CLIENT_ID | jq .objectId --raw-output)
 
+# ALT: Obtain existing Azure Application (Client ID) and the Azure Application's instantiation (Service Principal)
+# See Azure AAD 'App Registrations' blade
+# See Azure AAD IAM 'Enterprise Application' blade
+export AZ_CLIENT_ID=$(az ad app list --display-name "NAME" | jq .[].appId --raw-output)
+export AZ_SERVICE_PRINCIPAL_ID=$(az ad sp show --id "$AZ_CLIENT_ID" | jq .id --raw-output)
+
 # Assign default Azure AD Role with privileges for creating Azure Virtual Machines
 az role assignment create --assignee "$AZ_SERVICE_PRINCIPAL_ID" \
---subscription "$AZ_SUBSCRIPTION_ID" \
 --role "Virtual Machine Contributor" \
---role "Contributor"
+--role "Contributor" \
+--scope "/subscriptions/$AZ_SUBSCRIPTION_ID" \
+--subscription "$AZ_SUBSCRIPTION_ID"
 
 # Reset Azure Application, to provide the Client ID and Client Secret to use the Azure Service Principal
 az ad sp credential reset --name $AZ_CLIENT_ID

--- a/special_actions/sap_nwas_abap_ascs_ers_cluster/optional/ansible_extravars_existing_hosts.yml
+++ b/special_actions/sap_nwas_abap_ascs_ers_cluster/optional/ansible_extravars_existing_hosts.yml
@@ -14,6 +14,10 @@ sap_general_preconfigure_modify_etc_hosts: true
 sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
+# Path to target host's SSH private key on the execution node (String).
+# This SSH key has to be added to authorized_keys on managed node.
+sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
+
 # sap_storage role variable assignment per host
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]

--- a/special_actions/sap_nwas_abap_ascs_ers_cluster/optional/ansible_extravars_existing_hosts.yml
+++ b/special_actions/sap_nwas_abap_ascs_ers_cluster/optional/ansible_extravars_existing_hosts.yml
@@ -15,18 +15,6 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"
@@ -35,6 +23,12 @@ sap_storage_setup_definition:
 sap_vm_provision_nfs_mount_point: "ENTER_STRING_VALUE_HERE"
 sap_vm_provision_nfs_mount_point_type: "ENTER_STRING_VALUE_HERE"  # NFS version (String).
 sap_vm_provision_nfs_mount_point_opts: "ENTER_STRING_VALUE_HERE"  # NFS Mount options (String).
+
+### High Availability variables ###
+sap_vm_temp_vip_nwas_abap_ascs: "{{ sap_vm_provision_ha_vip_nwas_abap_ascs }}"
+sap_ha_pacemaker_cluster_vip_nwas_abap_ascs_ip_address: "{{ sap_vm_provision_ha_vip_nwas_abap_ascs }}"
+sap_vm_temp_vip_nwas_abap_ers: "{{ sap_vm_provision_ha_vip_nwas_abap_ers }}"
+sap_ha_pacemaker_cluster_vip_nwas_abap_ers_ip_address: "{{ sap_vm_provision_ha_vip_nwas_abap_ers }}"
 
 
 #### Ansible Dictionary for host specifications ####

--- a/special_actions/sap_webdispatcher_standalone/optional/ansible_extravars_existing_hosts.yml
+++ b/special_actions/sap_webdispatcher_standalone/optional/ansible_extravars_existing_hosts.yml
@@ -15,18 +15,6 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_host_type }}"
-
-sap_storage_setup_sid:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_sid }}"
-
-sap_storage_setup_host_type:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].sap_storage_setup_host_type }}"
-
 sap_storage_setup_definition:
   "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
     [inventory_hostname_short].storage_definition }}"

--- a/special_actions/sap_webdispatcher_standalone/optional/ansible_inventory_noninteractive.yml
+++ b/special_actions/sap_webdispatcher_standalone/optional/ansible_inventory_noninteractive.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
+# Ansible Inventory Group names must match sap_host_type variable - hana_primary, hana_secondary, anydb_primary, anydb_secondary, nwas_ascs, nwas_ers, nwas_pas, nwas_aas
 
 nwas_aas:
   hosts:


### PR DESCRIPTION
## Changes
-  `existing_hosts` extravars
   - Remove `sap_host_type`, `sap_storage_setup_sid`, `sap_storage_setup_host_type` from `existing_hosts` extravars file as they are not required. Storage role vars are taking care of that.
   - Add VIP vars into `existing_hosts` extravars
   - Add `sap_hana_install_update_firewall: true` to multi-host HANA scenarios, where ports are not enabled on non-Cloud images.
- Remove missed set_fact task for media list creation in `sap_hana_ha`
- Update MS Azure comments
