### PR TITLE
all: Move provisioning domain variable to fragments, Add placeholder validation, improve rsync dest 

### DIFF
--- a/common_fragments/vars/platform_vars_aws_ec2_vs.yml
+++ b/common_fragments/vars/platform_vars_aws_ec2_vs.yml
@@ -19,6 +19,7 @@ sap_vm_provision_aws_vpc_subnet_id: "ENTER_STRING_VALUE_HERE" # VPC Subnet ID (S
 sap_vm_provision_aws_vpc_subnet_create_boolean:
   "{{ true | default(false) if sap_vm_provision_aws_vpc_subnet_id == 'new' else false }}"
 
+sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"  # Root domain for DNS entries (e.g., example.com) (String).
 
 # Enter image name from dictionary sap_vm_provision_aws_ec2_vs_host_os_image_dictionary keys (String).
 # Example: sles-15-6-sap-ha (SUSE), rhel-9-4-sap-ha (Red Hat)

--- a/common_fragments/vars/platform_vars_gcp_ce_vm.yml
+++ b/common_fragments/vars/platform_vars_gcp_ce_vm.yml
@@ -19,6 +19,8 @@ sap_vm_provision_gcp_region_zone: "ENTER_STRING_VALUE_HERE"  # Region zone (Stri
 sap_vm_provision_gcp_vpc_name: "ENTER_STRING_VALUE_HERE"  # VPC name (String).
 sap_vm_provision_gcp_vpc_subnet_name: "ENTER_STRING_VALUE_HERE"  # VPC Subnet name (String).
 
+sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"  # Root domain for DNS entries (e.g., example.com) (String).
+
 # Enter image name from dictionary sap_vm_provision_gcp_ce_vm_host_os_image_dictionary keys (String)..
 # Example: sles-15-6-sap-ha (SUSE), rhel-9-latest (Red Hat)
 sap_vm_provision_gcp_ce_vm_host_os_image: "ENTER_STRING_VALUE_HERE"

--- a/common_fragments/vars/platform_vars_ibmcloud_powervs.yml
+++ b/common_fragments/vars/platform_vars_ibmcloud_powervs.yml
@@ -16,6 +16,8 @@ sap_vm_provision_ibmcloud_resource_group_name: "ENTER_STRING_VALUE_HERE" # Resou
 sap_vm_provision_ibmcloud_powervs_location: "ENTER_STRING_VALUE_HERE"  # Location (String).
 sap_vm_provision_ibmcloud_vpc_subnet_name: "ENTER_STRING_VALUE_HERE" # VPC Subnet name (String). only for ansible_to_terraform, can be name or 'new'
 
+sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"  # Root domain for DNS entries (e.g., example.com) (String).
+
 # Enter image name from dictionary sap_vm_provision_ibmcloud_powervs_host_os_image_dictionary keys (String)..
 # Example: sles-15-5-sap-ha (SUSE), rhel-9-2-sap-ha (Red Hat)
 sap_vm_provision_ibmcloud_powervs_host_os_image: "ENTER_STRING_VALUE_HERE"

--- a/common_fragments/vars/platform_vars_ibmcloud_vs.yml
+++ b/common_fragments/vars/platform_vars_ibmcloud_vs.yml
@@ -19,6 +19,8 @@ sap_vm_provision_ibmcloud_private_dns_instance_name: "ENTER_STRING_VALUE_HERE"  
 sap_vm_provision_ibmcloud_vpc_name: "ENTER_STRING_VALUE_HERE" # VPC Name (String). if ansible_to_terraform, use "new"
 sap_vm_provision_ibmcloud_vpc_subnet_name: "ENTER_STRING_VALUE_HERE" # VPC Subnet name (String). if ansible_to_terraform, use "new"
 
+sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"  # Root domain for DNS entries (e.g., example.com) (String).
+
 # Enter image name from dictionary sap_vm_provision_ibmcloud_vs_host_os_image_dictionary keys (String).
 # Example: sles-15-6-sap-ha (SUSE), rhel-9-4-sap-ha (Red Hat)
 sap_vm_provision_ibmcloud_vs_host_os_image: "ENTER_STRING_VALUE_HERE"

--- a/common_fragments/vars/platform_vars_ibmpowervm_vm.yml
+++ b/common_fragments/vars/platform_vars_ibmpowervm_vm.yml
@@ -22,6 +22,8 @@ sap_vm_provision_ibmpowervm_network_name: "ENTER_STRING_VALUE_HERE"  # Network n
 sap_vm_provision_ibmpowervm_network_vnic_type: "normal" # Virtual NIC Type (String). 'direct' == SR-IOV, 'normal' == Shared Ethernet Adapter (SEA)
 sap_vm_provision_ibmpowervm_storage_template_name: "ENTER_STRING_VALUE_HERE" # Storage template name (String). aka. Openstack Cinder Volume Type
 
+sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"  # Root domain for DNS entries (e.g., example.com) (String).
+
 # IBM PowerVM Virtual Machine OS Image (see IBM PowerVC Web GUI for list) (String).
 sap_vm_provision_ibmpowervm_vm_host_os_image: "ENTER_STRING_VALUE_HERE"
 

--- a/common_fragments/vars/platform_vars_kubevirt_vm.yml
+++ b/common_fragments/vars/platform_vars_kubevirt_vm.yml
@@ -19,6 +19,8 @@ sap_vm_provision_kubevirt_vm_host_os_image_url: "ENTER_STRING_VALUE_HERE" # Imag
 sap_vm_provision_kubevirt_os_user: "ENTER_STRING_VALUE_HERE"  # Optional OS user name (String).
 sap_vm_provision_kubevirt_os_user_password: "ENTER_STRING_VALUE_HERE"  # Optional OS user password (String).
 
+sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"  # Root domain for DNS entries (e.g., example.com) (String).
+
 # Variables required for sap_vm_provision_iac_type=ansible_to_terraform
 sap_vm_provision_terraform_state: "ENTER_STRING_VALUE_HERE" # present, absent
 sap_vm_provision_resource_prefix: "ENTER_STRING_VALUE_HERE"

--- a/common_fragments/vars/platform_vars_msazure_vm.yml
+++ b/common_fragments/vars/platform_vars_msazure_vm.yml
@@ -21,6 +21,8 @@ sap_vm_provision_msazure_location_availability_zone_no: 1  # ansible_to_terrafor
 sap_vm_provision_msazure_vnet_name: "ENTER_STRING_VALUE_HERE" # Virtual Network name (String). if ansible_to_terraform, use "new"
 sap_vm_provision_msazure_vnet_subnet_name: "ENTER_STRING_VALUE_HERE" # Virtual Network Subnet name (String). if ansible_to_terraform, use "new"
 
+sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"  # Root domain for DNS entries (e.g., example.com) (String).
+
 # Enter image name from dictionary sap_vm_provision_msazure_vm_host_os_image_dictionary keys (String).
 # Example: sles-15-6-sap-ha (SUSE), rhel-9-4-sap-ha (Red Hat)
 sap_vm_provision_msazure_vm_host_os_image: "ENTER_STRING_VALUE_HERE"

--- a/common_fragments/vars/platform_vars_ovirt_vm.yml
+++ b/common_fragments/vars/platform_vars_ovirt_vm.yml
@@ -28,6 +28,8 @@ sap_vm_provision_ovirt_vm_disk_type: "raw" # default is 'cow' = thin provisionin
 sap_vm_provision_ovirt_vm_timezone: "Etc/GMT"
 sap_vm_provision_ovirt_vm_operating_system: "other_linux"
 
+sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"  # Root domain for DNS entries (e.g., example.com) (String).
+
 # OVirt VM option 1 - create from VM Template Name
 sap_vm_provision_ovirt_vm_template_name: "ENTER_STRING_VALUE_HERE"
 

--- a/common_fragments/vars/platform_vars_vmware_vm.yml
+++ b/common_fragments/vars/platform_vars_vmware_vm.yml
@@ -25,6 +25,8 @@ sap_vm_provision_vmware_vm_cluster_datastore_name: ""  # VM Cluster datastore na
 sap_vm_provision_vmware_vm_content_library_name: ""  # VM Content library name (String).
 sap_vm_provision_vmware_vm_template_name: ""  # VM template name (String).
 
+sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"  # Root domain for DNS entries (e.g., example.com) (String).
+
 # Variables required for sap_vm_provision_iac_type=ansible_to_terraform
 # sap_vm_provision_terraform_state: "ENTER_STRING_VALUE_HERE" # present, absent
 # sap_vm_provision_resource_prefix: "ENTER_STRING_VALUE_HERE"

--- a/deploy_scenarios/sap_bw4hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_bw4hana_sandbox/ansible_extravars.yml
@@ -12,9 +12,6 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "B01"  # SAP System ID (SID) (String)
@@ -22,6 +19,11 @@ sap_system_hana_db_sid: "H01"  # SAP HANA Database ID (SID) (String).
 sap_system_hana_db_instance_nr: "90"  # SAP HANA Database instance number (String).
 sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance number (String).
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_bw4hana_2023_sandbox).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -112,11 +114,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_bw4hana_2023_sandbox).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_bw4hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_bw4hana_sandbox/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_extravars.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_extravars.yml
@@ -12,9 +12,6 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 # SAP HANA Scale-Out variables for role sap_vm_provision
 sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator: 1  # Number of active coordinators (Integer).
 sap_vm_provision_calculate_sap_hana_scaleout_active_worker: 2  # Number of active workers (Integer).
@@ -27,6 +24,11 @@ sap_system_hana_db_sid: "H01"  # SAP HANA Database ID (SID) (String).
 sap_system_hana_db_instance_nr: "90"  # SAP HANA Database instance number (String).
 sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance number (String).
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_bw4hana_2023_standard).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -126,11 +128,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_bw4hana_2023_standard).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:
@@ -207,7 +222,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false

--- a/deploy_scenarios/sap_ecc_hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_hana_sandbox/ansible_extravars.yml
@@ -12,9 +12,6 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "E01"  # SAP System ID (SID) (String)
@@ -22,6 +19,11 @@ sap_system_hana_db_sid: "H01"  # SAP HANA Database ID (SID) (String).
 sap_system_hana_db_instance_nr: "90"  # SAP HANA Database instance number (String).
 sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance number (String).
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_ecc6_ehp8_hana_sandbox).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -112,11 +114,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_ecc6_ehp8_hana_sandbox).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_ecc_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_hana_sandbox/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_extravars.yml
@@ -12,9 +12,6 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "E01"  # SAP System ID (SID) (String)
@@ -22,6 +19,11 @@ sap_system_anydb_sid: "DB2"  # SAP AnyDB (SID) (String).
 sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance number (String).
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
 sap_system_nwas_abap_aas_instance_nr: "11"  # SAP NetWeaver ABAP AAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_ecc6_ehp8_ibmdb2_distributed).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -82,11 +84,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_ecc6_ehp8_ibmdb2_distributed).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:
@@ -189,7 +204,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ sap_install_media_detect_source_directory }}/" # trailing slash to copy items in the directory, not the directory itself
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false
@@ -213,7 +228,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false
@@ -238,7 +253,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_extravars.yml
@@ -12,9 +12,6 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "E01"  # SAP System ID (SID) (String)
@@ -23,6 +20,11 @@ sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance 
 sap_system_nwas_abap_ers_instance_nr: "10"  # SAP NetWeaver ABAP ERS instance number (String).
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
 sap_system_nwas_abap_aas_instance_nr: "11"  # SAP NetWeaver ABAP AAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_ecc6_ehp8_ibmdb2_distributed).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -123,11 +125,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_ecc6_ehp8_ibmdb2_distributed).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:
@@ -198,7 +213,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ sap_install_media_detect_source_directory }}/" # trailing slash to copy items in the directory, not the directory itself
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false
@@ -222,7 +237,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false
@@ -247,7 +262,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false
@@ -272,7 +287,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false
@@ -547,7 +562,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ sap_install_media_detect_source_directory }}/db2_db_backup_anydb_primary_node" # no trailing slash to copy directory and the contents
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false

--- a/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_extravars.yml
@@ -12,15 +12,17 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "E01"  # SAP System ID (SID) (String)
 sap_system_anydb_sid: "DB2"  # SAP AnyDB (SID) (String).
 sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance number (String).
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_ecc6_ehp8_ibmdb2_sandbox).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -75,11 +77,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_ecc6_ehp8_ibmdb2_sandbox).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:

--- a/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_extravars.yml
@@ -12,15 +12,17 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "E01"  # SAP System ID (SID) (String)
 sap_system_anydb_sid: "OR1"  # SAP AnyDB (SID) (String).
 sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance number (String).
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_ecc6_ehp8_oracledb_sandbox).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -89,11 +91,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_ecc6_ehp8_oracledb_sandbox).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:

--- a/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_extravars.yml
@@ -12,15 +12,17 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "E01"  # SAP System ID (SID) (String)
 sap_system_anydb_sid: "AS1"  # SAP AnyDB (SID) (String).
 sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance number (String).
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_ecc6_ehp8_sapase_sandbox).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -75,11 +77,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_ecc6_ehp8_sapase_sandbox).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:

--- a/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_extravars.yml
@@ -12,15 +12,17 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "E01"  # SAP System ID (SID) (String)
 sap_system_anydb_sid: "MX1"  # SAP AnyDB (SID) (String).
 sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance number (String).
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_ecc6_ehp8_sapmaxdb_sandbox).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -76,11 +78,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_ecc6_ehp8_sapmaxdb_sandbox).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:

--- a/deploy_scenarios/sap_hana/ansible_extravars.yml
+++ b/deploy_scenarios/sap_hana/ansible_extravars.yml
@@ -12,13 +12,15 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_hana_db_sid: "H01"  # SAP HANA Database ID (SID) (String).
 sap_system_hana_db_instance_nr: "90"  # SAP HANA Database instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_hana_2_sps07_install).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -74,11 +76,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_hana_2_sps07_install).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_hana/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:

--- a/deploy_scenarios/sap_hana_ha/ansible_extravars.yml
+++ b/deploy_scenarios/sap_hana_ha/ansible_extravars.yml
@@ -12,13 +12,15 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_hana_db_sid: "H01"  # SAP HANA Database ID (SID) (String).
 sap_system_hana_db_instance_nr: "90"  # SAP HANA Database instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_hana_2_sps07_install).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -103,11 +105,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_hana_2_sps07_install).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_hana_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana_ha/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:
@@ -183,7 +198,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false

--- a/deploy_scenarios/sap_hana_scaleout/ansible_extravars.yml
+++ b/deploy_scenarios/sap_hana_scaleout/ansible_extravars.yml
@@ -12,9 +12,6 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 # SAP HANA Scale-Out variables for role sap_vm_provision
 sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator: 1  # Number of active coordinators (Integer).
 sap_vm_provision_calculate_sap_hana_scaleout_active_worker: 2  # Number of active workers (Integer).
@@ -24,6 +21,11 @@ sap_vm_provision_calculate_sap_hana_scaleout_standby: 1  # Number of standby nod
 #### Key SAP System variables ####
 sap_system_hana_db_sid: "H01"  # SAP HANA Database ID (SID) (String).
 sap_system_hana_db_instance_nr: "90"  # SAP HANA Database instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_hana_2_sps07_install).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -86,11 +88,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_hana_2_sps07_install).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:

--- a/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_extravars.yml
@@ -12,9 +12,6 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "E01"  # SAP System ID (SID) (String)
@@ -22,6 +19,11 @@ sap_system_hana_db_sid: "H01"  # SAP HANA Database ID (SID) (String).
 sap_system_hana_db_instance_nr: "90"  # SAP HANA Database instance number (String).
 sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance number (String).
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_ides_ecc6_ehp8_hana_sandbox).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -112,11 +114,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_ides_ecc6_ehp8_hana_sandbox).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:

--- a/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_extravars.yml
@@ -12,15 +12,17 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "E01"  # SAP System ID (SID) (String)
 sap_system_anydb_sid: "DB2"  # SAP AnyDB (SID) (String).
 sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance number (String).
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_ides_ecc6_ehp8_ibmdb2_sandbox).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -76,17 +78,12 @@ sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
 
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_ides_ecc6_ehp8_ibmdb2_onehost).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
-
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
 
   # SAP Business Suite 7i 2016 > EHP8 for SAP ERP 6.0 ABAP > IBM Db2 for Linux, UNIX, and Windows (LUW) > Installation > Application Server ABAP > Standard System
   # uses SAP NetWeaver 7.5
-  sap_ides_ecc6_ehp8_ibmdb2_onehost:
+  sap_ides_ecc6_ehp8_ibmdb2_sandbox:
 
     # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BS2016.ERP608.DB6.PD

--- a/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:

--- a/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/optional/ansible_extravars_interactive.yml
@@ -30,7 +30,7 @@ sap_software_install_dictionary:
 
   # SAP Business Suite 7i 2016 > EHP8 for SAP ERP 6.0 ABAP > IBM Db2 for Linux, UNIX, and Windows (LUW) > Installation > Application Server ABAP > Standard System
   # uses SAP NetWeaver 7.5
-  sap_ides_ecc6_ehp8_ibmdb2_onehost:
+  sap_ides_ecc6_ehp8_ibmdb2_sandbox:
 
     # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BS2016.ERP608.DB6.PD

--- a/deploy_scenarios/sap_landscape_s4hana_standard/ansible_extravars.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard/ansible_extravars.yml
@@ -12,12 +12,14 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 # Key variables are defined directly in host_specifications_dictionary
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_standard).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -101,11 +103,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_ides_ecc6_ehp8_ibmdb2_onehost).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_landscape_s4hana_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard/ansible_playbook.yml
@@ -11,6 +11,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:
@@ -212,7 +227,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false
@@ -234,7 +249,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false

--- a/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_extravars.yml
@@ -12,12 +12,14 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 # Key variables are defined directly in host_specifications_dictionary
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_standard).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -104,11 +106,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_ides_ecc6_ehp8_ibmdb2_onehost).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_playbook.yml
@@ -11,6 +11,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:
@@ -213,7 +228,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false
@@ -235,7 +250,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false

--- a/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_extravars.yml
@@ -12,9 +12,6 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "N01"  # SAP System ID (SID) (String)
@@ -22,6 +19,11 @@ sap_system_hana_db_sid: "H01"  # SAP HANA Database ID (SID) (String).
 sap_system_hana_db_instance_nr: "90"  # SAP HANA Database instance number (String).
 sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance number (String).
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_nwas_752_sp00_abap_hana_sandbox).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -112,11 +114,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_nwas_752_sp00_abap_hana_sandbox).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:

--- a/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_extravars.yml
@@ -12,15 +12,17 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "N01"  # SAP System ID (SID) (String)
 sap_system_anydb_sid: "DB2"  # SAP AnyDB (SID) (String).
 sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance number (String).
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_nwas_752_sp00_abap_ibmdb2_sandbox).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -75,11 +77,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_nwas_752_sp00_abap_ibmdb2_sandbox).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:

--- a/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_extravars.yml
@@ -12,15 +12,17 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "N01"  # SAP System ID (SID) (String)
 sap_system_anydb_sid: "OR1"  # SAP AnyDB (SID) (String).
 sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance number (String).
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_nwas_752_sp00_abap_oracledb_sandbox).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -89,11 +91,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_nwas_752_sp00_abap_oracledb_sandbox).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:

--- a/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_extravars.yml
@@ -12,15 +12,17 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "N01"  # SAP System ID (SID) (String)
 sap_system_anydb_sid: "AS1"  # SAP AnyDB (SID) (String).
 sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance number (String).
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_nwas_752_sp00_abap_sapase_sandbox).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -75,11 +77,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_nwas_752_sp00_abap_sapase_sandbox).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:

--- a/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_extravars.yml
@@ -12,15 +12,17 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "N01"  # SAP System ID (SID) (String)
 sap_system_anydb_sid: "MX1"  # SAP AnyDB (SID) (String).
 sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance number (String).
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_nwas_752_sp00_abap_sapmaxdb_sandbox).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -76,11 +78,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_nwas_752_sp00_abap_sapmaxdb_sandbox).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:

--- a/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_extravars.yml
@@ -12,9 +12,6 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "J01"  # SAP System ID (SID) (String)
@@ -23,6 +20,11 @@ sap_system_nwas_java_scs_instance_nr: "00"  # SAP NetWeaver JAVA SCS instance nu
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
 # NOTE: All JAVA SCS variables are defined under ABAP ASCS for compatibility with sap_vm_provision role.
 sap_system_nwas_abap_ascs_instance_nr: "{{ sap_system_nwas_java_scs_instance_nr }}"  # SAP NetWeaver ABAP ASCS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_nwas_750_sp22_java_ibmdb2_sandbox_ads).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -85,11 +87,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_nwas_750_sp22_java_ibmdb2_sandbox_ads).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:

--- a/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_extravars.yml
@@ -12,9 +12,6 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "J01"  # SAP System ID (SID) (String)
@@ -23,6 +20,11 @@ sap_system_nwas_java_scs_instance_nr: "00"  # SAP NetWeaver JAVA SCS instance nu
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
 # NOTE: All JAVA SCS variables are defined under ABAP ASCS for compatibility with sap_vm_provision role.
 sap_system_nwas_abap_ascs_instance_nr: "{{ sap_system_nwas_java_scs_instance_nr }}"  # SAP NetWeaver ABAP ASCS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_nwas_750_sp22_java_sapase_sandbox_ads).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -85,11 +87,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_nwas_750_sp22_java_sapase_sandbox_ads).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:

--- a/deploy_scenarios/sap_s4hana_distributed/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_distributed/ansible_extravars.yml
@@ -12,9 +12,6 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "S01"  # SAP System ID (SID) (String)
@@ -23,6 +20,11 @@ sap_system_hana_db_instance_nr: "90"  # SAP HANA Database instance number (Strin
 sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance number (String).
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
 sap_system_nwas_abap_aas_instance_nr: "11"  # SAP NetWeaver ABAP AAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_distributed).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -120,11 +122,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_distributed).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_s4hana_distributed/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:
@@ -197,7 +212,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false
@@ -222,7 +237,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false
@@ -247,7 +262,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false

--- a/deploy_scenarios/sap_s4hana_distributed_ha/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/ansible_extravars.yml
@@ -12,9 +12,6 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "S01"  # SAP System ID (SID) (String)
@@ -24,6 +21,11 @@ sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance 
 sap_system_nwas_abap_ers_instance_nr: "10"  # SAP NetWeaver ABAP ERS instance number (String).
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
 sap_system_nwas_abap_aas_instance_nr: "11"  # SAP NetWeaver ABAP AAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_distributed).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -163,11 +165,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_distributed).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_s4hana_distributed_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:
@@ -210,7 +225,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false
@@ -235,7 +250,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false
@@ -260,7 +275,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_extravars.yml
@@ -12,9 +12,6 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "S01"  # SAP System ID (SID) (String)
@@ -24,6 +21,11 @@ sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance 
 sap_system_nwas_abap_ers_instance_nr: "10"  # SAP NetWeaver ABAP ERS instance number (String).
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
 sap_system_nwas_abap_aas_instance_nr: "11"  # SAP NetWeaver ABAP AAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_distributed).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -166,11 +168,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_distributed).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:
@@ -211,7 +226,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false
@@ -236,7 +251,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false
@@ -261,7 +276,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false

--- a/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_extravars.yml
@@ -12,9 +12,6 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "S01"  # SAP System ID (SID) (String)
@@ -23,6 +20,11 @@ sap_system_hana_db_instance_nr: "90"  # SAP HANA Database instance number (Strin
 sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance number (String).
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
 sap_system_nwas_abap_aas_instance_nr: "11"  # SAP NetWeaver ABAP AAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_distributed).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -123,11 +125,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_distributed).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:
@@ -198,7 +213,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false
@@ -223,7 +238,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false
@@ -248,7 +263,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false

--- a/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_extravars.yml
@@ -12,9 +12,6 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "S01"  # SAP System ID (SID) (String)
@@ -22,6 +19,11 @@ sap_system_hana_db_sid: "H01"  # SAP HANA Database ID (SID) (String).
 sap_system_hana_db_instance_nr: "90"  # SAP HANA Database instance number (String).
 sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance number (String).
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_fndn_2023_sandbox).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -112,11 +114,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_fndn_2023_sandbox).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:

--- a/deploy_scenarios/sap_s4hana_foundation_standard/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_standard/ansible_extravars.yml
@@ -12,9 +12,6 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "S01"  # SAP System ID (SID) (String)
@@ -22,6 +19,11 @@ sap_system_hana_db_sid: "H01"  # SAP HANA Database ID (SID) (String).
 sap_system_hana_db_instance_nr: "90"  # SAP HANA Database instance number (String).
 sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance number (String).
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_fndn_2023_standard).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -115,11 +117,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_fndn_2023_standard).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_s4hana_foundation_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_standard/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:
@@ -181,7 +196,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false

--- a/deploy_scenarios/sap_s4hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox/ansible_extravars.yml
@@ -12,9 +12,6 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "S01"  # SAP System ID (SID) (String)
@@ -22,6 +19,11 @@ sap_system_hana_db_sid: "H01"  # SAP HANA Database ID (SID) (String).
 sap_system_hana_db_instance_nr: "90"  # SAP HANA Database instance number (String).
 sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance number (String).
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_sandbox).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -112,11 +114,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_sandbox).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_s4hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:

--- a/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_extravars.yml
@@ -12,9 +12,6 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "S01"  # SAP System ID (SID) (String)
@@ -22,6 +19,11 @@ sap_system_hana_db_sid: "H01"  # SAP HANA Database ID (SID) (String).
 sap_system_hana_db_instance_nr: "90"  # SAP HANA Database instance number (String).
 sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance number (String).
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_sandbox).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -115,11 +117,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_sandbox).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:

--- a/deploy_scenarios/sap_s4hana_standard/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_standard/ansible_extravars.yml
@@ -12,9 +12,6 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "S01"  # SAP System ID (SID) (String)
@@ -22,6 +19,11 @@ sap_system_hana_db_sid: "H01"  # SAP HANA Database ID (SID) (String).
 sap_system_hana_db_instance_nr: "90"  # SAP HANA Database instance number (String).
 sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance number (String).
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_standard).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -115,11 +117,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_standard).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_s4hana_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_standard/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:
@@ -181,7 +196,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false

--- a/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_extravars.yml
@@ -12,9 +12,6 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "S01"  # SAP System ID (SID) (String)
@@ -22,6 +19,11 @@ sap_system_hana_db_sid: "H01"  # SAP HANA Database ID (SID) (String).
 sap_system_hana_db_instance_nr: "90"  # SAP HANA Database instance number (String).
 sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance number (String).
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_standard).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -118,11 +120,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_standard).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_playbook.yml
@@ -36,6 +36,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:
@@ -181,7 +196,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false

--- a/deploy_scenarios/sap_solman_sapase_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_solman_sapase_sandbox/ansible_extravars.yml
@@ -12,9 +12,6 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid_abap: "SMA"  # SAP ABAP System ID (SID) (String)
@@ -24,6 +21,11 @@ sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance 
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
 sap_system_nwas_java_scs_instance_nr: "20"  # SAP NetWeaver JAVA SCS instance number (String).
 sap_system_nwas_java_ci_instance_nr: "21"  # SAP NetWeaver JAVA PAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_solman_72_sr2_sapase_sandbox).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -80,11 +82,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_solman_72_sr2_sapase_sandbox).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_solman_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_solman_sapase_sandbox/ansible_playbook.yml
@@ -11,6 +11,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:

--- a/deploy_scenarios/sap_solman_saphana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_solman_saphana_sandbox/ansible_extravars.yml
@@ -12,9 +12,6 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid_abap: "SMA"  # SAP ABAP System ID (SID) (String)
@@ -25,6 +22,11 @@ sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance 
 sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance number (String).
 sap_system_nwas_java_scs_instance_nr: "20"  # SAP NetWeaver JAVA SCS instance number (String).
 sap_system_nwas_java_ci_instance_nr: "21"  # SAP NetWeaver JAVA PAS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_solman_72_sr2_saphana_sandbox).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -115,11 +117,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_solman_72_sr2_saphana_sandbox).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/deploy_scenarios/sap_solman_saphana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_solman_saphana_sandbox/ansible_playbook.yml
@@ -11,6 +11,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:

--- a/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_extravars.yml
+++ b/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_extravars.yml
@@ -17,14 +17,16 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "AE1"  # SAP System ID (SID) (String)
 sap_system_nwas_abap_ascs_instance_nr: "00"  # SAP NetWeaver ABAP ASCS instance number (String).
 sap_system_nwas_abap_ers_instance_nr: "10"  # SAP NetWeaver ABAP ERS instance number (String).
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_distributed).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
 #### SAP Software installation media downloads ####
@@ -108,11 +110,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_distributed).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_playbook.yml
+++ b/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_playbook.yml
@@ -11,6 +11,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:
@@ -159,7 +174,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ sap_install_media_detect_source_directory }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false

--- a/special_actions/sap_webdispatcher_standalone/ansible_extravars.yml
+++ b/special_actions/sap_webdispatcher_standalone/ansible_extravars.yml
@@ -12,9 +12,6 @@ sap_vm_provision_iac_platform: "ENTER_STRING_VALUE_HERE"
 # Options: Defined in host_specifications_dictionary.
 sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
-# Root domain for DNS entries (e.g., example.com) (String). Not required for existing_hosts.
-sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"
-
 
 #### Key SAP System variables ####
 sap_system_sid: "S01"  # SAP System ID (SID) (String)
@@ -23,6 +20,12 @@ sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance nu
 sap_system_wd_instance_nr: "60"  # SAP Web Dispatcher instance number (String).
 sap_system_nwas_abap_ascs_hostname: "ENTER_STRING_VALUE_HERE"
 sap_system_nwas_abap_pas_hostname: "ENTER_STRING_VALUE_HERE"
+
+## SAP Product selection ##
+# Name of the SAP product to install (String).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_sandbox).
+sap_software_product: "ENTER_STRING_VALUE_HERE"
+
 
 #### SAP Software installation media downloads ####
 ## Required for download using community.sap_launchpad
@@ -175,11 +178,6 @@ sap_hostname: "{{ ansible_hostname }}"
 sap_domain: "{{ ansible_domain }}"
 sap_ip: "{{ ansible_default_ipv4.address }}"
 
-
-#### SAP Product selection ####
-# Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_sandbox).
-sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:

--- a/special_actions/sap_webdispatcher_standalone/ansible_playbook.yml
+++ b/special_actions/sap_webdispatcher_standalone/ansible_playbook.yml
@@ -11,6 +11,21 @@
   gather_facts: false
   tasks:
 
+    - name: Search variables for placeholders
+      ansible.builtin.set_fact:
+        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
+      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
+      no_log: true
+      ignore_errors: true
+      when: item.value == 'ENTER_STRING_VALUE_HERE'
+
+    - name: Warning if placeholder variable was found
+      ansible.builtin.fail:
+        msg: |
+          Ensure that the variables do not contain placeholder values before executing playbook again.
+          Variables: {{ sap_playbook_placeholder_vars | join(', ') }}
+      when: sap_playbook_placeholder_vars is defined and sap_playbook_placeholder_vars | length > 0
+
     - name: Set fact with selected host dictionary
       ansible.builtin.set_fact:
         sap_playbook_host_dictionary:


### PR DESCRIPTION
## Changes
1. Add validation for variables containing placeholder values to fail playbook before it proceeds with using them.
2. Move `sap_vm_provision_dns_root_domain` to platform fragment vars to ensure it does not trigger placeholder check when running for `existing_hosts`
3. Update RSYNC dest regex to ensure it is always pointing towards directory.
4. Move up `sap_software_product` into key variables to ensure improved visibility for users
5. Fix `onehost` > `sandbox` product directiory definition