### PR TITLE
all: ansible-lint fixes, noqa for ignore errors, syscopy permissions, bastion false for some platforms

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -7,6 +7,12 @@ on:
   schedule:
     - cron: '10 10 * * 1'
 
+  # Validate open pull requests
+  pull_request:
+    branches:
+      - stage
+      - dev
+
   # Runs on push to dev and main branches
   push:
     branches:

--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ This method is used to install the SAP system on an existing host(s).
    - Ansible inventory file (e.g. `optional/ansible_inventory_noninteractive.yml`).
    - The `sap_vm_provision_existing_hosts_host_specifications_dictionary` variable defined in `optional/ansible_extravars_existing_hosts.yml` file.
 
+#### Prerequisites for existing host(s)
+Control Node:
+- The `.ssh/known_hosts` file on the Ansible Control Node (under the execution user's home directory) must contain entries for the existing hosts.
+  - Ensure `ssh-keyscan` has been executed for the IP address or alias that corresponds to the host parameter defined in your Ansible inventory file. This ensures the control node can securely identify the managed hosts.
+
+Managed Nodes (existing hosts):
+- The firewall on the managed node must allow incoming SSH communication (typically TCP port 22) from the Ansible Control Node.
+- The `/root/.ssh/authorized_keys` file must be correctly configured to allow SSH access from the Ansible Control Node.
+   - The public SSH key from the Ansible Control Node must be added to the `/root/.ssh/authorized_keys` file on the managed node.
+- The `/etc/hosts` file must contain host's fully qualified domain hostname to determine `ansible_domain`, or set through `sap_domain` variable.
+- The `/etc/hosts` file must contain Virtual IP address for High Availability scenarios for SWPM execution (`sap_swpm` role).
+
 
 ### Ansible provisions host(s)
 This method provisions a new host(s) and installs the SAP system. 

--- a/common_fragments/ansible_requirements.yml
+++ b/common_fragments/ansible_requirements.yml
@@ -14,10 +14,10 @@ collections:
     version: 1.5.3
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.2.0
+    version: 1.2.1
   - name: community.sap_infrastructure
     type: galaxy
-    version: 1.1.2
+    version: 1.1.3
 #  - name: community.sap_operations
 #    type: galaxy
 #    version: 0.9.1

--- a/common_fragments/vars/platform_vars_ibmpowervm_vm.yml
+++ b/common_fragments/vars/platform_vars_ibmpowervm_vm.yml
@@ -1,14 +1,15 @@
 ---
 #### Bastion server details ####
 # Bastion variables are used when sap_vm_provision_bastion_execution is set to `true`
-sap_vm_provision_bastion_user: "ENTER_STRING_VALUE_HERE"  # Bastion user name (String).
-sap_vm_provision_bastion_ssh_port: "ENTER_STRING_VALUE_HERE"  # Bastion user password (String).
+sap_vm_provision_bastion_execution: false
+# sap_vm_provision_bastion_user: "ENTER_STRING_VALUE_HERE"  # Bastion user name (String).
+# sap_vm_provision_bastion_ssh_port: "ENTER_STRING_VALUE_HERE"  # Bastion user password (String).
 
 # Variables required for sap_vm_provision_iac_type=ansible
-sap_vm_provision_bastion_public_ip: "ENTER_STRING_VALUE_HERE"  # Public IP of the bastion server (String).
-sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion server's SSH private key on the execution node (String).
+# sap_vm_provision_bastion_public_ip: "ENTER_STRING_VALUE_HERE"  # Public IP of the bastion server (String).
+# sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion server's SSH private key on the execution node (String).
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to target host's SSH private key on the execution node (String).
-sap_vm_provision_ssh_host_public_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion public host key on execution node (String).
+# sap_vm_provision_ssh_host_public_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion public host key on execution node (String).
 
 #### Infrastructure platform variables ####
 sap_vm_provision_iac_platform: "ibmpowervm_vm"  # Name of the provisioning platform (String).

--- a/common_fragments/vars/platform_vars_kubevirt_vm.yml
+++ b/common_fragments/vars/platform_vars_kubevirt_vm.yml
@@ -1,12 +1,13 @@
 ---
 #### Bastion server details ####
 # Bastion variables are used when sap_vm_provision_bastion_execution is set to `true`
-sap_vm_provision_bastion_user: "ENTER_STRING_VALUE_HERE"  # Bastion user name (String).
-sap_vm_provision_bastion_ssh_port: "ENTER_STRING_VALUE_HERE"  # Bastion user password (String).
+sap_vm_provision_bastion_execution: false
+# sap_vm_provision_bastion_user: "ENTER_STRING_VALUE_HERE"  # Bastion user name (String).
+# sap_vm_provision_bastion_ssh_port: "ENTER_STRING_VALUE_HERE"  # Bastion user password (String).
 
 # Variables required for sap_vm_provision_iac_type=ansible
-sap_vm_provision_bastion_public_ip: "ENTER_STRING_VALUE_HERE"  # Public IP of the bastion server (String).
-sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion server's SSH private key on the execution node (String).
+# sap_vm_provision_bastion_public_ip: "ENTER_STRING_VALUE_HERE"  # Public IP of the bastion server (String).
+# sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion server's SSH private key on the execution node (String).
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to target host's SSH private key on the execution node (String).
 
 #### Infrastructure platform variables ####

--- a/common_fragments/vars/platform_vars_ovirt_vm.yml
+++ b/common_fragments/vars/platform_vars_ovirt_vm.yml
@@ -1,12 +1,13 @@
 ---
 #### Bastion server details ####
 # Bastion variables are used when sap_vm_provision_bastion_execution is set to `true`
-sap_vm_provision_bastion_user: "ENTER_STRING_VALUE_HERE"  # Bastion user name (String).
-sap_vm_provision_bastion_ssh_port: "ENTER_STRING_VALUE_HERE"  # Bastion user password (String).
+sap_vm_provision_bastion_execution: false
+# sap_vm_provision_bastion_user: "ENTER_STRING_VALUE_HERE"  # Bastion user name (String).
+# sap_vm_provision_bastion_ssh_port: "ENTER_STRING_VALUE_HERE"  # Bastion user password (String).
 
 # Variables required for sap_vm_provision_iac_type=ansible
-sap_vm_provision_bastion_public_ip: "ENTER_STRING_VALUE_HERE"  # Public IP of the bastion server (String).
-sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion server's SSH private key on the execution node (String).
+# sap_vm_provision_bastion_public_ip: "ENTER_STRING_VALUE_HERE"  # Public IP of the bastion server (String).
+# sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion server's SSH private key on the execution node (String).
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to target host's SSH private key on the execution node (String).
 
 #### Infrastructure platform variables ####

--- a/common_fragments/vars/platform_vars_vmware_vm.yml
+++ b/common_fragments/vars/platform_vars_vmware_vm.yml
@@ -1,14 +1,15 @@
 ---
 #### Bastion server details ####
 # Bastion variables are used when sap_vm_provision_bastion_execution is set to `true`
-sap_vm_provision_bastion_user: "ENTER_STRING_VALUE_HERE"  # Bastion user name (String).
-sap_vm_provision_bastion_ssh_port: "ENTER_STRING_VALUE_HERE"  # Bastion user password (String).
+sap_vm_provision_bastion_execution: false
+# sap_vm_provision_bastion_user: "ENTER_STRING_VALUE_HERE"  # Bastion user name (String).
+# sap_vm_provision_bastion_ssh_port: "ENTER_STRING_VALUE_HERE"  # Bastion user password (String).
 
 # Variables required for sap_vm_provision_iac_type=ansible
-sap_vm_provision_bastion_public_ip: "ENTER_STRING_VALUE_HERE"  # Public IP of the bastion server (String).
-sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion server's SSH private key on the execution node (String).
+# sap_vm_provision_bastion_public_ip: "ENTER_STRING_VALUE_HERE"  # Public IP of the bastion server (String).
+# sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion server's SSH private key on the execution node (String).
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to target host's SSH private key on the execution node (String).
-sap_vm_provision_ssh_host_public_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion public host key on execution node (String).
+# sap_vm_provision_ssh_host_public_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion public host key on execution node (String).
 
 #### Infrastructure platform variables ####
 sap_vm_provision_iac_platform: "vmware_vm"  # Name of the provisioning platform (String).

--- a/deploy_scenarios/sap_bw4hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_bw4hana_sandbox/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_ecc_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_hana_sandbox/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_hana/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_hana_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana_ha/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_landscape_s4hana_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard/ansible_playbook.yml
@@ -11,7 +11,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_playbook.yml
@@ -11,7 +11,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_s4hana_distributed/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_s4hana_distributed_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_s4hana_foundation_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_standard/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_s4hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_s4hana_sandbox_syscopy/README.md
+++ b/deploy_scenarios/sap_s4hana_sandbox_syscopy/README.md
@@ -116,3 +116,10 @@ The playbook executes the following sequence of tasks:
    - **Install Application:** The `sap_install.sap_swpm` Ansible Role is used to install the application.
    - **SAP SWPM Product ID Prefix:** `NW_ABAP_OneHost`
    - Includes Database Load using SAP HANA complete data backup files.
+
+
+## Guidelines for SAP HANA COMPLETE Backup files
+- The backup files should have at minimum `0666` file permissions to begin with. This will allow sap_swpm Ansible Role to change ownership to OS User SIDadm and group sapsys.
+- The backup files cannot not be on a mounted NFS, they must be copied to a local drive for SAP SWPM to unpack during DB Restore.
+- The backup files cannot be from a later version of SAP HANA, than the version of SAP HANA that is the target.
+- The backup files from different CPU Architecture (e.g. backup from x86_64 > target is ppc64le) will require `SGEN` execution after SAP System is installed.

--- a/deploy_scenarios/sap_s4hana_sandbox_syscopy/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_syscopy/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
@@ -181,10 +181,14 @@
         dest: "/tmp/hosts_rsa"
         mode: "0400"
 
+    # Create directory for database backups with ownership of SAP HANA sidadm:sapsys
     - name: Prepare for file transfers, create directory for SAP HANA complete data backup
       ansible.builtin.file:
         path: "{{ sap_install_media_detect_source_directory + '/backup/' }}"
         state: directory
+        owner: "{{ sap_system_hana_db_sid | lower ~ 'adm' }}"
+        group: sapsys
+        mode: '0755'
 
     # synchronize Ansible Module does not natively provide a remote host folder to folder copy
     # it is expected to use the copy Ansible Module instead, but as this copy is from an NFS
@@ -195,7 +199,7 @@
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ (sap_install_media_detect_source_directory + '/backup/' + (item | basename)) | regex_replace('//', '/') }}"
+        dest: "{{ sap_install_media_detect_source_directory | trim | regex_replace('//', '/') | regex_replace(' ', '') | regex_replace('\\/+$', '') + '/backup/' }}"
         mode: "push"
         dest_port: 22
         use_ssh_args: false

--- a/deploy_scenarios/sap_s4hana_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_standard/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_playbook.yml
@@ -36,7 +36,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_solman_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_solman_sapase_sandbox/ansible_playbook.yml
@@ -11,7 +11,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/deploy_scenarios/sap_solman_saphana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_solman_saphana_sandbox/ansible_playbook.yml
@@ -11,7 +11,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_playbook.yml
+++ b/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_playbook.yml
@@ -11,7 +11,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"

--- a/special_actions/sap_webdispatcher_standalone/ansible_playbook.yml
+++ b/special_actions/sap_webdispatcher_standalone/ansible_playbook.yml
@@ -11,7 +11,7 @@
   gather_facts: false
   tasks:
 
-    - name: Search variables for placeholders
+    - name: Search variables for placeholders  # noqa: ignore-errors
       ansible.builtin.set_fact:
         sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key] }}"
       loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"


### PR DESCRIPTION
## Changes
- Enable linting for open PR.
- Update permissions in `file` task in `syscopy` scenario to fix linting error.
- Add `noqa` for placeholder checks
- Add `sap_vm_provision_bastion_execution: false` for platforms where bastion is not used.
- Update readme with instructions for existing hosts after testing.