### PR TITLE
all: Update playbooks for ansible-core 2.19

### DIFF
--- a/common_fragments/tasks/interactive/main.yml
+++ b/common_fragments/tasks/interactive/main.yml
@@ -312,7 +312,7 @@
   register: sap_playbook_collection_list_output
 
 - name: Block for sap_id_user
-  when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+  when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
   no_log: true
   block:
     - name: Prompt for SAP S-User ID
@@ -343,7 +343,7 @@
 
 
 - name: Block for sap_id_user_password
-  when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+  when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
   no_log: true
   block:
     - name: Prompt for SAP S-User Password

--- a/common_fragments/vars/platform_vars_ibmcloud_powervs.yml
+++ b/common_fragments/vars/platform_vars_ibmcloud_powervs.yml
@@ -14,7 +14,6 @@ sap_vm_provision_iac_platform: "ibmcloud_powervs"  # Name of the provisioning pl
 sap_vm_provision_ibmcloud_api_key: "ENTER_STRING_VALUE_HERE"  # IBM Cloud API Key (String).
 sap_vm_provision_ibmcloud_resource_group_name: "ENTER_STRING_VALUE_HERE" # Resource Group name (String). if ansible_to_terraform, use "new"
 sap_vm_provision_ibmcloud_powervs_location: "ENTER_STRING_VALUE_HERE"  # Location (String).
-sap_vm_provision_ibmcloud_vpc_subnet_name: "ENTER_STRING_VALUE_HERE" # VPC Subnet name (String). only for ansible_to_terraform, can be name or 'new'
 
 sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"  # Root domain for DNS entries (e.g., example.com) (String).
 
@@ -28,9 +27,9 @@ sap_vm_provision_ibmcloud_powervs_workspace_name: "ENTER_STRING_VALUE_HERE"  # W
 sap_vm_provision_ibmcloud_powervs_vlan_subnet_name: "ENTER_STRING_VALUE_HERE"  # VLAN Subnet name (String).
 sap_vm_provision_ibmcloud_powervs_key_pair_name_ssh_host_public_key: "ENTER_STRING_VALUE_HERE"  # SSH key pair name (String).
 sap_vm_provision_ibmcloud_private_dns_custom_resolver_ip: "ENTER_STRING_VALUE_HERE"  # Custom DNS resolver IP (String).
-sap_vm_provision_ibmcloud_private_dns_resource_group_name: "" # optional, default use of sap_vm_provision_ibmcloud_resource_group_name
-sap_vm_provision_proxy_web_forward_proxy_ip: "ENTER_STRING_VALUE_HERE" # IP:Port only, no http:// prefix
-sap_vm_provision_proxy_web_forward_exclusions: "localhost,127.0.0.1,{{ sap_vm_provision_dns_root_domain }}"
+# sap_vm_provision_ibmcloud_private_dns_resource_group_name: "" # optional, default use of sap_vm_provision_ibmcloud_resource_group_name
+# sap_vm_provision_proxy_web_forward_proxy_ip: "ENTER_STRING_VALUE_HERE" # IP:Port only, no http:// prefix
+# sap_vm_provision_proxy_web_forward_exclusions: "localhost,127.0.0.1,{{ sap_vm_provision_dns_root_domain }}"
 
 # Variables required for sap_vm_provision_iac_type=ansible_to_terraform
 # sap_vm_provision_terraform_state: "ENTER_STRING_VALUE_HERE" # present, absent

--- a/common_fragments/vars/platform_vars_ibmcloud_vs.yml
+++ b/common_fragments/vars/platform_vars_ibmcloud_vs.yml
@@ -27,8 +27,8 @@ sap_vm_provision_ibmcloud_vs_host_os_image: "ENTER_STRING_VALUE_HERE"
 
 # Variables required for sap_vm_provision_iac_type=ansible
 sap_vm_provision_ibmcloud_key_pair_name_ssh_host_public_key: "ENTER_STRING_VALUE_HERE"  # SSH key pair name (String).
-sap_vm_provision_ibmcloud_vpc_sg_names: "ENTER_STRING_VALUE_HERE,ENTER_STRING_VALUE_HERE" # comma-separated, if ansible_to_terraform then ignore this variable
-sap_vm_provision_ibmcloud_private_dns_resource_group_name: "" # optional, default use of sap_vm_provision_ibmcloud_resource_group_name
+sap_vm_provision_ibmcloud_vpc_sg_names: "ENTER_STRING_VALUE_HERE" # comma-separated, if ansible_to_terraform then ignore this variable
+# sap_vm_provision_ibmcloud_private_dns_resource_group_name: "" # optional, default use of sap_vm_provision_ibmcloud_resource_group_name
 
 # Variables required for sap_vm_provision_iac_type=ansible_to_terraform
 # sap_vm_provision_terraform_state: "ENTER_STRING_VALUE_HERE" # present, absent

--- a/common_fragments/vars/platform_vars_msazure_vm.yml
+++ b/common_fragments/vars/platform_vars_msazure_vm.yml
@@ -29,7 +29,7 @@ sap_vm_provision_msazure_vm_host_os_image: "ENTER_STRING_VALUE_HERE"
 
 # Variables required for sap_vm_provision_iac_type=ansible
 sap_vm_provision_msazure_key_pair_name_ssh_host_public_key: "ENTER_STRING_VALUE_HERE"  # SSH key pair name (String).
-sap_vm_provision_msazure_private_dns_resource_group_name: "" # optional, default use of sap_vm_provision_msazure_resource_group_name
+# sap_vm_provision_msazure_private_dns_resource_group_name: "" # optional, default use of sap_vm_provision_msazure_resource_group_name
 
 # Variables required for sap_vm_provision_iac_type=ansible_to_terraform
 # sap_vm_provision_terraform_state: "ENTER_STRING_VALUE_HERE" # present, absent

--- a/deploy_scenarios/sap_bw4hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_bw4hana_sandbox/ansible_extravars.yml
@@ -112,7 +112,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_bw4hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_bw4hana_sandbox/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,25 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -122,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -143,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -165,10 +213,13 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 #### Begin downloading SAP software installation media to hosts ####
@@ -198,7 +249,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
 #### Begin SAP software hosts preparation ####

--- a/deploy_scenarios/sap_bw4hana_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_bw4hana_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_extravars.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_extravars.yml
@@ -65,7 +65,7 @@ sap_hana_install_use_master_password: "y"  # Use a master password for SAP HANA 
 sap_hana_install_master_password: ''  # The master password for SAP HANA (String).
 
 # SAP HANA Scale-Out variables for role sap_Hana_install
-sap_hana_install_new_system: true  # Set to 'false', when adding hosts using sap_hana_install_addhosts
+sap_hana_install_new_system: true  # Set to false, when adding hosts using sap_hana_install_addhosts
 # sap_hana_install_addhosts: ''  # Set to 'true', when adding hosts dynamically after provisioning
 sap_hana_install_workergroup: default  # must be 'default', see README
 sap_hana_install_group: default  # must be 'default', see README
@@ -126,7 +126,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml
@@ -461,7 +461,7 @@
     # NOTE: if incorrect workergroup and failover group are defined, will result in error shown in SAP Note 3043860 - Recovery fails due to incorrect worker group assignment
     - name: Ansible Vars extravars file check if non-interactive (no var prompts) requested by end user
       ansible.builtin.set_fact:
-        sap_hana_install_addhosts: |
+        sap_hana_install_addhosts: >-
           {%- if sap_vm_provision_calculate_sap_hana_scaleout_standby > 0 -%}
             {%- for host in (groups['hana_primary'] | reject('regex', '0$') | list)[:-1] -%}
               {{ hostvars[host]['inventory_hostname_short'] }}:role=worker:workergroup={{ sap_hana_install_workergroup }}:group={{ sap_hana_install_group }},

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,48 +107,76 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
-
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
-
-    - name: Dynamically create new Ansible Dictionary for SAP HANA Scale-Out
-      ansible.builtin.set_fact:
-        sap_playbook_scaleout_dictionary: "{{ sap_playbook_scaleout_dictionary | default({}) | combine({
-          (sap_playbook_host_dictionary.keys() | first + scaleout_node_number | string): sap_playbook_host_dictionary[sap_playbook_host_dictionary.keys() | first]}) }}"
-      loop: "{{ range(0, scaleout_node_count | int, 1) | list }}"
-      loop_control:
-        loop_var: scaleout_node_number
-      when: sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
       vars:
-        scaleout_node_count: "{{ sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator | int
-          + sap_vm_provision_calculate_sap_hana_scaleout_active_worker | int
-          + sap_vm_provision_calculate_sap_hana_scaleout_standby | int }}"
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Combine new Ansible Dictionary for SAP HANA Scale-Out with remaining hosts
-      ansible.builtin.set_fact:
-        "{{ sap_vm_provision_iac_platform + '_host_specifications_dictionary' }}":
-          "{{ {} | combine({sap_vm_provision_host_specification_plan: combined_dictionary}) }}"
-      when: sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined
-      vars:
-        others_dictionary: "{{ sap_playbook_host_dictionary | combine({sap_playbook_host_dictionary.keys() | first: omit}) }}"
-        combined_dictionary: "{{ {} | combine(sap_playbook_scaleout_dictionary, others_dictionary) }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ lookup('ansible.builtin.vars', sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan].keys()
-        if sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined else sap_playbook_host_dictionary.keys() }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Set fact with selected host dictionary
+          ansible.builtin.set_fact:
+            sap_playbook_host_dictionary:
+              "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
+                + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+
+        - name: Dynamically create new Ansible Dictionary for SAP HANA Scale-Out
+          ansible.builtin.set_fact:
+            sap_playbook_scaleout_dictionary: "{{ sap_playbook_scaleout_dictionary | default({}) | combine({
+              (sap_playbook_host_dictionary.keys() | first + scaleout_node_number | string): sap_playbook_host_dictionary[sap_playbook_host_dictionary.keys() | first]}) }}"
+          loop: "{{ range(0, scaleout_node_count | int, 1) | list }}"
+          loop_control:
+            loop_var: scaleout_node_number
+          when: sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined
+          vars:
+            scaleout_node_count: "{{ sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator | int
+              + sap_vm_provision_calculate_sap_hana_scaleout_active_worker | int
+              + sap_vm_provision_calculate_sap_hana_scaleout_standby | int }}"
+
+        - name: Combine new Ansible Dictionary for SAP HANA Scale-Out with remaining hosts
+          ansible.builtin.set_fact:
+            "{{ sap_vm_provision_iac_platform + '_host_specifications_dictionary' }}":
+              "{{ {} | combine({sap_vm_provision_host_specification_plan: combined_dictionary}) }}"
+          when: sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined
+          vars:
+            others_dictionary: "{{ sap_playbook_host_dictionary | combine({sap_playbook_host_dictionary.keys() | first: omit}) }}"
+            combined_dictionary: "{{ {} | combine(sap_playbook_scaleout_dictionary, others_dictionary) }}"
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan].keys()
+            if sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined else sap_playbook_host_dictionary.keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -145,9 +191,14 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
+
 
     - name: Execute Ansible Role sap_vm_provision
       ansible.builtin.include_role:
@@ -166,7 +217,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -189,13 +244,16 @@
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
         sap_playbook_host_dictionary_hostname:
-          "{{ sap_playbook_host_dictionary_plan[inventory_hostname_short | regex_replace('^(.+?)\\d*$', '\\1')]
-            if inventory_hostname not in sap_playbook_host_dictionary_plan
-            else sap_playbook_host_dictionary_plan[inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+          "{{ sap_playbook_host_dictionary_plan[inventory_hostname_short]
+            if (inventory_hostname_short | d('')) in sap_playbook_host_dictionary_plan
+            else sap_playbook_host_dictionary_plan[inventory_hostname_short | regex_replace('^(.+?)\\d*$', '\\1')] }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 - name: Ansible Play for ensuring rsync on all hosts
@@ -238,7 +296,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
     - name: Find SAP HANA installation media

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 # Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true

--- a/deploy_scenarios/sap_ecc_hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_hana_sandbox/ansible_extravars.yml
@@ -112,7 +112,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_ecc_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_hana_sandbox/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -166,10 +213,13 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 #### Begin downloading SAP software installation media to hosts ####
@@ -199,7 +249,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
 #### Begin SAP software hosts preparation ####

--- a/deploy_scenarios/sap_ecc_hana_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ecc_hana_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_extravars.yml
@@ -79,7 +79,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -166,11 +213,15 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_aas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_aas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_aas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_aas_instance_nr', (sap_system_nwas_abap_aas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 - name: Ansible Play for ensuring rsync on all hosts
@@ -213,7 +264,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
     - name: Find SAP NetWeaver ASCS installation media

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 # Define the NFS mount points for HANA data, log, and shared directories (String).
 sap_vm_provision_nfs_mount_point: "ENTER_STRING_VALUE_HERE"

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_extravars.yml
@@ -78,7 +78,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### High Availability variables ####

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -166,12 +213,17 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_ers_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ers_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_aas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_aas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_ers_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ers_instance_nr', (sap_system_nwas_abap_ers_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_aas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_aas_instance_nr', (sap_system_nwas_abap_aas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 - name: Ansible Play for ensuring rsync on all hosts
@@ -214,7 +266,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
     - name: Find SAP NetWeaver ASCS installation media

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 # Define the NFS mount point (String).
 sap_vm_provision_nfs_mount_point: "ENTER_STRING_VALUE_HERE"

--- a/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_extravars.yml
@@ -72,7 +72,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -166,10 +213,13 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 #### Begin downloading SAP software installation media to hosts ####
@@ -199,7 +249,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
 #### Begin SAP software hosts preparation ####

--- a/deploy_scenarios/sap_ecc_ibmdb2_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_extravars.yml
@@ -86,7 +86,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -166,11 +213,13 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_aas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_aas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 #### Begin downloading SAP software installation media to hosts ####
@@ -200,7 +249,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
 #### Begin SAP software hosts preparation ####

--- a/deploy_scenarios/sap_ecc_oracledb_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ecc_oracledb_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_extravars.yml
@@ -72,7 +72,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -166,11 +213,13 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_aas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_aas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 #### Begin downloading SAP software installation media to hosts ####
@@ -200,7 +249,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
 #### Begin SAP software hosts preparation ####

--- a/deploy_scenarios/sap_ecc_sapase_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ecc_sapase_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_extravars.yml
@@ -73,7 +73,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####
@@ -96,7 +96,7 @@ sap_software_install_dictionary:
     sap_swpm_inifile_sections_list:
       - swpm_installation_media
       - swpm_installation_media_swpm1_exportfiles
-      - swpm_installation_media_swpm1_sapmaxdb
+      # - swpm_installation_media_swpm1_sapmaxdb  # Required when using CD Media, not SAR file.
       - credentials
       - credentials_anydb_sapmaxdb
       - db_config_anydb_all

--- a/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -166,11 +213,13 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_aas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_aas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 #### Begin downloading SAP software installation media to hosts ####
@@ -200,7 +249,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
 #### Begin SAP software hosts preparation ####

--- a/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/optional/ansible_extravars_interactive.yml
@@ -39,7 +39,7 @@ sap_software_install_dictionary:
     sap_swpm_inifile_sections_list:
       - swpm_installation_media
       - swpm_installation_media_swpm1_exportfiles
-      - swpm_installation_media_swpm1_sapmaxdb
+      # - swpm_installation_media_swpm1_sapmaxdb  # Required when using CD Media, not SAR file.
       - credentials
       - credentials_anydb_sapmaxdb
       - db_config_anydb_all

--- a/deploy_scenarios/sap_hana/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,25 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -122,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -143,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -165,8 +213,9 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_system_hana_db_sid', (sap_system_hana_db_sid | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 #### Begin downloading SAP software installation media to hosts ####
@@ -196,7 +245,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
 #### Begin SAP software hosts preparation ####

--- a/deploy_scenarios/sap_hana/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_hana/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 # Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true

--- a/deploy_scenarios/sap_hana_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana_ha/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,25 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -122,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -143,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -170,8 +218,9 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_system_hana_db_sid', (sap_system_hana_db_sid | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 - name: Ansible Play for ensuring rsync on all hosts
@@ -214,7 +263,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
     - name: Find SAP HANA installation media

--- a/deploy_scenarios/sap_hana_ha/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_hana_ha/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 # Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true

--- a/deploy_scenarios/sap_hana_scaleout/ansible_extravars.yml
+++ b/deploy_scenarios/sap_hana_scaleout/ansible_extravars.yml
@@ -57,7 +57,7 @@ sap_hana_install_use_master_password: "y"  # Use a master password for SAP HANA 
 sap_hana_install_master_password: ''  # The master password for SAP HANA (String).
 
 # SAP HANA Scale-Out variables for role sap_Hana_install
-sap_hana_install_new_system: true  # Set to 'false', when adding hosts using sap_hana_install_addhosts
+sap_hana_install_new_system: true  # Set to false, when adding hosts using sap_hana_install_addhosts
 # sap_hana_install_addhosts: ''  # Set to 'true', when adding hosts dynamically after provisioning
 sap_hana_install_workergroup: default  # must be 'default', see README
 sap_hana_install_group: default  # must be 'default', see README

--- a/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,49 +107,77 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
-
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
-
-    - name: Dynamically create new Ansible Dictionary for SAP HANA Scale-Out
-      ansible.builtin.set_fact:
-        sap_playbook_scaleout_dictionary: "{{ sap_playbook_scaleout_dictionary | default({}) | combine({
-          (sap_playbook_host_dictionary.keys() | first + scaleout_node_number | string): sap_playbook_host_dictionary[sap_playbook_host_dictionary.keys() | first]}) }}"
-      loop: "{{ range(0, scaleout_node_count | int, 1) | list }}"
-      loop_control:
-        loop_var: scaleout_node_number
-      when: sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
       vars:
-        scaleout_node_count: "{{ sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator | int
-          + sap_vm_provision_calculate_sap_hana_scaleout_active_worker | int
-          + sap_vm_provision_calculate_sap_hana_scaleout_standby | int }}"
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Combine new Ansible Dictionary for SAP HANA Scale-Out with remaining hosts
-      ansible.builtin.set_fact:
-        "{{ sap_vm_provision_iac_platform + '_host_specifications_dictionary' }}":
-          "{{ {} | combine({sap_vm_provision_host_specification_plan: combined_dictionary}) }}"
-      when: sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined
-      vars:
-        others_dictionary: "{{ sap_playbook_host_dictionary | combine({sap_playbook_host_dictionary.keys() | first: omit}) }}"
-        combined_dictionary: "{{ {} | combine(sap_playbook_scaleout_dictionary, others_dictionary) }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ lookup('ansible.builtin.vars', sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan].keys()
-        if sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined else sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Set fact with selected host dictionary
+          ansible.builtin.set_fact:
+            sap_playbook_host_dictionary:
+              "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
+                + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+
+        - name: Dynamically create new Ansible Dictionary for SAP HANA Scale-Out
+          ansible.builtin.set_fact:
+            sap_playbook_scaleout_dictionary: "{{ sap_playbook_scaleout_dictionary | default({}) | combine({
+              (sap_playbook_host_dictionary.keys() | first + scaleout_node_number | string): sap_playbook_host_dictionary[sap_playbook_host_dictionary.keys() | first]}) }}"
+          loop: "{{ range(0, scaleout_node_count | int, 1) | list }}"
+          loop_control:
+            loop_var: scaleout_node_number
+          when: sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined
+          vars:
+            scaleout_node_count: "{{ sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator | int
+              + sap_vm_provision_calculate_sap_hana_scaleout_active_worker | int
+              + sap_vm_provision_calculate_sap_hana_scaleout_standby | int }}"
+
+        - name: Combine new Ansible Dictionary for SAP HANA Scale-Out with remaining hosts
+          ansible.builtin.set_fact:
+            "{{ sap_vm_provision_iac_platform + '_host_specifications_dictionary' }}":
+              "{{ {} | combine({sap_vm_provision_host_specification_plan: combined_dictionary}) }}"
+          when: sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined
+          vars:
+            others_dictionary: "{{ sap_playbook_host_dictionary | combine({sap_playbook_host_dictionary.keys() | first: omit}) }}"
+            combined_dictionary: "{{ {} | combine(sap_playbook_scaleout_dictionary, others_dictionary) }}"
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', sap_vm_provision_iac_platform + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan].keys()
+            if sap_vm_provision_calculate_sap_hana_scaleout_active_coordinator is defined else sap_playbook_host_dictionary.keys() }}"
+          when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -146,7 +192,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -167,7 +217,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -189,11 +243,12 @@
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
         sap_playbook_host_dictionary_hostname:
-          "{{ sap_playbook_host_dictionary_plan[inventory_hostname_short | regex_replace('^(.+?)\\d*$', '\\1')]
-            if inventory_hostname not in sap_playbook_host_dictionary_plan
-            else sap_playbook_host_dictionary_plan[inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+          "{{ sap_playbook_host_dictionary_plan[inventory_hostname_short]
+            if (inventory_hostname_short | d('')) in sap_playbook_host_dictionary_plan
+            else sap_playbook_host_dictionary_plan[inventory_hostname_short | regex_replace('^(.+?)\\d*$', '\\1')] }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_system_hana_db_sid', (sap_system_hana_db_sid | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 - name: Ansible Play for ensuring rsync on all hosts
@@ -236,7 +291,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
 #### Begin SAP software hosts preparation ####

--- a/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml
@@ -384,7 +384,7 @@
     # NOTE: if incorrect workergroup and failover group are defined, will result in error shown in SAP Note 3043860 - Recovery fails due to incorrect worker group assignment
     - name: Ansible Vars extravars file check if non-interactive (no var prompts) requested by end user
       ansible.builtin.set_fact:
-        sap_hana_install_addhosts: |
+        sap_hana_install_addhosts: >-
           {%- if sap_vm_provision_calculate_sap_hana_scaleout_standby > 0 -%}
             {%- for host in (groups['hana_primary'] | reject('regex', '0$') | list)[:-1] -%}
               {{ hostvars[host]['inventory_hostname_short'] }}:role=worker:workergroup={{ sap_hana_install_workergroup }}:group={{ sap_hana_install_group }},

--- a/deploy_scenarios/sap_hana_scaleout/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_hana_scaleout/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 # Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true

--- a/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_extravars.yml
@@ -112,7 +112,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -166,10 +213,13 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 #### Begin downloading SAP software installation media to hosts ####
@@ -199,7 +249,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
 #### Begin SAP software hosts preparation ####

--- a/deploy_scenarios/sap_ides_ecc_hana_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ides_ecc_hana_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_extravars.yml
@@ -72,7 +72,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -166,10 +213,13 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 #### Begin downloading SAP software installation media to hosts ####
@@ -199,7 +249,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
 #### Begin SAP software hosts preparation ####

--- a/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_landscape_s4hana_standard/ansible_extravars.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard/ansible_extravars.yml
@@ -101,7 +101,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_landscape_s4hana_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard/ansible_playbook.yml
@@ -10,32 +10,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -64,26 +82,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -92,36 +131,12 @@
   gather_facts: false
   tasks:
 
-    # Ensure that all sap_* or __sap_* variables set in Interactive Mode are appended to the target inventory Group
-    - name: Assign all relevant facts from execution node before provisioning  # noqa: ignore-errors
-      ansible.builtin.set_fact:
-        "{{ item.key }}": "{{ item.value }}"
-        cacheable: true
-      loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
-      no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
-
     - name: Execute Ansible Role sap_vm_provision
       ansible.builtin.include_role:
         name: community.sap_infrastructure.sap_vm_provision
       when:
         - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
         - sap_vm_provision_iac_platform != 'existing_hosts'
-
-- name: Ansible Play to set sap variables on provisioned hosts
-  hosts: sap_vm_provision_target_inventory_group  # noqa: ignore-errors
-  gather_facts: false
-  tasks:
-
-    - name: Assign all relevant facts from execution node after provisioning  # noqa: ignore-errors
-      ansible.builtin.set_fact:
-        "{{ item.key }}": "{{ item.value }}"
-        cacheable: true
-      loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
-      no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
 
 
 #### VM storage filesystem setup ####
@@ -141,11 +156,15 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_aas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_aas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_aas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_aas_instance_nr', (sap_system_nwas_abap_aas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 - name: Ansible Play for ensuring rsync on all hosts
@@ -188,7 +207,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
     - name: Find SAP HANA installation media
       ansible.builtin.find:

--- a/deploy_scenarios/sap_landscape_s4hana_standard/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 # Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true

--- a/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_extravars.yml
@@ -104,7 +104,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_playbook.yml
@@ -10,32 +10,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -64,26 +82,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -92,36 +131,12 @@
   gather_facts: false
   tasks:
 
-    # Ensure that all sap_* or __sap_* variables set in Interactive Mode are appended to the target inventory Group
-    - name: Assign all relevant facts from execution node before provisioning  # noqa: ignore-errors
-      ansible.builtin.set_fact:
-        "{{ item.key }}": "{{ item.value }}"
-        cacheable: true
-      loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
-      no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
-
     - name: Execute Ansible Role sap_vm_provision
       ansible.builtin.include_role:
         name: community.sap_infrastructure.sap_vm_provision
       when:
         - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
         - sap_vm_provision_iac_platform != 'existing_hosts'
-
-- name: Ansible Play to set sap variables on provisioned hosts
-  hosts: sap_vm_provision_target_inventory_group  # noqa: ignore-errors
-  gather_facts: false
-  tasks:
-
-    - name: Assign all relevant facts from execution node after provisioning  # noqa: ignore-errors
-      ansible.builtin.set_fact:
-        "{{ item.key }}": "{{ item.value }}"
-        cacheable: true
-      loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
-      no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
 
 
 #### VM storage filesystem setup ####
@@ -141,11 +156,15 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_aas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_aas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_aas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_aas_instance_nr', (sap_system_nwas_abap_aas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 - name: Ansible Play for ensuring rsync on all hosts
@@ -189,7 +208,7 @@
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
         sap_software_download_mp_transaction: "{{ sap_maintenance_planner_transaction_name }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
     - name: Find SAP HANA installation media
       ansible.builtin.find:

--- a/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 # Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true

--- a/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_extravars.yml
@@ -112,7 +112,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -166,10 +213,13 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 #### Begin downloading SAP software installation media to hosts ####
@@ -199,7 +249,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
 #### Begin SAP software hosts preparation ####

--- a/deploy_scenarios/sap_nwas_abap_hana_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_nwas_abap_hana_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_extravars.yml
@@ -72,7 +72,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -166,10 +213,13 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 #### Begin downloading SAP software installation media to hosts ####
@@ -199,7 +249,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
 #### Begin SAP software hosts preparation ####

--- a/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_extravars.yml
@@ -86,7 +86,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -166,11 +213,15 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_aas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_aas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_aas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_aas_instance_nr', (sap_system_nwas_abap_aas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 #### Begin downloading SAP software installation media to hosts ####
@@ -200,7 +251,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
 #### Begin SAP software hosts preparation ####

--- a/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_extravars.yml
@@ -72,7 +72,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -166,11 +213,15 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_aas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_aas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_aas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_aas_instance_nr', (sap_system_nwas_abap_aas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 #### Begin downloading SAP software installation media to hosts ####
@@ -200,7 +251,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
 #### Begin SAP software hosts preparation ####

--- a/deploy_scenarios/sap_nwas_abap_sapase_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapase_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_extravars.yml
@@ -73,7 +73,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####
@@ -95,7 +95,7 @@ sap_software_install_dictionary:
     sap_swpm_inifile_sections_list:
       - swpm_installation_media
       - swpm_installation_media_swpm1_exportfiles
-      - swpm_installation_media_swpm1_sapmaxdb
+      # - swpm_installation_media_swpm1_sapmaxdb  # Required when using CD Media, not SAR file.
       - credentials
       - credentials_anydb_sapmaxdb
       - db_config_anydb_all
@@ -135,7 +135,7 @@ sap_software_install_dictionary:
     sap_swpm_inifile_sections_list:
       - swpm_installation_media
       - swpm_installation_media_swpm1_exportfiles
-      - swpm_installation_media_swpm1_sapmaxdb
+      # - swpm_installation_media_swpm1_sapmaxdb  # Required when using CD Media, not SAR file.
       - credentials
       - credentials_anydb_sapmaxdb
       - db_config_anydb_all

--- a/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -166,11 +213,15 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_aas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_aas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_aas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_aas_instance_nr', (sap_system_nwas_abap_aas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 #### Begin downloading SAP software installation media to hosts ####
@@ -200,7 +251,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
 #### Begin SAP software hosts preparation ####

--- a/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/optional/ansible_extravars_interactive.yml
@@ -38,7 +38,7 @@ sap_software_install_dictionary:
     sap_swpm_inifile_sections_list:
       - swpm_installation_media
       - swpm_installation_media_swpm1_exportfiles
-      - swpm_installation_media_swpm1_sapmaxdb
+      # - swpm_installation_media_swpm1_sapmaxdb  # Required when using CD Media, not SAR file.
       - credentials
       - credentials_anydb_sapmaxdb
       - db_config_anydb_all
@@ -78,7 +78,7 @@ sap_software_install_dictionary:
     sap_swpm_inifile_sections_list:
       - swpm_installation_media
       - swpm_installation_media_swpm1_exportfiles
-      - swpm_installation_media_swpm1_sapmaxdb
+      # - swpm_installation_media_swpm1_sapmaxdb  # Required when using CD Media, not SAR file.
       - credentials
       - credentials_anydb_sapmaxdb
       - db_config_anydb_all

--- a/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_extravars.yml
@@ -70,7 +70,8 @@ sap_swpm_templates_install_dictionary: "{{ sap_software_install_dictionary }}"
 sap_swpm_fqdn: "{{ ansible_domain }}"
 
 # SAP NetWeaver JAVA Parameters
-sap_swpm_java_scs_instance_hostname: "{{ sap_hostname | d(ansible_hostname) }}"
+sap_swpm_pas_instance_hostname: "{{ sap_swpm_db_host }}"
+sap_swpm_java_scs_instance_hostname: "{{ sap_swpm_db_host }}"
 sap_swpm_ume_instance_nr: "{{ sap_swpm_pas_instance_nr }}"
 sap_swpm_ume_j2ee_admin_password: "{{ sap_swpm_master_password }}"
 sap_swpm_ume_sapjsf_password: "{{ sap_swpm_master_password }}"
@@ -82,7 +83,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -166,10 +213,13 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_java_scs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_java_scs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_java_ci_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_java_ci_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_java_scs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_java_scs_instance_nr', (sap_system_nwas_java_scs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_java_ci_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_java_ci_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 #### Begin downloading SAP software installation media to hosts ####
@@ -199,7 +249,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
 #### Begin SAP software hosts preparation ####

--- a/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_extravars.yml
@@ -82,7 +82,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -166,10 +213,13 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_java_scs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_java_scs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_java_ci_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_java_ci_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_java_scs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_java_scs_instance_nr', (sap_system_nwas_java_scs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_java_ci_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_java_ci_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 #### Begin downloading SAP software installation media to hosts ####
@@ -199,7 +249,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
 #### Begin SAP software hosts preparation ####

--- a/deploy_scenarios/sap_nwas_java_sapase_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_nwas_java_sapase_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_s4hana_distributed/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_distributed/ansible_extravars.yml
@@ -120,7 +120,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_s4hana_distributed/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -166,11 +213,15 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_aas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_aas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_aas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_aas_instance_nr', (sap_system_nwas_abap_aas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 - name: Ansible Play for ensuring rsync on all hosts
@@ -213,7 +264,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
     - name: Find SAP HANA installation media

--- a/deploy_scenarios/sap_s4hana_distributed/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_distributed/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 # Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true

--- a/deploy_scenarios/sap_s4hana_distributed_ha/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/ansible_extravars.yml
@@ -118,7 +118,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### High Availability variables ####

--- a/deploy_scenarios/sap_s4hana_distributed_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -170,12 +217,17 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_ers_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ers_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_aas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_aas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_ers_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ers_instance_nr', (sap_system_nwas_abap_ers_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_aas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_aas_instance_nr', (sap_system_nwas_abap_aas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 - name: Ansible Play for ensuring rsync on all hosts
@@ -218,7 +270,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
     - name: Find SAP HANA installation media

--- a/deploy_scenarios/sap_s4hana_distributed_ha/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 # Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_extravars.yml
@@ -121,7 +121,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### High Availability variables ####

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -170,12 +217,17 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_ers_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ers_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_aas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_aas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_ers_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ers_instance_nr', (sap_system_nwas_abap_ers_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_aas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_aas_instance_nr', (sap_system_nwas_abap_aas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 - name: Ansible Play for ensuring rsync on all hosts
@@ -219,7 +271,7 @@
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
         sap_software_download_mp_transaction: "{{ sap_maintenance_planner_transaction_name }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
     - name: Find SAP HANA installation media

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 # Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true

--- a/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_extravars.yml
@@ -123,7 +123,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -166,11 +213,15 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_aas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_aas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_aas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_aas_instance_nr', (sap_system_nwas_abap_aas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 - name: Ansible Play for ensuring rsync on all hosts
@@ -214,7 +265,7 @@
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
         sap_software_download_mp_transaction: "{{ sap_maintenance_planner_transaction_name }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
     - name: Find SAP HANA installation media

--- a/deploy_scenarios/sap_s4hana_distributed_maintplan/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_maintplan/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 # Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true

--- a/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_extravars.yml
@@ -112,7 +112,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -166,10 +213,13 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 #### Begin downloading SAP software installation media to hosts ####
@@ -199,7 +249,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
 #### Begin SAP software hosts preparation ####

--- a/deploy_scenarios/sap_s4hana_foundation_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 # Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true

--- a/deploy_scenarios/sap_s4hana_foundation_standard/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_standard/ansible_extravars.yml
@@ -115,7 +115,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_s4hana_foundation_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_standard/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -166,11 +213,15 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_aas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_aas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_aas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_aas_instance_nr', (sap_system_nwas_abap_aas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 - name: Ansible Play for ensuring rsync on all hosts
@@ -213,7 +264,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
     - name: Find SAP HANA installation media

--- a/deploy_scenarios/sap_s4hana_foundation_standard/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_standard/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 # Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true

--- a/deploy_scenarios/sap_s4hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox/ansible_extravars.yml
@@ -112,7 +112,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_s4hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -166,10 +213,13 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 #### Begin downloading SAP software installation media to hosts ####
@@ -199,7 +249,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
 #### Begin SAP software hosts preparation ####

--- a/deploy_scenarios/sap_s4hana_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_extravars.yml
@@ -115,7 +115,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -166,10 +213,13 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 #### Begin downloading SAP software installation media to hosts ####
@@ -200,7 +250,7 @@
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
         sap_software_download_mp_transaction: "{{ sap_maintenance_planner_transaction_name }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
 #### Begin SAP software hosts preparation ####

--- a/deploy_scenarios/sap_s4hana_sandbox_maintplan/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_maintplan/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_s4hana_sandbox_syscopy/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_syscopy/ansible_extravars.yml
@@ -120,7 +120,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_s4hana_sandbox_syscopy/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_syscopy/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -166,10 +213,13 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 #### Begin downloading SAP software installation media to hosts ####
@@ -199,7 +249,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
 #### Begin downloading SAP HANA complete data backup

--- a/deploy_scenarios/sap_s4hana_sandbox_syscopy/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_syscopy/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_s4hana_standard/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_standard/ansible_extravars.yml
@@ -115,7 +115,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_s4hana_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_standard/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -166,11 +213,15 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_aas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_aas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_aas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_aas_instance_nr', (sap_system_nwas_abap_aas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 - name: Ansible Play for ensuring rsync on all hosts
@@ -213,7 +264,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
     - name: Find SAP HANA installation media

--- a/deploy_scenarios/sap_s4hana_standard/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_standard/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 # Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true

--- a/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_extravars.yml
@@ -118,7 +118,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_playbook.yml
@@ -35,32 +35,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -89,26 +107,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -123,7 +162,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -144,7 +187,11 @@
         "{{ item.key }}": "{{ item.value }}"
         cacheable: true
       loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
+      when:
+        - sap_playbook_interactive_product is defined and sap_playbook_interactive_product | length > 0
+        - sap_playbook_interactive_database is defined and sap_playbook_interactive_database | length > 0
+        - sap_playbook_interactive_layout is defined and sap_playbook_interactive_layout | length > 0
+        - vars[item.key] is undefined
       no_log: true
       ignore_errors: true  # Ignore errors for variables defined later during runtime
 
@@ -166,11 +213,15 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_pas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_pas_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_aas_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_aas_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_pas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_pas_instance_nr', (sap_system_nwas_abap_pas_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_aas_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_aas_instance_nr', (sap_system_nwas_abap_aas_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 - name: Ansible Play for ensuring rsync on all hosts
@@ -214,7 +265,7 @@
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
         sap_software_download_mp_transaction: "{{ sap_maintenance_planner_transaction_name }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
     - name: Find SAP HANA installation media
       ansible.builtin.find:

--- a/deploy_scenarios/sap_s4hana_standard_maintplan/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_s4hana_standard_maintplan/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 # Variable opens firewall for multiple host SAP HANA database
 sap_hana_install_update_firewall: true

--- a/deploy_scenarios/sap_solman_sapase_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_solman_sapase_sandbox/ansible_extravars.yml
@@ -77,7 +77,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_solman_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_solman_sapase_sandbox/ansible_playbook.yml
@@ -10,32 +10,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -64,26 +82,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -92,36 +131,12 @@
   gather_facts: false
   tasks:
 
-    # Ensure that all sap_* or __sap_* variables set in Interactive Mode are appended to the target inventory Group
-    - name: Assign all relevant facts from execution node before provisioning  # noqa: ignore-errors
-      ansible.builtin.set_fact:
-        "{{ item.key }}": "{{ item.value }}"
-        cacheable: true
-      loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
-      no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
-
     - name: Execute Ansible Role sap_vm_provision
       ansible.builtin.include_role:
         name: community.sap_infrastructure.sap_vm_provision
       when:
         - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
         - sap_vm_provision_iac_platform != 'existing_hosts'
-
-- name: Ansible Play to set sap variables on provisioned hosts
-  hosts: sap_vm_provision_target_inventory_group  # noqa: ignore-errors
-  gather_facts: false
-  tasks:
-
-    - name: Assign all relevant facts from execution node after provisioning  # noqa: ignore-errors
-      ansible.builtin.set_fact:
-        "{{ item.key }}": "{{ item.value }}"
-        cacheable: true
-      loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
-      no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
 
 
 #### VM storage filesystem setup ####
@@ -189,7 +204,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
 #### Begin SAP software hosts preparation ####
@@ -222,7 +237,7 @@
   max_fail_percentage: 0
   tasks:
 
-    - name: Execute Ansible Role sap_install_media_detect
+    - name: Execute Ansible Role sap_install_media_detect for abap
       ansible.builtin.include_role:
         name: community.sap_install.sap_install_media_detect
       vars:
@@ -245,7 +260,7 @@
         sap_swpm_pas_instance_nr: "{{ sap_system_nwas_abap_pas_instance_nr }}"
 
 
-    - name: Execute Ansible Role sap_install_media_detect
+    - name: Execute Ansible Role sap_install_media_detect for java
       ansible.builtin.include_role:
         name: community.sap_install.sap_install_media_detect
       vars:

--- a/deploy_scenarios/sap_solman_sapase_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_solman_sapase_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 
 #### Ansible Dictionary for host specifications ####

--- a/deploy_scenarios/sap_solman_saphana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_solman_saphana_sandbox/ansible_extravars.yml
@@ -115,7 +115,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### Shared Ansible Facts ####

--- a/deploy_scenarios/sap_solman_saphana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_solman_saphana_sandbox/ansible_playbook.yml
@@ -10,32 +10,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -64,26 +82,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -92,36 +131,12 @@
   gather_facts: false
   tasks:
 
-    # Ensure that all sap_* or __sap_* variables set in Interactive Mode are appended to the target inventory Group
-    - name: Assign all relevant facts from execution node before provisioning  # noqa: ignore-errors
-      ansible.builtin.set_fact:
-        "{{ item.key }}": "{{ item.value }}"
-        cacheable: true
-      loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
-      no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
-
     - name: Execute Ansible Role sap_vm_provision
       ansible.builtin.include_role:
         name: community.sap_infrastructure.sap_vm_provision
       when:
         - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
         - sap_vm_provision_iac_platform != 'existing_hosts'
-
-- name: Ansible Play to set sap variables on provisioned hosts
-  hosts: sap_vm_provision_target_inventory_group  # noqa: ignore-errors
-  gather_facts: false
-  tasks:
-
-    - name: Assign all relevant facts from execution node after provisioning  # noqa: ignore-errors
-      ansible.builtin.set_fact:
-        "{{ item.key }}": "{{ item.value }}"
-        cacheable: true
-      loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
-      no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
 
 
 #### VM storage filesystem setup ####
@@ -190,7 +205,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
 #### Begin SAP software hosts preparation ####
@@ -250,7 +265,7 @@
   max_fail_percentage: 0
   tasks:
 
-    - name: Execute Ansible Role sap_install_media_detect
+    - name: Execute Ansible Role sap_install_media_detect for abap
       ansible.builtin.include_role:
         name: community.sap_install.sap_install_media_detect
       vars:
@@ -272,7 +287,7 @@
         sap_swpm_pas_instance_nr: "{{ sap_system_nwas_abap_pas_instance_nr }}"
 
 
-    - name: Execute Ansible Role sap_install_media_detect
+    - name: Execute Ansible Role sap_install_media_detect for java
       ansible.builtin.include_role:
         name: community.sap_install.sap_install_media_detect
       vars:

--- a/deploy_scenarios/sap_solman_saphana_sandbox/optional/ansible_extravars_existing_hosts.yml
+++ b/deploy_scenarios/sap_solman_saphana_sandbox/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 
 #### Ansible Dictionary for host specifications ####

--- a/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_extravars.yml
+++ b/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_extravars.yml
@@ -79,7 +79,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 #### High Availability variables ####
@@ -148,12 +148,9 @@ sap_software_install_dictionary:
         - swpm_installation_media
         - swpm_installation_media_swpm2_hana
         - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
+        - credentials_hana=
         - nw_config_other
         - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
         - nw_config_ports
         - nw_config_host_agent
         - sap_os_linux_user

--- a/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_playbook.yml
+++ b/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_playbook.yml
@@ -10,32 +10,50 @@
   # gather_facts is required for loop over hostvars
   tasks:
 
-    - name: Fail if sap_vm_provision_iac_type is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_type' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_type is defined
+          - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_type' is undefined or invalid.
           Available options: ansible, ansible_to_terraform, existing_hosts
-      when: sap_vm_provision_iac_type is not defined or sap_vm_provision_iac_type not in ['ansible', 'ansible_to_terraform', 'existing_hosts']
 
-    - name: Fail if sap_vm_provision_iac_platform is undefined or invalid
-      ansible.builtin.fail:
-        msg: |
+    - name: Assert that the variable 'sap_vm_provision_iac_platform' is valid
+      ansible.builtin.assert:
+        that:
+          - sap_vm_provision_iac_platform is defined
+          - sap_vm_provision_iac_platform in
+            ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+        fail_msg: |
           The variable 'sap_vm_provision_iac_platform' is undefined or invalid.
           Available options: aws_ec2_vs, gcp_ce_vm, msazure_vm, ibmcloud_powervs, ibmcloud_vs, ibmpowervm_vm, kubevirt_vm, ovirt_vm, vmware_vm, existing_hosts
-      when: sap_vm_provision_iac_platform is not defined or sap_vm_provision_iac_platform not in
-        ['aws_ec2_vs', 'gcp_ce_vm', 'msazure_vm', 'ibmcloud_powervs', 'ibmcloud_vs', 'ibmpowervm_vm', 'kubevirt_vm', 'ovirt_vm', 'vmware_vm', 'existing_hosts']
+
+    # Ignore registered vars and sap_swpm hostnames which could contain hostvars.
+    - name: Prepare list of SAP variables for validation  # noqa: ignore-errors
+      ansible.builtin.set_fact:
+        sap_playbook_dictionary_vars:
+          "{{ dict(sap_playbook_dictionary_vars | zip(lookup('ansible.builtin.vars', *sap_playbook_dictionary_vars))) }}"
+      vars:
+        sap_playbook_dictionary_vars:
+          "{{ lookup('ansible.builtin.varnames', '^(__)?sap_', wantlist=true)
+              | reject('search', '(^(__)?sap_swpm_.*_hostname$)|(.*_register$)')
+              | reject('in', ['sap_swpm_db_host'])
+              | list }}"
+      no_log: true
+      ignore_errors: true
 
     - name: Identify variables with placeholder values or empty passwords  # noqa: ignore-errors
       ansible.builtin.set_fact:
-        sap_playbook_placeholder_vars: "{{ sap_playbook_placeholder_vars | d([]) + [item.key]
-          if item.value in ['ENTER_STRING_VALUE_HERE']
-          else sap_playbook_placeholder_vars | d([]) }}"
-        sap_playbook_empty_password_vars: "{{ sap_playbook_empty_password_vars | d([]) + [item.key]
-          if 'password' in item.key and (item.value is none or not item.value is string or item.value == '')
-          else sap_playbook_empty_password_vars | d([]) }}"
-      loop: "{{ vars | dict2items | selectattr('key', 'match', '^(__)?sap_') | rejectattr('key', 'match', '.*_register$') | list }}"
+        sap_playbook_placeholder_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items
+              | selectattr('value', 'equalto', 'ENTER_STRING_VALUE_HERE') | map(attribute='key') | list }}"
+
+        sap_playbook_empty_password_vars:
+          "{{ sap_playbook_dictionary_vars | dict2items | selectattr('key', 'search', 'password')
+              | selectattr('value', 'in', [none, '']) | map(attribute='key') | list }}"
       no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
+      ignore_errors: true
 
     - name: Report SAP variable validation failures
       ansible.builtin.fail:
@@ -64,25 +82,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -91,36 +131,9 @@
   gather_facts: false
   tasks:
 
-    # Ensure that all sap_* or __sap_* variables set in Interactive Mode are appended to the target inventory Group
-    - name: Assign all relevant facts from execution node before provisioning  # noqa: ignore-errors
-      ansible.builtin.set_fact:
-        "{{ item.key }}": "{{ item.value }}"
-        cacheable: true
-      loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
-      no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
-
     - name: Execute Ansible Role sap_vm_provision
       ansible.builtin.include_role:
         name: community.sap_infrastructure.sap_vm_provision
-      when:
-        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
-        - sap_vm_provision_iac_platform != 'existing_hosts'
-
-- name: Ansible Play to set sap variables on provisioned hosts
-  hosts: sap_vm_provision_target_inventory_group  # noqa: ignore-errors
-  gather_facts: false
-  tasks:
-
-    - name: Assign all relevant facts from execution node after provisioning  # noqa: ignore-errors
-      ansible.builtin.set_fact:
-        "{{ item.key }}": "{{ item.value }}"
-        cacheable: true
-      loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
-      no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
 
 
 #### VM storage filesystem setup ####
@@ -144,10 +157,13 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_nwas_abap_ascs_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ascs_instance_nr'] | d('') }}"
-        sap_storage_setup_nwas_abap_ers_instance_nr: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_nwas_abap_ers_instance_nr'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_nwas_abap_ascs_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ascs_instance_nr', (sap_system_nwas_abap_ascs_instance_nr | d(''))) }}"
+        sap_storage_setup_nwas_abap_ers_instance_nr:
+          "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_nwas_abap_ers_instance_nr', (sap_system_nwas_abap_ers_instance_nr | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 - name: Ansible Play for ensuring rsync on all hosts
@@ -190,7 +206,7 @@
         sap_software_download_deduplicate: first
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_architecture] }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
     - name: Find SAP NetWeaver ERS installation media

--- a/special_actions/sap_nwas_abap_ascs_ers_cluster/optional/ansible_extravars_existing_hosts.yml
+++ b/special_actions/sap_nwas_abap_ascs_ers_cluster/optional/ansible_extravars_existing_hosts.yml
@@ -19,9 +19,15 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# This format ensures that variable validation pass since localhost is not part of dictionary.
+sap_storage_setup_definition: >-
+  {{ (
+       (
+         (sap_vm_provision_existing_hosts_host_specifications_dictionary
+         ).get(sap_vm_provision_host_specification_plan) | default({})
+       ).get(inventory_hostname_short) | default({})
+     ).get('storage_definition') | default([])
+  }}
 
 # Define the NFS mount point (String).
 sap_vm_provision_nfs_mount_point: "ENTER_STRING_VALUE_HERE"

--- a/special_actions/sap_system_copy_restore_hana_sandbox/ansible_extravars.yml
+++ b/special_actions/sap_system_copy_restore_hana_sandbox/ansible_extravars.yml
@@ -52,8 +52,6 @@ sap_hana_install_use_master_password: y
 # Pass some extra arguments to the hdblcm cli, e.g.  --ignore=<check1>[,<check2>]...
 # sap_hana_install_hdblcm_extraargs:
 
-# Update hosts file
-sap_hana_install_update_etchosts: 'false'
 
 # For more optional parameters please consult the documentation or
 # Check the file <role path>/defaults/main.yml
@@ -75,7 +73,7 @@ sap_swpm_templates_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BS2016.ERP608.HDB.CP
 
     sap_swpm_inifile_sections_list:
-      sap_swpm_update_etchosts: 'false'
+      sap_swpm_update_etchosts: false
       #sap_swpm_cd_rdms_path:
       sap_swpm_load_type: HBR
 
@@ -100,7 +98,7 @@ sap_swpm_templates_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BS2013SR2.ERP607SR2.HDB.CP
 
     sap_swpm_inifile_sections_list:
-      sap_swpm_update_etchosts: 'false'
+      sap_swpm_update_etchosts: false
       #sap_swpm_cd_rdms_path:
       sap_swpm_load_type: HBR
 
@@ -125,7 +123,7 @@ sap_swpm_templates_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA1909.CORE.HDB.CP
 
     sap_swpm_inifile_sections_list:
-      sap_swpm_update_etchosts: 'false'
+      sap_swpm_update_etchosts: false
 
     sap_swpm_inifile_list:
       - swpm_installation_media
@@ -148,7 +146,7 @@ sap_swpm_templates_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2020.CORE.HDB.CP
 
     sap_swpm_inifile_sections_list:
-      sap_swpm_update_etchosts: 'false'
+      sap_swpm_update_etchosts: false
 
     sap_swpm_inifile_list:
       - swpm_installation_media
@@ -171,7 +169,7 @@ sap_swpm_templates_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2021.CORE.HDB.CP
 
     sap_swpm_inifile_sections_list:
-      sap_swpm_update_etchosts: 'false'
+      sap_swpm_update_etchosts: false
 
     sap_swpm_inifile_list:
       - swpm_installation_media
@@ -194,7 +192,7 @@ sap_swpm_templates_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2022.CORE.HDB.CP
 
     sap_swpm_inifile_sections_list:
-      sap_swpm_update_etchosts: 'false'
+      sap_swpm_update_etchosts: false
 
     sap_swpm_inifile_list:
       - swpm_installation_media
@@ -217,7 +215,7 @@ sap_swpm_templates_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2023.CORE.HDB.CP
 
     sap_swpm_inifile_sections_list:
-      sap_swpm_update_etchosts: 'false'
+      sap_swpm_update_etchosts: false
 
     sap_swpm_inifile_list:
       - swpm_installation_media

--- a/special_actions/sap_system_copy_restore_hana_sandbox/ansible_playbook.yml
+++ b/special_actions/sap_system_copy_restore_hana_sandbox/ansible_playbook.yml
@@ -101,7 +101,7 @@
         sap_swpm_pas_instance_nr: "{{ ansible_prompt_sap_system_id_instance_nwas_pas }}"
 
         sap_swpm_fqdn: "{{ ansible_domain }}"
-        sap_swpm_update_etchosts: 'false'
+        sap_swpm_update_etchosts: false
         sap_swpm_db_host: "{{ ansible_hostname }}"
         sap_swpm_ascs_instance_hostname: "{{ ansible_hostname }}"
 
@@ -132,7 +132,7 @@
       ansible.builtin.include_role:
         name: community.sap_install.sap_hana_install
 
-    - name: Execute Ansible Role sap_install_media_detect
+    - name: Execute Ansible Role sap_install_media_detect with export
       ansible.builtin.include_role:
         name: community.sap_install.sap_install_media_detect
       vars:

--- a/special_actions/sap_webdispatcher_standalone/ansible_extravars.yml
+++ b/special_actions/sap_webdispatcher_standalone/ansible_extravars.yml
@@ -62,13 +62,13 @@ sap_swpm_fqdn: "{{ ansible_domain }}"
 sap_swpm_wd_virtual_host: "{{ ansible_hostname }}"
 sap_swpm_wd_instance_nr: "{{ sap_system_wd_instance_nr }}"
 
-sap_swpm_wd_system_connectivity: 'true'
+sap_swpm_wd_system_connectivity: true
 sap_swpm_wd_backend_sid: "{{ sap_system_sid }}"
 sap_swpm_wd_backend_ms_host: "{{ sap_swpm_ascs_instance_hostname }}"
 sap_swpm_wd_backend_ms_http_port: '80{{ sap_swpm_ascs_instance_nr }}'
 sap_swpm_wd_backend_scenario_size: '500'
 
-sap_swpm_wd_activate_icf: 'true'
+sap_swpm_wd_activate_icf: true
 sap_swpm_wd_backend_rfc_host: "{{ sap_swpm_pas_instance_hostname }}"
 sap_swpm_wd_backend_rfc_instance_nr: "{{ sap_swpm_pas_instance_nr }}"
 sap_swpm_wd_backend_rfc_client_nr: "000" # 000 default
@@ -82,7 +82,7 @@ sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
 sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
 sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
-sap_swpm_update_etchosts: 'false'  # Whether to update the /etc/hosts file during SWPM installation (String).
+sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 
 
 # SAP Web Dispatcher version to download
@@ -199,7 +199,7 @@ sap_software_install_dictionary:
     sap_swpm_inifile_dictionary:
 
       # SAP Host Agent
-      sap_swpm_install_saphostagent: 'false'
+      sap_swpm_install_saphostagent: false
 
 
   sap_webdispatcher_pre_7_5x_standalone_swpm1:
@@ -220,4 +220,4 @@ sap_software_install_dictionary:
     sap_swpm_inifile_dictionary:
 
       # SAP Host Agent
-      sap_swpm_install_saphostagent: 'false'
+      sap_swpm_install_saphostagent: false

--- a/special_actions/sap_webdispatcher_standalone/ansible_playbook.yml
+++ b/special_actions/sap_webdispatcher_standalone/ansible_playbook.yml
@@ -11,26 +11,47 @@
   gather_facts: false
   tasks:
 
-    - name: Fail if 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty
-      ansible.builtin.fail:
-        msg: |
-          Variable 'sap_vm_provision_{{ sap_vm_provision_iac_platform }}_host_specifications_dictionary' is undefined or empty.
+    - name: Block to prepare inventory for provisioning
       when:
-        - "'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary' not in vars
-          or lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform + '_host_specifications_dictionary') | length == 0"
+        - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - sap_vm_provision_iac_platform != 'existing_hosts'
+      vars:
+        __sap_playbook_host_dictionary_name: "{{ 'sap_vm_provision_' ~ sap_vm_provision_iac_platform ~ '_host_specifications_dictionary' }}"
+      block:
+        - name: Assert that the variable {{ __sap_playbook_host_dictionary_name }} is defined and valid
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name) | length > 0
+            fail_msg: |
+              The variable {{ __sap_playbook_host_dictionary_name }} is undefined or invalid.
+              It must be a non-empty dictionary.
 
-    - name: Set fact with selected host dictionary
-      ansible.builtin.set_fact:
-        sap_playbook_host_dictionary:
-          "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
-            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan] }}"
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is defined and valid
+          ansible.builtin.assert:
+            that:
+              - sap_vm_provision_host_specification_plan is defined
+              - sap_vm_provision_host_specification_plan is string
+              - sap_vm_provision_host_specification_plan | trim | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is undefined or invalid.
+              It must be a non-empty string.
 
-    - name: Create dynamic inventory group for Ansible Role sap_vm_provision
-      ansible.builtin.add_host:
-        name: "{{ item }}"
-        group: sap_vm_provision_target_inventory_group
-      loop: "{{ sap_playbook_host_dictionary.keys() }}"
-      when: sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
+        - name: Assert that the variable 'sap_vm_provision_host_specification_plan' is present in a dictionary
+          ansible.builtin.assert:
+            that:
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is defined
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] is mapping
+              - lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan] | length > 0
+            fail_msg: |
+              The variable 'sap_vm_provision_host_specification_plan' is not present in a dictionary {{ __sap_playbook_host_dictionary_name }}.
+
+        - name: Create dynamic inventory group for Ansible Role sap_vm_provision
+          ansible.builtin.add_host:
+            name: "{{ item }}"
+            group: sap_vm_provision_target_inventory_group
+          loop: "{{ lookup('ansible.builtin.vars', __sap_playbook_host_dictionary_name)[sap_vm_provision_host_specification_plan].keys() }}"
 
 
 # Ansible Play target hosts pattern, use Inventory Group created by previous Ansible Task (add_host)
@@ -39,36 +60,12 @@
   gather_facts: false
   tasks:
 
-    # Ensure that all sap_* or __sap_* variables set in Interactive Mode are appended to the target inventory Group
-    - name: Assign all relevant facts from execution node before provisioning  # noqa: ignore-errors
-      ansible.builtin.set_fact:
-        "{{ item.key }}": "{{ item.value }}"
-        cacheable: true
-      loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
-      no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
-
     - name: Execute Ansible Role sap_vm_provision
       ansible.builtin.include_role:
         name: community.sap_infrastructure.sap_vm_provision
       when:
         - sap_vm_provision_iac_type in ['ansible', 'ansible_to_terraform']
         - sap_vm_provision_iac_platform != 'existing_hosts'
-
-- name: Ansible Play to set sap variables on provisioned hosts
-  hosts: sap_vm_provision_target_inventory_group  # noqa: ignore-errors
-  gather_facts: false
-  tasks:
-
-    - name: Assign all relevant facts from execution node after provisioning  # noqa: ignore-errors
-      ansible.builtin.set_fact:
-        "{{ item.key }}": "{{ item.value }}"
-        cacheable: true
-      loop: "{{ hostvars['localhost'] | dict2items | selectattr('key', 'match', '^(__)?sap_') | list }}"
-      when: vars[item.key] is undefined
-      no_log: true
-      ignore_errors: true  # Ignore errors for variables defined later during runtime
 
 
 #### VM storage filesystem setup ####
@@ -88,8 +85,9 @@
         sap_playbook_host_dictionary_hostname:
           "{{ lookup('ansible.builtin.vars', 'sap_vm_provision_' + sap_vm_provision_iac_platform
            + '_host_specifications_dictionary')[sap_vm_provision_host_specification_plan][inventory_hostname_short] }}"
-        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_sid'] | d('') }}"
-        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname['sap_storage_setup_host_type'] | list }}"
+        sap_storage_setup_sid: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_sid', (sap_system_sid | d(''))) }}"
+        sap_storage_setup_host_type: "{{ sap_playbook_host_dictionary_hostname.get('sap_storage_setup_host_type', []) }}"
+      when: sap_playbook_host_dictionary_hostname is defined
 
 
 #### Begin downloading SAP software installation media to hosts ####
@@ -121,7 +119,7 @@
           if ansible_architecture == 'x86_64'
           else (softwarecenter_search_list_ppc64le[sap_playbook_webdispatcher_version]
             if ansible_architecture == 'ppc64le' else '') }}"
-      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad')
+      when: sap_playbook_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
 #### Begin SAP software hosts preparation ####

--- a/special_actions/sap_webdispatcher_standalone/optional/ansible_extravars_existing_hosts.yml
+++ b/special_actions/sap_webdispatcher_standalone/optional/ansible_extravars_existing_hosts.yml
@@ -15,9 +15,11 @@ sap_general_preconfigure_domain: "{{ ansible_domain }}"
 
 
 # sap_storage role variable assignment per host
-sap_storage_setup_definition:
-  "{{ sap_vm_provision_existing_hosts_host_specifications_dictionary[sap_vm_provision_host_specification_plan]
-    [inventory_hostname_short].storage_definition }}"
+# Defaults ensure that validation for placeholders will not show error.
+sap_storage_setup_definition: >-
+  {{ (sap_vm_provision_existing_hosts_host_specifications_dictionary
+      [sap_vm_provision_host_specification_plan]
+      [inventory_hostname_short] | default({})).storage_definition | default([]) }}
 
 
 #### Ansible Dictionary for host specifications ####


### PR DESCRIPTION
## Reason
Details about upcoming ansible-core 2.19 are listed in https://github.com/sap-linuxlab/ansible.playbooks_for_sap/issues/84

## Changes
- Add length conditionals where required, because 2.19 no longer considers bool check of string as truthy.
- Remove `vars[]` and lookup for unexpanded variables, because it no longer works as explained here https://github.com/ansible/ansible/issues/85667
  - This was replaced by new lookup for `varnames`, reject known vars with `hostvars` and validate rest.
  - **NOTE:** We can no longer validate unexpanded variables to catch hostvars so reject is used here for known items like hostnames.
- Replace some dictionary lookups with `.get()` to be able to lookup without failure if key does not exist.
- Add conditionals for both task `Assign all relevant facts from execution node` to ensure it runs only for Interactive mode, because provisioning during runtime will always inherit from play level.
- Fix incorrect `'true'` variables with `true`.
- Replace fail modules with assert to ensure that playbook fails before getting to provisioning.

## Tests
Testing is ongoing and waiting for https://github.com/sap-linuxlab/community.sap_install/pull/1111
