### PR TITLE
collection: Bump requirements versions to support 2.19

### DIFF
--- a/common_fragments/ansible_requirements.yml
+++ b/common_fragments/ansible_requirements.yml
@@ -1,11 +1,14 @@
 ---
+# Update for ansible-core 2.19:
+# - SAP linux-lab collections were updated for 2.19.
+# - Vendor collections were raised to version included in Ansible 12.
 
 collections:
 
 # Collections from Ansible Galaxy
   - name: community.general
     type: galaxy
-    version: 10.1.0
+    version: ">=11.2.1"
   - name: fedora.linux_system_roles
     type: galaxy
     version: ">=1.100.0"
@@ -18,50 +21,36 @@ collections:
   - name: community.sap_infrastructure
     type: galaxy
     version: ">=1.3.0"
-#  - name: community.sap_operations
-#    type: galaxy
-#    version: 0.9.1
 
 # Collections for Infrastructure from Ansible Galaxy
   - name: cloud.terraform
     type: galaxy
-    version: 3.0.0
+    version: ">=4.0.0"
   - name: amazon.aws
     type: galaxy
-    version: 9.0.0
+    version: ">=10.1.0"
   - name: community.aws
     type: galaxy
-    version: 9.0.0
+    version: ">=10.0.0"
   - name: azure.azcollection
     type: galaxy
-    version: 3.2.0
+    version: ">=3.8.0"
   - name: google.cloud
     type: galaxy
-    version: 1.5.0
+    version: ">=1.7.0"
   # Replace with ibm.cloud in future, legacy Ansible Collection uses hidden on-the-fly Terraform files in /var/tmp/ansible/ibmcloud)
   - name: ibm.cloudcollection
     type: galaxy
     version: 1.71.2
   - name: ovirt.ovirt
     type: galaxy
-    version: 3.2.0
+    version: ">=3.2.1"
   - name: openstack.cloud
     type: galaxy
-    version: 2.4.0
+    version: ">=2.4.1"
   - name: vmware.vmware_rest
     type: galaxy
-    version: 4.5.0
+    version: ">=4.9.0"
   - name: cloud.common
     type: galaxy
-    version: 4.0.0
-
-# Collections from public repositories via HTTPS
-#  - name: https://github.com/sap-linuxlab/community.sap_install.git
-#    type: git
-#    version: dev
-
-# Collections from private repositories via use SSH (embedded GitHub PAT does not work)
-# Used for customised/forked Ansible Collections
-#  - name: git@github.domain.com:gheorg/namespace.sap_install.git
-#    type: git
-#    version: main
+    version: ">=5.0.0"

--- a/common_fragments/ansible_requirements.yml
+++ b/common_fragments/ansible_requirements.yml
@@ -8,16 +8,16 @@ collections:
     version: 10.1.0
   - name: fedora.linux_system_roles
     type: galaxy
-    version: 1.100.0
+    version: ">=1.100.0"
   - name: community.sap_install
     type: galaxy
-    version: 1.5.3
+    version: ">=1.7.1"
   - name: community.sap_launchpad
     type: galaxy
-    version: 1.2.1
+    version: ">=1.3.0"
   - name: community.sap_infrastructure
     type: galaxy
-    version: 1.1.3
+    version: ">=1.3.0"
 #  - name: community.sap_operations
 #    type: galaxy
 #    version: 0.9.1

--- a/common_fragments/ansible_requirements.yml
+++ b/common_fragments/ansible_requirements.yml
@@ -14,7 +14,7 @@ collections:
     version: ">=1.100.0"
   - name: community.sap_install
     type: galaxy
-    version: ">=1.7.1"
+    version: ">=1.8.0"
   - name: community.sap_launchpad
     type: galaxy
     version: ">=1.3.0"
@@ -41,7 +41,7 @@ collections:
   # Replace with ibm.cloud in future, legacy Ansible Collection uses hidden on-the-fly Terraform files in /var/tmp/ansible/ibmcloud)
   - name: ibm.cloudcollection
     type: galaxy
-    version: 1.71.2
+    version: "1.71.2"
   - name: ovirt.ovirt
     type: galaxy
     version: ">=3.2.1"

--- a/deploy_scenarios/sap_hana_ha/ansible_extravars_aws_ec2_vs_base.yml
+++ b/deploy_scenarios/sap_hana_ha/ansible_extravars_aws_ec2_vs_base.yml
@@ -9,5 +9,5 @@ sap_ha_pacemaker_cluster_aws_secret_access_key: "{{ sap_vm_provision_aws_secret_
 sap_ha_pacemaker_cluster_aws_vip_update_rt: "ENTER_STRING_VALUE_HERE"  # AWS Routing Table ID (String).
 
 # Override of AWS IAM HA roles is required if 'HA-Role-Pacemaker' already exists
-# sap_vm_provision_aws_ha_iam_role: "HA-Role-Pacemaker-{{ sap_system_sid }}"
-# sap_vm_provision_aws_ha_iam_instance_profile: "HA-Role-Pacemaker-{{ sap_system_sid }}-profile"
+# sap_vm_provision_aws_ha_iam_role: "HA-Role-Pacemaker-{{ sap_system_hana_db_sid }}"
+# sap_vm_provision_aws_ha_iam_instance_profile: "HA-Role-Pacemaker-{{ sap_system_hana_db_sid }}-profile"


### PR DESCRIPTION
## Changes
- Bump requirements versions to support `2.19` to ensure AP4S requires correct fixed collections.
- Fix `hana_ha` variable where it used wrong SID for AWS.

# NOTE
We have to wait for 2.19 fixes to be released in `sap_install` and bump it up to `1.8.0`