### PR TITLE
hana: Update SAP HANA versions and add throttle for rsync 

### DIFF
--- a/deploy_scenarios/sap_bw4hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_bw4hana_sandbox/ansible_extravars.yml
@@ -144,14 +144,12 @@ sap_software_install_dictionary:
       - sap_os_linux_user
 
     softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_077_0-80002031.SAR'
-      - 'IMDB_LCAPPS_2077_3-20010426.SAR'
-      - 'IMDB_AFL20_077_0-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'
+      # Application
       - 'SAPEXE_51-70007807.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (785), SAP HANA 2.0
       - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent 7.22
@@ -165,16 +163,19 @@ sap_software_install_dictionary:
       - 'BW4HANA400_INST_EXPORT_8.zip'
       - 'BW4HANA400_INST_EXPORT_9.zip'
       # - 'BW4HANA400_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
     softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_077_0-80002046.SAR'
-      - 'IMDB_LCAPPS_2077_3-80002183.SAR'
-      - 'IMDB_AFL20_077_0-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'
+      # Application
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (785), SAP HANA 2.0
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent 7.22
@@ -188,6 +189,11 @@ sap_software_install_dictionary:
       - 'BW4HANA400_INST_EXPORT_8.zip'
       - 'BW4HANA400_INST_EXPORT_9.zip'
       # - 'BW4HANA400_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
   sap_bw4hana_2021_sandbox:
 

--- a/deploy_scenarios/sap_bw4hana_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_bw4hana_sandbox/optional/ansible_extravars_interactive.yml
@@ -52,14 +52,12 @@ sap_software_install_dictionary:
       - sap_os_linux_user
 
     softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_077_0-80002031.SAR'
-      - 'IMDB_LCAPPS_2077_3-20010426.SAR'
-      - 'IMDB_AFL20_077_0-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'
+      # Application
       - 'SAPEXE_51-70007807.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (785), SAP HANA 2.0
       - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent 7.22
@@ -69,19 +67,23 @@ sap_software_install_dictionary:
       - 'BW4HANA400_INST_EXPORT_4.zip'
       - 'BW4HANA400_INST_EXPORT_5.zip'
       - 'BW4HANA400_INST_EXPORT_6.zip'
-      - '19118000000000009032'
+      - 'BW4HANA400_INST_EXPORT_7.zip'
       - 'BW4HANA400_INST_EXPORT_8.zip'
-    #  - 'BW4HANA400_NW_LANG_EN.SAR'
+      - 'BW4HANA400_INST_EXPORT_9.zip'
+      # - 'BW4HANA400_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
     softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_077_0-80002046.SAR'
-      - 'IMDB_LCAPPS_2077_3-80002183.SAR'
-      - 'IMDB_AFL20_077_0-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'
+      # Application
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (785), SAP HANA 2.0
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent 7.22
@@ -91,9 +93,15 @@ sap_software_install_dictionary:
       - 'BW4HANA400_INST_EXPORT_4.zip'
       - 'BW4HANA400_INST_EXPORT_5.zip'
       - 'BW4HANA400_INST_EXPORT_6.zip'
-      - '19118000000000009032'
+      - 'BW4HANA400_INST_EXPORT_7.zip'
       - 'BW4HANA400_INST_EXPORT_8.zip'
-    #  - 'BW4HANA400_NW_LANG_EN.SAR'
+      - 'BW4HANA400_INST_EXPORT_9.zip'
+      # - 'BW4HANA400_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
   sap_bw4hana_2021_sandbox:
 

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_extravars.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_extravars.yml
@@ -159,14 +159,12 @@ sap_software_install_dictionary:
       - sap_os_linux_user
 
     softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_077_0-80002031.SAR'
-      - 'IMDB_LCAPPS_2077_3-20010426.SAR'
-      - 'IMDB_AFL20_077_0-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database - SPS07 is used because NFS for /lss/shared is not enforced like in SPS08.
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007807.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (785), SAP HANA 2.0
       - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent 7.22
@@ -179,17 +177,20 @@ sap_software_install_dictionary:
       - 'BW4HANA400_INST_EXPORT_7.zip'
       - 'BW4HANA400_INST_EXPORT_8.zip'
       - 'BW4HANA400_INST_EXPORT_9.zip'
-    #  - 'BW4HANA400_NW_LANG_EN.SAR'
+      # - 'BW4HANA400_NW_LANG_EN.SAR'
+      - 'igsexe_6-70005417.sar'  # Support Package SAP IGS 7.81 Linux on x86_64 64bit
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
     softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_077_0-80002046.SAR'
-      - 'IMDB_LCAPPS_2077_3-80002183.SAR'
-      - 'IMDB_AFL20_077_0-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (785), SAP HANA 2.0
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent 7.22
@@ -202,7 +203,12 @@ sap_software_install_dictionary:
       - 'BW4HANA400_INST_EXPORT_7.zip'
       - 'BW4HANA400_INST_EXPORT_8.zip'
       - 'BW4HANA400_INST_EXPORT_9.zip'
-    #  - 'BW4HANA400_NW_LANG_EN.SAR'
+      # - 'BW4HANA400_NW_LANG_EN.SAR'
+      - 'igsexe_6-70005446.sar'  # Support Package SAP IGS 7.81 Linux on x86_64 64bit
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
     software_files_wildcard_list:
       - 'SAPCAR*'

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml
@@ -349,6 +349,9 @@
       loop: "{{ hostvars[software_source_hostname].__sap_playbook_register_sap_hana_install_media_files.files | map(attribute='path') | list }}"
       loop_control:
         loop_var: file_item
+      # In some operating systems (e.g. SLES 16), the particular combination of RSYNC version and SSH configuration can cause issues.
+      # 'throttle: 1' prevents a 'Network is unreachable' errors during parallel execution.
+      throttle: 1
       vars:
         software_source_hostname: "{{ hostvars[inventory_hostname].groups.nwas_pas[0] | d(none) }}"
         software_source_ip: "{{ hostvars[software_source_hostname].ansible_host | d(none) }}"
@@ -475,7 +478,7 @@
     # For further details, see documentation 'SAP HANA Administration Guide for SAP HANA Platform - Add Hosts Using the Command-Line Interface'
     ## role - worker, standby etc.
     ## workergroup - Worker Group
-    ## group - High-Availability Group (failover gooup)
+    ## group - High-Availability Group (failover group)
     # NOTE: hdblcm addhosts parameter will alter nameserver.ini '[landscape]' section
     # NOTE: if incorrect workergroup and failover group are defined, will result in error shown:
     # SAP Note 3043860 - Recovery fails due to incorrect worker group assignment
@@ -503,11 +506,11 @@
         loop_var: host_item
       changed_when: false
 
-    # Install SAP HANA from designated coordinator node
+    # Restriction to 'hana_primary' was removed,
+    # because 'sap_hana_install' now requires all nodes in Scale-Out in order to correctly apply all pre and post tasks.
     - name: Execute Ansible Role sap_hana_install
       ansible.builtin.include_role:
         name: community.sap_install.sap_hana_install
-      when: inventory_hostname_short == (groups['hana_primary'] | first)
 
 
 - name: Ansible Play for SAP NetWeaver Application Server installation - ABAP Central Services (ASCS), Database Load, Primary Application Server (PAS)

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/optional/ansible_extravars_interactive.yml
@@ -61,14 +61,12 @@ sap_software_install_dictionary:
       - sap_os_linux_user
 
     softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_077_0-80002031.SAR'
-      - 'IMDB_LCAPPS_2077_3-20010426.SAR'
-      - 'IMDB_AFL20_077_0-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database - SPS07 is used because NFS for /lss/shared is not enforced like in SPS08.
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007807.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (785), SAP HANA 2.0
       - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent 7.22
@@ -78,19 +76,23 @@ sap_software_install_dictionary:
       - 'BW4HANA400_INST_EXPORT_4.zip'
       - 'BW4HANA400_INST_EXPORT_5.zip'
       - 'BW4HANA400_INST_EXPORT_6.zip'
-      - '19118000000000009032'
+      - 'BW4HANA400_INST_EXPORT_7.zip'
       - 'BW4HANA400_INST_EXPORT_8.zip'
-    #  - 'BW4HANA400_NW_LANG_EN.SAR'
+      - 'BW4HANA400_INST_EXPORT_9.zip'
+      # - 'BW4HANA400_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
     softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_077_0-80002046.SAR'
-      - 'IMDB_LCAPPS_2077_3-80002183.SAR'
-      - 'IMDB_AFL20_077_0-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (785), SAP HANA 2.0
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent 7.22
@@ -100,9 +102,15 @@ sap_software_install_dictionary:
       - 'BW4HANA400_INST_EXPORT_4.zip'
       - 'BW4HANA400_INST_EXPORT_5.zip'
       - 'BW4HANA400_INST_EXPORT_6.zip'
-      - '19118000000000009032'
+      - 'BW4HANA400_INST_EXPORT_7.zip'
       - 'BW4HANA400_INST_EXPORT_8.zip'
-    #  - 'BW4HANA400_NW_LANG_EN.SAR'
+      - 'BW4HANA400_INST_EXPORT_9.zip'
+      # - 'BW4HANA400_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
     software_files_wildcard_list:
       - 'SAPCAR*'

--- a/deploy_scenarios/sap_ecc_hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_hana_sandbox/ansible_extravars.yml
@@ -153,8 +153,8 @@ sap_software_install_dictionary:
 
     softwarecenter_search_list_x86_64:
       - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_085_0-80002031.SAR'  # Revision 2.00.085.0 (SPS08) for HANA DB 2.0
-      - 'IMDB_CLIENT20_024_24-80002082.SAR' # SAP HANA CLIENT Version 2.24
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
       # - 'VCH202300_2085_0-70007416.SAR'  # Not mandatory
       - 'SWPM10SP43_3-20009701.SAR'
       - 'igsexe_5-80007786.sar' # IGS 7.54
@@ -179,8 +179,8 @@ sap_software_install_dictionary:
 
     softwarecenter_search_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_085_0-80002046.SAR'  # Revision 2.00.085.0 (SPS08) for HANA DB 2.0
-      - 'IMDB_CLIENT20_024_24-80002095.SAR'  # SAP HANA CLIENT Version 2.24
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
       # - 'VCH202300_2085_0-70007417.SAR'  # Not mandatory
       - 'SWPM10SP43_3-70002492.SAR'
       - 'igsexe_5-80007795.sar' # IGS 7.54

--- a/deploy_scenarios/sap_ecc_hana_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_ecc_hana_sandbox/optional/ansible_extravars_interactive.yml
@@ -61,8 +61,8 @@ sap_software_install_dictionary:
 
     softwarecenter_search_list_x86_64:
       - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_085_0-80002031.SAR'  # Revision 2.00.085.0 (SPS08) for HANA DB 2.0
-      - 'IMDB_CLIENT20_024_24-80002082.SAR' # SAP HANA CLIENT Version 2.24
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
       # - 'VCH202300_2085_0-70007416.SAR'  # Not mandatory
       - 'SWPM10SP43_3-20009701.SAR'
       - 'igsexe_5-80007786.sar' # IGS 7.54
@@ -87,8 +87,8 @@ sap_software_install_dictionary:
 
     softwarecenter_search_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_085_0-80002046.SAR'  # Revision 2.00.085.0 (SPS08) for HANA DB 2.0
-      - 'IMDB_CLIENT20_024_24-80002095.SAR'  # SAP HANA CLIENT Version 2.24
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
       # - 'VCH202300_2085_0-70007417.SAR'  # Not mandatory
       - 'SWPM10SP43_3-70002492.SAR'
       - 'igsexe_5-80007795.sar' # IGS 7.54

--- a/deploy_scenarios/sap_hana/ansible_extravars.yml
+++ b/deploy_scenarios/sap_hana/ansible_extravars.yml
@@ -86,28 +86,40 @@ sap_software_install_dictionary:
   sap_hana_2_sps08_install:
 
     softwarecenter_search_list_x86_64:
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP Host Agent 7.22
       - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_085_0-80002031.SAR'  # Revision 2.00.085.0 (SPS08) for HANA DB 2.0
-      - 'IMDB_CLIENT20_024_24-80002082.SAR' # SAP HANA CLIENT Version 2.24
-      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent 7.22
 
     softwarecenter_search_list_ppc64le:
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      - 'SAPHOSTAGENT67_67-80004831.SAR'  # SAP Host Agent 7.22
       - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_085_0-80002046.SAR'  # Revision 2.00.085.0 (SPS08) for HANA DB 2.0
-      - 'IMDB_CLIENT20_024_24-80002095.SAR'  # SAP HANA CLIENT Version 2.24
-      - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent 7.22
+
+    software_files_wildcard_list:
+      - 'SAPCAR*'
+      - 'IMDB_*'
+      - 'SAPHOSTAGENT*'
 
   sap_hana_2_sps07_install:
 
     softwarecenter_search_list_x86_64:
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP Host Agent 7.22
       - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_077_0-80002031.SAR'
-      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent 7.22
 
     softwarecenter_search_list_ppc64le:
+      - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      - 'SAPHOSTAGENT67_67-80004831.SAR'  # SAP Host Agent 7.22
       - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_077_0-80002046.SAR'
-      - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent 7.22
+
+    software_files_wildcard_list:
+      - 'SAPCAR*'
+      - 'IMDB_*'
+      - 'SAPHOSTAGENT*'
 
   sap_hana_2_sps06_install:
 

--- a/deploy_scenarios/sap_hana/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_hana/optional/ansible_extravars_interactive.yml
@@ -27,28 +27,40 @@ sap_software_install_dictionary:
   sap_hana_2_sps08_install:
 
     softwarecenter_search_list_x86_64:
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP Host Agent 7.22
       - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_085_0-80002031.SAR'  # Revision 2.00.085.0 (SPS08) for HANA DB 2.0
-      - 'IMDB_CLIENT20_024_24-80002082.SAR' # SAP HANA CLIENT Version 2.24
-      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent 7.22
 
     softwarecenter_search_list_ppc64le:
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      - 'SAPHOSTAGENT67_67-80004831.SAR'  # SAP Host Agent 7.22
       - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_085_0-80002046.SAR'  # Revision 2.00.085.0 (SPS08) for HANA DB 2.0
-      - 'IMDB_CLIENT20_024_24-80002095.SAR'  # SAP HANA CLIENT Version 2.24
-      - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent 7.22
+
+    software_files_wildcard_list:
+      - 'SAPCAR*'
+      - 'IMDB_*'
+      - 'SAPHOSTAGENT*'
 
   sap_hana_2_sps07_install:
 
     softwarecenter_search_list_x86_64:
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP Host Agent 7.22
       - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_077_0-80002031.SAR'
-      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent 7.22
 
     softwarecenter_search_list_ppc64le:
+      - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      - 'SAPHOSTAGENT67_67-80004831.SAR'  # SAP Host Agent 7.22
       - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_077_0-80002046.SAR'
-      - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent 7.22
+
+    software_files_wildcard_list:
+      - 'SAPCAR*'
+      - 'IMDB_*'
+      - 'SAPHOSTAGENT*'
 
   sap_hana_2_sps06_install:
 

--- a/deploy_scenarios/sap_hana_ha/ansible_extravars.yml
+++ b/deploy_scenarios/sap_hana_ha/ansible_extravars.yml
@@ -117,34 +117,35 @@ sap_software_install_dictionary:
   sap_hana_2_sps08_install:
 
     softwarecenter_search_list_x86_64:
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP Host Agent 7.22
       - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_085_0-80002031.SAR'  # Revision 2.00.085.0 (SPS08) for HANA DB 2.0
-      - 'IMDB_CLIENT20_024_24-80002082.SAR' # SAP HANA CLIENT Version 2.24
-      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent 7.22
 
     softwarecenter_search_list_ppc64le:
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      - 'SAPHOSTAGENT67_67-80004831.SAR'  # SAP Host Agent 7.22
       - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_085_0-80002046.SAR'  # Revision 2.00.085.0 (SPS08) for HANA DB 2.0
-      - 'IMDB_CLIENT20_024_24-80002095.SAR'  # SAP HANA CLIENT Version 2.24
-      - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent 7.22
 
     software_files_wildcard_list:
       - 'SAPCAR*'
       - 'IMDB_*'
       - 'SAPHOSTAGENT*'
 
-
   sap_hana_2_sps07_install:
 
     softwarecenter_search_list_x86_64:
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP Host Agent 7.22
       - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_077_0-80002031.SAR'
-      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent 7.22
 
     softwarecenter_search_list_ppc64le:
+      - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      - 'SAPHOSTAGENT67_67-80004831.SAR'  # SAP Host Agent 7.22
       - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_077_0-80002046.SAR'
-      - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent 7.22
 
     software_files_wildcard_list:
       - 'SAPCAR*'

--- a/deploy_scenarios/sap_hana_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana_ha/ansible_playbook.yml
@@ -421,6 +421,9 @@
 
         sap_ha_pacemaker_cluster_cluster_nodes: "{{ sap_hana_cluster_nodes }}"
 
+        # Ensures that conflicting packages are uninstalled before using SAP HANA Angi.
+        sap_ha_pacemaker_cluster_saphanasr_angi_force: true
+
 
 #### Post-install alterations for Infrastructure Platform ####
 - name: "Ansible Play for Post-install alterations for Infrastructure Platform"

--- a/deploy_scenarios/sap_hana_ha/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_hana_ha/optional/ansible_extravars_interactive.yml
@@ -27,34 +27,35 @@ sap_software_install_dictionary:
   sap_hana_2_sps08_install:
 
     softwarecenter_search_list_x86_64:
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP Host Agent 7.22
       - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_085_0-80002031.SAR'  # Revision 2.00.085.0 (SPS08) for HANA DB 2.0
-      - 'IMDB_CLIENT20_024_24-80002082.SAR' # SAP HANA CLIENT Version 2.24
-      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent 7.22
 
     softwarecenter_search_list_ppc64le:
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      - 'SAPHOSTAGENT67_67-80004831.SAR'  # SAP Host Agent 7.22
       - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_085_0-80002046.SAR'  # Revision 2.00.085.0 (SPS08) for HANA DB 2.0
-      - 'IMDB_CLIENT20_024_24-80002095.SAR'  # SAP HANA CLIENT Version 2.24
-      - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent 7.22
 
     software_files_wildcard_list:
       - 'SAPCAR*'
       - 'IMDB_*'
       - 'SAPHOSTAGENT*'
 
-
   sap_hana_2_sps07_install:
 
     softwarecenter_search_list_x86_64:
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP Host Agent 7.22
       - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_077_0-80002031.SAR'
-      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent 7.22
 
     softwarecenter_search_list_ppc64le:
+      - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      - 'SAPHOSTAGENT67_67-80004831.SAR'  # SAP Host Agent 7.22
       - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_077_0-80002046.SAR'
-      - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent 7.22
 
     software_files_wildcard_list:
       - 'SAPCAR*'

--- a/deploy_scenarios/sap_hana_scaleout/ansible_extravars.yml
+++ b/deploy_scenarios/sap_hana_scaleout/ansible_extravars.yml
@@ -95,37 +95,39 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
 
+  # NOTE: SPS08 requires NFS mounted /lss/shared.
   sap_hana_2_sps08_install:
 
     softwarecenter_search_list_x86_64:
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP Host Agent 7.22
       - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_085_0-80002031.SAR'  # Revision 2.00.085.0 (SPS08) for HANA DB 2.0
-      - 'IMDB_CLIENT20_024_24-80002082.SAR' # SAP HANA CLIENT Version 2.24
-      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent 7.22
 
     softwarecenter_search_list_ppc64le:
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      - 'SAPHOSTAGENT67_67-80004831.SAR'  # SAP Host Agent 7.22
       - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_085_0-80002046.SAR'  # Revision 2.00.085.0 (SPS08) for HANA DB 2.0
-      - 'IMDB_CLIENT20_024_24-80002095.SAR'  # SAP HANA CLIENT Version 2.24
-      - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent 7.22
 
     software_files_wildcard_list:
       - 'SAPCAR*'
       - 'IMDB_*'
       - 'SAPHOSTAGENT*'
 
-
   sap_hana_2_sps07_install:
 
     softwarecenter_search_list_x86_64:
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP Host Agent 7.22
       - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_077_0-80002031.SAR'
-      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent 7.22
 
     softwarecenter_search_list_ppc64le:
+      - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      - 'SAPHOSTAGENT67_67-80004831.SAR'  # SAP Host Agent 7.22
       - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_077_0-80002046.SAR'
-      - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent 7.22
 
     software_files_wildcard_list:
       - 'SAPCAR*'

--- a/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml
@@ -262,19 +262,6 @@
       when: sap_playbook_host_dictionary_hostname is defined
 
 
-- name: Ansible Play for ensuring rsync on all hosts
-  hosts: hana_primary
-  become: true
-  any_errors_fatal: true
-  max_fail_percentage: 0
-  tasks:
-
-    - name: Install rsync
-      ansible.builtin.package:
-        name: rsync
-        state: present
-
-
 #### Begin downloading SAP software installation media to hosts ####
 - name: Ansible Play for downloading SAP HANA installation media
   hosts: hana_primary
@@ -397,7 +384,7 @@
     # For further details, see documentation 'SAP HANA Administration Guide for SAP HANA Platform - Add Hosts Using the Command-Line Interface'
     ## role - worker, standby etc.
     ## workergroup - Worker Group
-    ## group - High-Availability Group (failover gooup)
+    ## group - High-Availability Group (failover group)
     # NOTE: hdblcm addhosts parameter will alter nameserver.ini '[landscape]' section
     # NOTE: if incorrect workergroup and failover group are defined, will result in error shown:
     # SAP Note 3043860 - Recovery fails due to incorrect worker group assignment
@@ -425,7 +412,8 @@
         loop_var: host_item
       changed_when: false
 
+    # Restriction to 'hana_primary' was removed,
+    # because 'sap_hana_install' now requires all nodes in Scale-Out in order to correctly apply all pre and post tasks.
     - name: Execute Ansible Role sap_hana_install
       ansible.builtin.include_role:
         name: community.sap_install.sap_hana_install
-      when: inventory_hostname_short == (groups['hana_primary'] | first)

--- a/deploy_scenarios/sap_hana_scaleout/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_hana_scaleout/optional/ansible_extravars_interactive.yml
@@ -29,17 +29,39 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
 
+  # NOTE: SPS08 requires NFS mounted /lss/shared.
+  sap_hana_2_sps08_install:
+
+    softwarecenter_search_list_x86_64:
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP Host Agent 7.22
+      - 'SAPCAR_1300-70007716.EXE'
+
+    softwarecenter_search_list_ppc64le:
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      - 'SAPHOSTAGENT67_67-80004831.SAR'  # SAP Host Agent 7.22
+      - 'SAPCAR_1300-70007726.EXE'
+
+    software_files_wildcard_list:
+      - 'SAPCAR*'
+      - 'IMDB_*'
+      - 'SAPHOSTAGENT*'
+
   sap_hana_2_sps07_install:
 
     softwarecenter_search_list_x86_64:
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP Host Agent 7.22
       - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_077_0-80002031.SAR'
-      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent 7.22
 
     softwarecenter_search_list_ppc64le:
+      - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      - 'SAPHOSTAGENT67_67-80004831.SAR'  # SAP Host Agent 7.22
       - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_077_0-80002046.SAR'
-      - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent 7.22
 
     software_files_wildcard_list:
       - 'SAPCAR*'

--- a/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_extravars.yml
@@ -149,8 +149,8 @@ sap_software_install_dictionary:
 
     softwarecenter_search_list_x86_64:
       - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_085_0-80002031.SAR'  # Revision 2.00.085.0 (SPS08) for HANA DB 2.0
-      - 'IMDB_CLIENT20_024_24-80002082.SAR' # SAP HANA CLIENT Version 2.24
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
       # - 'VCH202300_2085_0-70007416.SAR'  # Not mandatory
       - 'SWPM10SP43_3-20009701.SAR'
       - 'igsexe_5-80007786.sar' # IGS 7.54
@@ -165,8 +165,8 @@ sap_software_install_dictionary:
 
     softwarecenter_search_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_085_0-80002046.SAR'  # Revision 2.00.085.0 (SPS08) for HANA DB 2.0
-      - 'IMDB_CLIENT20_024_24-80002095.SAR'  # SAP HANA CLIENT Version 2.24
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
       # - 'VCH202300_2085_0-70007417.SAR'  # Not mandatory
       - 'SWPM10SP43_3-70002492.SAR'
       - 'igsexe_5-80007795.sar' # IGS 7.54

--- a/deploy_scenarios/sap_ides_ecc_hana_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_ides_ecc_hana_sandbox/optional/ansible_extravars_interactive.yml
@@ -57,8 +57,8 @@ sap_software_install_dictionary:
 
     softwarecenter_search_list_x86_64:
       - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_085_0-80002031.SAR'  # Revision 2.00.085.0 (SPS08) for HANA DB 2.0
-      - 'IMDB_CLIENT20_024_24-80002082.SAR' # SAP HANA CLIENT Version 2.24
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
       # - 'VCH202300_2085_0-70007416.SAR'  # Not mandatory
       - 'SWPM10SP43_3-20009701.SAR'
       - 'igsexe_5-80007786.sar' # IGS 7.54
@@ -73,8 +73,8 @@ sap_software_install_dictionary:
 
     softwarecenter_search_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_085_0-80002046.SAR'  # Revision 2.00.085.0 (SPS08) for HANA DB 2.0
-      - 'IMDB_CLIENT20_024_24-80002095.SAR'  # SAP HANA CLIENT Version 2.24
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
       # - 'VCH202300_2085_0-70007417.SAR'  # Not mandatory
       - 'SWPM10SP43_3-70002492.SAR'
       - 'igsexe_5-80007795.sar' # IGS 7.54

--- a/deploy_scenarios/sap_landscape_s4hana_standard/ansible_extravars.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard/ansible_extravars.yml
@@ -159,14 +159,12 @@ sap_software_install_dictionary:
       - 'SAPHOSTAGENT*'
 
     softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_077_0-80002031.SAR'
-      - 'IMDB_LCAPPS_2077_3-20010426.SAR'
-      - 'IMDB_AFL20_077_0-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
@@ -201,18 +199,21 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_29.zip'
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
-#      - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
-#      - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
+      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
+      # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
     softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_077_0-80002046.SAR'
-      - 'IMDB_LCAPPS_2077_3-80002183.SAR'
-      - 'IMDB_AFL20_077_0-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
@@ -247,8 +248,13 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_29.zip'
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
-#      - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
-#      - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
+      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
+      # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
 
   sap_s4hana_2022_standard:

--- a/deploy_scenarios/sap_landscape_s4hana_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard/ansible_playbook.yml
@@ -311,6 +311,9 @@
       loop: "{{ hostvars[sap_inventory_project_dev_nwas_pas_hostname].__sap_playbook_register_sap_hana_install_media_files.files | map(attribute='path') | list }}"
       loop_control:
         loop_var: file_item
+      # In some operating systems (e.g. SLES 16), the particular combination of RSYNC version and SSH configuration can cause issues.
+      # 'throttle: 1' prevents a 'Network is unreachable' errors during parallel execution.
+      throttle: 1
 
 
 - name: Ansible Play for copying SAP NetWeaver installation media to host
@@ -335,6 +338,9 @@
       loop: "{{ hostvars[sap_inventory_project_dev_nwas_pas_hostname].__sap_playbook_register_sap_nwas_install_media_files.files | map(attribute='path') | list }}"
       loop_control:
         loop_var: file_item
+      # In some operating systems (e.g. SLES 16), the particular combination of RSYNC version and SSH configuration can cause issues.
+      # 'throttle: 1' prevents a 'Network is unreachable' errors during parallel execution.
+      throttle: 1
 
 
 - name: Ansible Play to remove temporary files from SAP NetWeaver PAS

--- a/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_playbook.yml
@@ -312,6 +312,9 @@
       loop: "{{ hostvars[sap_inventory_project_dev_nwas_pas_hostname].__sap_playbook_register_sap_hana_install_media_files.files | map(attribute='path') | list }}"
       loop_control:
         loop_var: file_item
+      # In some operating systems (e.g. SLES 16), the particular combination of RSYNC version and SSH configuration can cause issues.
+      # 'throttle: 1' prevents a 'Network is unreachable' errors during parallel execution.
+      throttle: 1
 
 
 - name: Ansible Play for copying SAP NetWeaver installation media to host
@@ -336,6 +339,9 @@
       loop: "{{ hostvars[sap_inventory_project_dev_nwas_pas_hostname].__sap_playbook_register_sap_nwas_install_media_files.files | map(attribute='path') | list }}"
       loop_control:
         loop_var: file_item
+      # In some operating systems (e.g. SLES 16), the particular combination of RSYNC version and SSH configuration can cause issues.
+      # 'throttle: 1' prevents a 'Network is unreachable' errors during parallel execution.
+      throttle: 1
 
 
 - name: Ansible Play to remove temporary files from SAP NetWeaver PAS

--- a/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_extravars.yml
@@ -148,8 +148,8 @@ sap_software_install_dictionary:
 
     softwarecenter_search_list_x86_64:
       - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_085_0-80002031.SAR'  # Revision 2.00.085.0 (SPS08) for HANA DB 2.0
-      - 'IMDB_CLIENT20_024_24-80002082.SAR' # SAP HANA CLIENT Version 2.24
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
       # - 'VCH202300_2085_0-70007416.SAR'  # Not mandatory
       - 'SWPM10SP43_3-20009701.SAR'
       - 'igsexe_5-80007786.sar' # IGS 7.54
@@ -162,8 +162,8 @@ sap_software_install_dictionary:
 
     softwarecenter_search_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_085_0-80002046.SAR'  # Revision 2.00.085.0 (SPS08) for HANA DB 2.0
-      - 'IMDB_CLIENT20_024_24-80002095.SAR'  # SAP HANA CLIENT Version 2.24
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
       # - 'VCH202300_2085_0-70007417.SAR'  # Not mandatory
       - 'SWPM10SP43_3-70002492.SAR'
       - 'igsexe_5-80007795.sar' # IGS 7.54

--- a/deploy_scenarios/sap_nwas_abap_hana_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_nwas_abap_hana_sandbox/optional/ansible_extravars_interactive.yml
@@ -56,8 +56,8 @@ sap_software_install_dictionary:
 
     softwarecenter_search_list_x86_64:
       - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_085_0-80002031.SAR'  # Revision 2.00.085.0 (SPS08) for HANA DB 2.0
-      - 'IMDB_CLIENT20_024_24-80002082.SAR' # SAP HANA CLIENT Version 2.24
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
       # - 'VCH202300_2085_0-70007416.SAR'  # Not mandatory
       - 'SWPM10SP43_3-20009701.SAR'
       - 'igsexe_5-80007786.sar' # IGS 7.54
@@ -70,8 +70,8 @@ sap_software_install_dictionary:
 
     softwarecenter_search_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_085_0-80002046.SAR'  # Revision 2.00.085.0 (SPS08) for HANA DB 2.0
-      - 'IMDB_CLIENT20_024_24-80002095.SAR'  # SAP HANA CLIENT Version 2.24
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
       # - 'VCH202300_2085_0-70007417.SAR'  # Not mandatory
       - 'SWPM10SP43_3-70002492.SAR'
       - 'igsexe_5-80007795.sar' # IGS 7.54

--- a/deploy_scenarios/sap_s4hana_distributed/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_distributed/ansible_extravars.yml
@@ -135,14 +135,12 @@ sap_software_install_dictionary:
   sap_s4hana_2023_distributed:
 
     softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_077_0-80002031.SAR'
-      - 'IMDB_LCAPPS_2077_3-20010426.SAR'
-      - 'IMDB_AFL20_077_0-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
@@ -177,18 +175,21 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_29.zip'
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
-    #  - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
-    #  - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
+      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
+      # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
     softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_077_0-80002046.SAR'
-      - 'IMDB_LCAPPS_2077_3-80002183.SAR'
-      - 'IMDB_AFL20_077_0-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
@@ -223,8 +224,13 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_29.zip'
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
-    #  - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
-    #  - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
+      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
+      # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
     software_files_hana_wildcard_list:
       - 'SAPCAR*'

--- a/deploy_scenarios/sap_s4hana_distributed/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_distributed/optional/ansible_extravars_interactive.yml
@@ -41,14 +41,12 @@ sap_software_install_dictionary:
   sap_s4hana_2023_distributed:
 
     softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_077_0-80002031.SAR'
-      - 'IMDB_LCAPPS_2077_3-20010426.SAR'
-      - 'IMDB_AFL20_077_0-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
@@ -83,18 +81,21 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_29.zip'
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
-    #  - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
-    #  - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
+      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
+      # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
     softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_077_0-80002046.SAR'
-      - 'IMDB_LCAPPS_2077_3-80002183.SAR'
-      - 'IMDB_AFL20_077_0-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
@@ -129,8 +130,13 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_29.zip'
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
-    #  - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
-    #  - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
+      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
+      # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
     software_files_hana_wildcard_list:
       - 'SAPCAR*'

--- a/deploy_scenarios/sap_s4hana_distributed_ha/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/ansible_extravars.yml
@@ -180,14 +180,12 @@ sap_software_install_dictionary:
   sap_s4hana_2023_distributed:
 
     softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_077_0-80002031.SAR'
-      - 'IMDB_LCAPPS_2077_3-20010426.SAR'
-      - 'IMDB_AFL20_077_0-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
@@ -222,18 +220,21 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_29.zip'
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
-    #  - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
-    #  - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
+      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
+      # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
     softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_077_0-80002046.SAR'
-      - 'IMDB_LCAPPS_2077_3-80002183.SAR'
-      - 'IMDB_AFL20_077_0-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
@@ -268,8 +269,13 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_29.zip'
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
-    #  - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
-    #  - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
+      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
+      # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
     software_files_hana_wildcard_list:
       - 'SAPCAR*'

--- a/deploy_scenarios/sap_s4hana_distributed_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/ansible_playbook.yml
@@ -344,6 +344,9 @@
       loop: "{{ hostvars[software_source_hostname].__sap_playbook_register_sap_hana_install_media_files.files | map(attribute='path') | list }}"
       loop_control:
         loop_var: file_item
+      # In some operating systems (e.g. SLES 16), the particular combination of RSYNC version and SSH configuration can cause issues.
+      # 'throttle: 1' prevents a 'Network is unreachable' errors during parallel execution.
+      throttle: 1
       vars:
         software_source_hostname: "{{ hostvars[inventory_hostname].groups.nwas_pas[0] | d(none) }}"
         software_source_ip: "{{ hostvars[software_source_hostname].ansible_host | d(none) }}"
@@ -371,6 +374,9 @@
       loop: "{{ hostvars[software_source_hostname].__sap_playbook_register_sap_nwas_ascs_install_media_files.files | map(attribute='path') | list }}"
       loop_control:
         loop_var: file_item
+      # In some operating systems (e.g. SLES 16), the particular combination of RSYNC version and SSH configuration can cause issues.
+      # 'throttle: 1' prevents a 'Network is unreachable' errors during parallel execution.
+      throttle: 1
       vars:
         software_source_hostname: "{{ hostvars[inventory_hostname].groups.nwas_pas[0] | d(none) }}"
         software_source_ip: "{{ hostvars[software_source_hostname].ansible_host | d(none) }}"

--- a/deploy_scenarios/sap_s4hana_distributed_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/ansible_playbook.yml
@@ -526,6 +526,9 @@
 
         sap_ha_pacemaker_cluster_cluster_nodes: "{{ sap_hana_cluster_nodes }}"
 
+        # Ensures that conflicting packages are uninstalled before using SAP HANA Angi.
+        sap_ha_pacemaker_cluster_saphanasr_angi_force: true
+
 
 - name: Ansible Play for SAP NetWeaver Application Server installation - ABAP Central Services (ASCS) for HA
   hosts: nwas_ascs

--- a/deploy_scenarios/sap_s4hana_distributed_ha/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/optional/ansible_extravars_interactive.yml
@@ -45,14 +45,12 @@ sap_software_install_dictionary:
   sap_s4hana_2023_distributed:
 
     softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_077_0-80002031.SAR'
-      - 'IMDB_LCAPPS_2077_3-20010426.SAR'
-      - 'IMDB_AFL20_077_0-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
@@ -87,18 +85,21 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_29.zip'
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
-    #  - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
-    #  - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
+      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
+      # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
     softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_077_0-80002046.SAR'
-      - 'IMDB_LCAPPS_2077_3-80002183.SAR'
-      - 'IMDB_AFL20_077_0-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
@@ -133,8 +134,13 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_29.zip'
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
-    #  - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
-    #  - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
+      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
+      # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
     software_files_hana_wildcard_list:
       - 'SAPCAR*'

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_playbook.yml
@@ -345,6 +345,9 @@
       loop: "{{ hostvars[software_source_hostname].__sap_playbook_register_sap_hana_install_media_files.files | map(attribute='path') | list }}"
       loop_control:
         loop_var: file_item
+      # In some operating systems (e.g. SLES 16), the particular combination of RSYNC version and SSH configuration can cause issues.
+      # 'throttle: 1' prevents a 'Network is unreachable' errors during parallel execution.
+      throttle: 1
       vars:
         software_source_hostname: "{{ hostvars[inventory_hostname].groups.nwas_pas[0] | d(none) }}"
         software_source_ip: "{{ hostvars[software_source_hostname].ansible_host | d(none) }}"
@@ -372,6 +375,9 @@
       loop: "{{ hostvars[software_source_hostname].__sap_playbook_register_sap_nwas_ascs_install_media_files.files | map(attribute='path') | list }}"
       loop_control:
         loop_var: file_item
+      # In some operating systems (e.g. SLES 16), the particular combination of RSYNC version and SSH configuration can cause issues.
+      # 'throttle: 1' prevents a 'Network is unreachable' errors during parallel execution.
+      throttle: 1
       vars:
         software_source_hostname: "{{ hostvars[inventory_hostname].groups.nwas_pas[0] | d(none) }}"
         software_source_ip: "{{ hostvars[software_source_hostname].ansible_host | d(none) }}"

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_playbook.yml
@@ -527,6 +527,9 @@
 
         sap_ha_pacemaker_cluster_cluster_nodes: "{{ sap_hana_cluster_nodes }}"
 
+        # Ensures that conflicting packages are uninstalled before using SAP HANA Angi.
+        sap_ha_pacemaker_cluster_saphanasr_angi_force: true
+
 
 - name: Ansible Play for SAP NetWeaver Application Server installation - ABAP Central Services (ASCS) for HA
   hosts: nwas_ascs

--- a/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_extravars.yml
@@ -145,14 +145,12 @@ sap_software_install_dictionary:
       - sap_os_linux_user
 
     softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_077_0-80002031.SAR'
-      - 'IMDB_LCAPPS_2077_3-20010426.SAR'
-      - 'IMDB_AFL20_077_0-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
@@ -166,18 +164,21 @@ sap_software_install_dictionary:
       - 'S4FND108_INST_EXPORT_8.zip'
       - 'S4FND108_INST_EXPORT_9.zip'
       - 'S4FND108_NW_LANG_EN.SAR'
-    #  - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
-    #  - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
+      # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
     softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_077_0-80002046.SAR'
-      - 'IMDB_LCAPPS_2077_3-80002183.SAR'
-      - 'IMDB_AFL20_077_0-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
@@ -191,8 +192,13 @@ sap_software_install_dictionary:
       - 'S4FND108_INST_EXPORT_8.zip'
       - 'S4FND108_INST_EXPORT_9.zip'
       - 'S4FND108_NW_LANG_EN.SAR'
-    #  - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
-    #  - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
+      # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
 
   sap_s4hana_fndn_2022_sandbox:

--- a/deploy_scenarios/sap_s4hana_foundation_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_sandbox/optional/ansible_extravars_interactive.yml
@@ -53,14 +53,12 @@ sap_software_install_dictionary:
       - sap_os_linux_user
 
     softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_077_0-80002031.SAR'
-      - 'IMDB_LCAPPS_2077_3-20010426.SAR'
-      - 'IMDB_AFL20_077_0-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
@@ -74,18 +72,21 @@ sap_software_install_dictionary:
       - 'S4FND108_INST_EXPORT_8.zip'
       - 'S4FND108_INST_EXPORT_9.zip'
       - 'S4FND108_NW_LANG_EN.SAR'
-    #  - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
-    #  - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
+      # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
     softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_077_0-80002046.SAR'
-      - 'IMDB_LCAPPS_2077_3-80002183.SAR'
-      - 'IMDB_AFL20_077_0-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
@@ -99,8 +100,13 @@ sap_software_install_dictionary:
       - 'S4FND108_INST_EXPORT_8.zip'
       - 'S4FND108_INST_EXPORT_9.zip'
       - 'S4FND108_NW_LANG_EN.SAR'
-    #  - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
-    #  - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
+      # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
 
   sap_s4hana_fndn_2022_sandbox:

--- a/deploy_scenarios/sap_s4hana_foundation_standard/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_standard/ansible_extravars.yml
@@ -148,14 +148,12 @@ sap_software_install_dictionary:
       - sap_os_linux_user
 
     softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_077_0-80002031.SAR'
-      - 'IMDB_LCAPPS_2077_3-20010426.SAR'
-      - 'IMDB_AFL20_077_0-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
@@ -169,18 +167,21 @@ sap_software_install_dictionary:
       - 'S4FND108_INST_EXPORT_8.zip'
       - 'S4FND108_INST_EXPORT_9.zip'
       - 'S4FND108_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
     softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_077_0-80002046.SAR'
-      - 'IMDB_LCAPPS_2077_3-80002183.SAR'
-      - 'IMDB_AFL20_077_0-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
@@ -194,7 +195,12 @@ sap_software_install_dictionary:
       - 'S4FND108_INST_EXPORT_8.zip'
       - 'S4FND108_INST_EXPORT_9.zip'
       - 'S4FND108_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
       # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
     software_files_hana_wildcard_list:

--- a/deploy_scenarios/sap_s4hana_foundation_standard/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_standard/optional/ansible_extravars_interactive.yml
@@ -56,14 +56,12 @@ sap_software_install_dictionary:
       - sap_os_linux_user
 
     softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_077_0-80002031.SAR'
-      - 'IMDB_LCAPPS_2077_3-20010426.SAR'
-      - 'IMDB_AFL20_077_0-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
@@ -77,18 +75,21 @@ sap_software_install_dictionary:
       - 'S4FND108_INST_EXPORT_8.zip'
       - 'S4FND108_INST_EXPORT_9.zip'
       - 'S4FND108_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
     softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_077_0-80002046.SAR'
-      - 'IMDB_LCAPPS_2077_3-80002183.SAR'
-      - 'IMDB_AFL20_077_0-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
@@ -102,7 +103,12 @@ sap_software_install_dictionary:
       - 'S4FND108_INST_EXPORT_8.zip'
       - 'S4FND108_INST_EXPORT_9.zip'
       - 'S4FND108_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
       # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
     software_files_hana_wildcard_list:

--- a/deploy_scenarios/sap_s4hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox/ansible_extravars.yml
@@ -145,14 +145,12 @@ sap_software_install_dictionary:
       - sap_os_linux_user
 
     softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_077_0-80002031.SAR'
-      - 'IMDB_LCAPPS_2077_3-20010426.SAR'
-      - 'IMDB_AFL20_077_0-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
@@ -188,17 +186,20 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
     softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_077_0-80002046.SAR'
-      - 'IMDB_LCAPPS_2077_3-80002183.SAR'
-      - 'IMDB_AFL20_077_0-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
@@ -234,6 +235,11 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
       # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
 

--- a/deploy_scenarios/sap_s4hana_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox/optional/ansible_extravars_interactive.yml
@@ -53,14 +53,12 @@ sap_software_install_dictionary:
       - sap_os_linux_user
 
     softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_077_0-80002031.SAR'
-      - 'IMDB_LCAPPS_2077_3-20010426.SAR'
-      - 'IMDB_AFL20_077_0-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
@@ -96,17 +94,20 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
     softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_077_0-80002046.SAR'
-      - 'IMDB_LCAPPS_2077_3-80002183.SAR'
-      - 'IMDB_AFL20_077_0-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
@@ -142,6 +143,11 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
       # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
 

--- a/deploy_scenarios/sap_s4hana_sandbox_syscopy/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_syscopy/ansible_extravars.yml
@@ -157,14 +157,12 @@ sap_software_install_dictionary:
       - sap_os_linux_user
 
     softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_077_0-80002031.SAR'
-      - 'IMDB_LCAPPS_2077_3-20010426.SAR'
-      - 'IMDB_AFL20_077_0-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
@@ -200,17 +198,20 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
     softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_077_0-80002046.SAR'
-      - 'IMDB_LCAPPS_2077_3-80002183.SAR'
-      - 'IMDB_AFL20_077_0-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
@@ -246,6 +247,11 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
       # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
 

--- a/deploy_scenarios/sap_s4hana_sandbox_syscopy/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_syscopy/optional/ansible_extravars_interactive.yml
@@ -53,14 +53,12 @@ sap_software_install_dictionary:
       - sap_os_linux_user
 
     softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_077_0-80002031.SAR'
-      - 'IMDB_LCAPPS_2077_3-20010426.SAR'
-      - 'IMDB_AFL20_077_0-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
@@ -96,17 +94,20 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
     softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_077_0-80002046.SAR'
-      - 'IMDB_LCAPPS_2077_3-80002183.SAR'
-      - 'IMDB_AFL20_077_0-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
@@ -142,6 +143,11 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
       # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
 

--- a/deploy_scenarios/sap_s4hana_standard/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_standard/ansible_extravars.yml
@@ -148,14 +148,12 @@ sap_software_install_dictionary:
       - sap_os_linux_user
 
     softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_077_0-80002031.SAR'
-      - 'IMDB_LCAPPS_2077_3-20010426.SAR'
-      - 'IMDB_AFL20_077_0-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
@@ -191,17 +189,20 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
     softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_077_0-80002046.SAR'
-      - 'IMDB_LCAPPS_2077_3-80002183.SAR'
-      - 'IMDB_AFL20_077_0-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
@@ -237,6 +238,11 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
       # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
     software_files_hana_wildcard_list:

--- a/deploy_scenarios/sap_s4hana_standard/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_standard/optional/ansible_extravars_interactive.yml
@@ -56,14 +56,12 @@ sap_software_install_dictionary:
       - sap_os_linux_user
 
     softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_077_0-80002031.SAR'
-      - 'IMDB_LCAPPS_2077_3-20010426.SAR'
-      - 'IMDB_AFL20_077_0-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
@@ -99,17 +97,20 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
     softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
-      - 'IMDB_SERVER20_077_0-80002046.SAR'
-      - 'IMDB_LCAPPS_2077_3-80002183.SAR'
-      - 'IMDB_AFL20_077_0-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Database
+      - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
@@ -145,6 +146,11 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
       # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
     software_files_hana_wildcard_list:

--- a/deploy_scenarios/sap_solman_saphana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_solman_saphana_sandbox/ansible_extravars.yml
@@ -142,8 +142,8 @@ sap_software_install_dictionary:
       # EXP3, EXP4 (SAP:SOLMAN:SR27.2:DVD_EXPORT(2/2):SAP SOLUTION MANAGER 7.2 SR2 Installation Export DVD 2/2:Dxxxxxxxx_2)
       - '51054655_2'
       # - '51054655_3' # SAP Solution Manager 7.2 SR2 Language, ZIP. (SAP:SAP:SAP:MM:SAP:Dxxxxxxxx_3)
-      - 'IMDB_SERVER20_085_0-80002031.SAR'  # Revision 2.00.085.0 (SPS08) for HANA DB 2.0
-      - 'IMDB_CLIENT20_024_24-80002082.SAR' # SAP HANA CLIENT Version 2.24
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
       - 'SAPEXE_500-80007612.SAR'  # Kernel Part I (754)
       - 'SAPEXEDB_500-80007611.SAR'  # Kernel Part II (754)
       # JAVA specific
@@ -170,8 +170,8 @@ sap_software_install_dictionary:
       # EXP3, EXP4 (SAP:SOLMAN:SR27.2:DVD_EXPORT(2/2):SAP SOLUTION MANAGER 7.2 SR2 Installation Export DVD 2/2:Dxxxxxxxx_2)
       - '51054655_2'
       # - '51054655_3' # SAP Solution Manager 7.2 SR2 Language, ZIP. (SAP:SAP:SAP:MM:SAP:Dxxxxxxxx_3)
-      - 'IMDB_SERVER20_085_0-80002046.SAR'  # Revision 2.00.085.0 (SPS08) for HANA DB 2.0
-      - 'IMDB_CLIENT20_024_24-80002095.SAR'  # SAP HANA CLIENT Version 2.24
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
       - 'SAPEXE_500-80007669.SAR' # Kernel Part I (754)
       - 'SAPEXEDB_500-80007668.SAR' # Kernel Part II (754), SAP HANA
       # JAVA specific


### PR DESCRIPTION
## Changes
- Update SAP HANA versions to latest revision 79 and 89 for all products where HANA is used.
  - Validated with Maintenance Planner to verify that SAP offers latest HANA revisions even for older initial stacks.

- Remove limitation for `hana_primary` for Scale-Out, because my PR in `sap_hana_install` implemented correct processing with all nodes, not just primary.

- Add `throttle: 1` to all RSYNC tasks, where multiple hosts are targeted at same time.
  - REASON: SLES 16 and potentially other OS with newer RSYNC/SSH versions are showing behavior where `ansible.posix.synchronize` is handling RSYNC differently from native command, resulting in `Failed to connect to the host via ssh: ssh: connect to host 10.10.10.176 port 22: Network is unreachable'` when synchronizing to multiple targets.
  - ASCS/ERS will experience minimal slowness because they have only SAP Kernel files, which are small.
  - HANA will experience minimal slowness as synchronized HANA files are usually few GBs.
  - S4H Landscape playbooks will show slower synchronization as they are synchronizing all S4H files, not just database.
    NOTE: Parallel tasks are still taking all bandwidth so if it is redirected into one process, there should be similar results in total.

## Tests
Tests were executed on SLES_SAP 15 and 16 on AWS.
```
SLES 15 > 1x SLES 15 = OK
SLES 15 > 4x SLES 15 = OK
SLES 15 > 1x SLES 16 = OK
SLES 15 > 4x SLES 16 = OK

SLES 16 > 1x SLES 15 = OK
SLES 16 > 4x SLES 15 = OK
SLES 16 > 1x SLES 16 = OK
SLES 16 > 4x SLES 16 = FAIL > Fixed with throttle: 1
```