### PR TITLE
all: Add S4HANA and S4HANA FND 2025 software lists

### DIFF
--- a/deploy_scenarios/sap_landscape_s4hana_standard/ansible_extravars.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard/ansible_extravars.yml
@@ -18,7 +18,7 @@ sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
 ## SAP Product selection ##
 # Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_standard).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2025_standard).
 sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
@@ -112,6 +112,176 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
+
+  sap_s4hana_2025_standard:
+
+    # SWPM product catalog ID for the installation (String).
+    sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.CORE.HDB.ABAP
+
+    # List of INI file sections to generate using sap_install.sap_swpm role (List).
+    sap_swpm_inifile_sections_list:
+      - swpm_installation_media
+      - swpm_installation_media_swpm2_hana
+      - credentials
+      - credentials_hana
+      - db_config_hana
+      - db_connection_nw_hana
+      - nw_config_other
+      - nw_config_central_services_abap
+      - nw_config_primary_application_server_instance
+      - nw_config_ports
+      - nw_config_host_agent
+      - sap_os_linux_user
+
+    software_files_wildcard_list:
+      - 'SAPCAR*'
+      - 'IMDB_CLIENT*'
+      - 'SWPM20*'
+      - 'igsexe_*'
+      - 'igshelper_*'
+      - 'SAPEXE_*'
+      - 'SAPEXEDB_*'
+      - 'SUM*'
+      - 'SAPHOSTAGENT*'
+      - 'S4CORE*'
+      - 'S4HANAOP*'
+      - 'HANAUMML*'
+      - 'K-*'
+      - 'KD*'
+      - 'KE*'
+      - 'KIT*'
+      - 'SAPPAAPL*'
+      - 'SAP_BASIS*'
+
+    software_files_hana_wildcard_list:
+      - 'SAPCAR*'
+      - 'IMDB_*'
+      - 'SAPHOSTAGENT*'
+
+    softwarecenter_search_list_x86_64:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'SAPPAAPL4_2405_0-80004547.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
+      # Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007716.EXE'
+      - 'SWPM20SP23_2-80003424.SAR'
+      # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    softwarecenter_search_list_ppc64le:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
+      # Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007726.EXE'
+      - 'SWPM20SP23_2-80003426.SAR'
+      # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
 
   sap_s4hana_2023_standard:
 

--- a/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_extravars.yml
@@ -18,7 +18,7 @@ sap_vm_provision_host_specification_plan: "ENTER_STRING_VALUE_HERE"
 
 ## SAP Product selection ##
 # Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_standard).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2025_standard).
 sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
@@ -115,6 +115,72 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
+
+  sap_s4hana_2025_standard:
+
+    # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
+    softwarecenter_search_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
+
+    softwarecenter_search_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
+
+    software_files_hana_wildcard_list:
+      - 'SAPCAR*'
+      - 'IMDB_*'
+      - 'SAPHOSTAGENT*'
+
+    # SWPM product catalog ID for the installation (String).
+    sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.CORE.HDB.ABAP
+
+    # List of INI file sections to generate using sap_install.sap_swpm role (List).
+    sap_swpm_inifile_sections_list:
+      - swpm_installation_media
+      - swpm_installation_media_swpm2_hana
+      - credentials
+      - credentials_hana
+      - db_config_hana
+      - db_connection_nw_hana
+      - nw_config_other
+      - nw_config_central_services_abap
+      - nw_config_primary_application_server_instance
+      - nw_config_ports
+      - nw_config_host_agent
+      - sap_os_linux_user
+      - maintenance_plan_stack_tms_config
+      - maintenance_plan_stack_spam_config
+      - maintenance_plan_stack_sum_config
+
+    sap_swpm_inifile_dictionary:
+
+      # SAP SWPM using SAP Maintenance Planner Stack XML
+      # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
+      sap_swpm_configure_tms: true
+      sap_swpm_tmsadm_password: ''
+      sap_swpm_spam_update: false
+      sap_swpm_sum_prepare: true
+      sap_swpm_sum_start: true
+
+    software_files_wildcard_list:
+      - 'SAPCAR*'
+      - 'IMDB_CLIENT*'
+      - 'SWPM20*'
+      - 'igsexe_*'
+      - 'igshelper_*'
+      - 'SAPEXE_*'
+      - 'SAPEXEDB_*'
+      - 'SUM*'
+      - 'SAPHOSTAGENT*'
+      - 'S4CORE*'
+      - 'S4HANAOP*'
+      - 'HANAUMML*'
+      - 'K-*'
+      - 'KD*'
+      - 'KE*'
+      - 'KIT*'
+      - 'SAPPAAPL*'
+      - 'SAP_BASIS*'
+
 
   sap_s4hana_2023_standard:
 

--- a/deploy_scenarios/sap_s4hana_distributed/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_distributed/ansible_extravars.yml
@@ -23,7 +23,7 @@ sap_system_nwas_abap_aas_instance_nr: "11"  # SAP NetWeaver ABAP AAS instance nu
 
 ## SAP Product selection ##
 # Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_distributed).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2025_distributed).
 sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
@@ -131,6 +131,273 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
+
+  sap_s4hana_2025_distributed:
+
+    softwarecenter_search_list_x86_64:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'SAPPAAPL4_2405_0-80004547.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
+      # Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007716.EXE'
+      - 'SWPM20SP23_2-80003424.SAR'
+      # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    softwarecenter_search_list_ppc64le:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
+      # Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007726.EXE'
+      - 'SWPM20SP23_2-80003426.SAR'
+      # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    software_files_hana_wildcard_list:
+      - 'SAPCAR*'
+      - 'IMDB_*'
+      - 'SAPHOSTAGENT*'
+
+    nwas_ascs:
+
+      # SWPM product catalog ID for the installation (String).
+      sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2025.CORE.HDB.ABAP
+
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_other
+        - nw_config_central_services_abap
+        - nw_config_primary_application_server_instance
+        - nw_config_ports
+        - nw_config_host_agent
+        - sap_os_linux_user
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+
+    nwas_pas_dbload:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2025.CORE.HDB.ABAP
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_other
+        - nw_config_central_services_abap
+        - nw_config_primary_application_server_instance
+        - nw_config_ports
+        - nw_config_host_agent
+        - sap_os_linux_user
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+        - 'S4CORE*'
+        - 'S4HANAOP*'
+        - 'HANAUMML*'
+        - 'K-*'
+        - 'KD*'
+        - 'KE*'
+        - 'KIT*'
+        - 'SAPPAAPL*'
+        - 'SAP_BASIS*'
+
+    nwas_pas:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2025.CORE.HDB.ABAP
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_other
+        - nw_config_central_services_abap
+        - nw_config_primary_application_server_instance
+        - nw_config_ports
+        - nw_config_host_agent
+        - sap_os_linux_user
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+
+    nwas_aas:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_DI:S4HANA2025.CORE.HDB.PD
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_ports
+        - nw_config_other
+        - nw_config_additional_application_server_instance
+        - nw_config_host_agent
+        - sap_os_linux_user
+
+      sap_swpm_inifile_dictionary:
+
+        # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
+        sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
+        sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+
 
   sap_s4hana_2023_distributed:
 

--- a/deploy_scenarios/sap_s4hana_distributed/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_distributed/optional/ansible_extravars_interactive.yml
@@ -38,6 +38,273 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
 
+  sap_s4hana_2025_distributed:
+
+    softwarecenter_search_list_x86_64:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'SAPPAAPL4_2405_0-80004547.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
+      # Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007716.EXE'
+      - 'SWPM20SP23_2-80003424.SAR'
+      # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    softwarecenter_search_list_ppc64le:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
+      # Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007726.EXE'
+      - 'SWPM20SP23_2-80003426.SAR'
+      # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    software_files_hana_wildcard_list:
+      - 'SAPCAR*'
+      - 'IMDB_*'
+      - 'SAPHOSTAGENT*'
+
+    nwas_ascs:
+
+      # SWPM product catalog ID for the installation (String).
+      sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2025.CORE.HDB.ABAP
+
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_other
+        - nw_config_central_services_abap
+        - nw_config_primary_application_server_instance
+        - nw_config_ports
+        - nw_config_host_agent
+        - sap_os_linux_user
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+
+    nwas_pas_dbload:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2025.CORE.HDB.ABAP
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_other
+        - nw_config_central_services_abap
+        - nw_config_primary_application_server_instance
+        - nw_config_ports
+        - nw_config_host_agent
+        - sap_os_linux_user
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+        - 'S4CORE*'
+        - 'S4HANAOP*'
+        - 'HANAUMML*'
+        - 'K-*'
+        - 'KD*'
+        - 'KE*'
+        - 'KIT*'
+        - 'SAPPAAPL*'
+        - 'SAP_BASIS*'
+
+    nwas_pas:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2025.CORE.HDB.ABAP
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_other
+        - nw_config_central_services_abap
+        - nw_config_primary_application_server_instance
+        - nw_config_ports
+        - nw_config_host_agent
+        - sap_os_linux_user
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+
+    nwas_aas:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_DI:S4HANA2025.CORE.HDB.PD
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_ports
+        - nw_config_other
+        - nw_config_additional_application_server_instance
+        - nw_config_host_agent
+        - sap_os_linux_user
+
+      sap_swpm_inifile_dictionary:
+
+        # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
+        sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
+        sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+
+
   sap_s4hana_2023_distributed:
 
     softwarecenter_search_list_x86_64:

--- a/deploy_scenarios/sap_s4hana_distributed_ha/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/ansible_extravars.yml
@@ -24,7 +24,7 @@ sap_system_nwas_abap_aas_instance_nr: "11"  # SAP NetWeaver ABAP AAS instance nu
 
 ## SAP Product selection ##
 # Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_distributed).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2025_distributed).
 sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
@@ -176,6 +176,299 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
+
+  sap_s4hana_2025_distributed:
+
+    softwarecenter_search_list_x86_64:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'SAPPAAPL4_2405_0-80004547.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
+      # Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007716.EXE'
+      - 'SWPM20SP23_2-80003424.SAR'
+      # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    softwarecenter_search_list_ppc64le:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
+      # Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007726.EXE'
+      - 'SWPM20SP23_2-80003426.SAR'
+      # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    software_files_hana_wildcard_list:
+      - 'SAPCAR*'
+      - 'IMDB_*'
+      - 'SAPHOSTAGENT*'
+
+    nwas_ascs_ha:
+
+      # SWPM product catalog ID for the installation (String).
+      sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2025.CORE.HDB.ABAPHA
+
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_other
+        - nw_config_central_services_abap
+        - nw_config_primary_application_server_instance
+        - nw_config_ports
+        - nw_config_host_agent
+        - sap_os_linux_user
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+
+    nwas_ers_ha:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_ERS:S4HANA2025.CORE.HDB.ABAPHA
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - credentials
+        - nw_config_other
+        - nw_config_ers
+        - sap_os_linux_user
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+
+    nwas_pas_dbload_ha:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2025.CORE.HDB.ABAPHA
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_other
+        - nw_config_central_services_abap
+        - nw_config_primary_application_server_instance
+        - nw_config_ports
+        - nw_config_host_agent
+        - sap_os_linux_user
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+        - 'S4CORE*'
+        - 'S4HANAOP*'
+        - 'HANAUMML*'
+        - 'K-*'
+        - 'KD*'
+        - 'KE*'
+        - 'KIT*'
+        - 'SAPPAAPL*'
+        - 'SAP_BASIS*'
+
+    nwas_pas:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2025.CORE.HDB.ABAP
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_other
+        - nw_config_central_services_abap
+        - nw_config_primary_application_server_instance
+        - nw_config_ports
+        - nw_config_host_agent
+        - sap_os_linux_user
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+
+    nwas_aas:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_DI:S4HANA2025.CORE.HDB.PD
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_ports
+        - nw_config_other
+        - nw_config_additional_application_server_instance
+        - nw_config_host_agent
+        - sap_os_linux_user
+
+      sap_swpm_inifile_dictionary:
+
+        # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
+        sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
+        sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
+
+        # SAP Host Agent
+        sap_swpm_install_saphostagent: true
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+
 
   sap_s4hana_2023_distributed:
 

--- a/deploy_scenarios/sap_s4hana_distributed_ha/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/optional/ansible_extravars_interactive.yml
@@ -42,6 +42,299 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
 
+  sap_s4hana_2025_distributed:
+
+    softwarecenter_search_list_x86_64:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'SAPPAAPL4_2405_0-80004547.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
+      # Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007716.EXE'
+      - 'SWPM20SP23_2-80003424.SAR'
+      # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    softwarecenter_search_list_ppc64le:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
+      # Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007726.EXE'
+      - 'SWPM20SP23_2-80003426.SAR'
+      # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    software_files_hana_wildcard_list:
+      - 'SAPCAR*'
+      - 'IMDB_*'
+      - 'SAPHOSTAGENT*'
+
+    nwas_ascs_ha:
+
+      # SWPM product catalog ID for the installation (String).
+      sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2025.CORE.HDB.ABAPHA
+
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_other
+        - nw_config_central_services_abap
+        - nw_config_primary_application_server_instance
+        - nw_config_ports
+        - nw_config_host_agent
+        - sap_os_linux_user
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+
+    nwas_ers_ha:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_ERS:S4HANA2025.CORE.HDB.ABAPHA
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - credentials
+        - nw_config_other
+        - nw_config_ers
+        - sap_os_linux_user
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+
+    nwas_pas_dbload_ha:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2025.CORE.HDB.ABAPHA
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_other
+        - nw_config_central_services_abap
+        - nw_config_primary_application_server_instance
+        - nw_config_ports
+        - nw_config_host_agent
+        - sap_os_linux_user
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+        - 'S4CORE*'
+        - 'S4HANAOP*'
+        - 'HANAUMML*'
+        - 'K-*'
+        - 'KD*'
+        - 'KE*'
+        - 'KIT*'
+        - 'SAPPAAPL*'
+        - 'SAP_BASIS*'
+
+    nwas_pas:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2025.CORE.HDB.ABAP
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_other
+        - nw_config_central_services_abap
+        - nw_config_primary_application_server_instance
+        - nw_config_ports
+        - nw_config_host_agent
+        - sap_os_linux_user
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+
+    nwas_aas:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_DI:S4HANA2025.CORE.HDB.PD
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_ports
+        - nw_config_other
+        - nw_config_additional_application_server_instance
+        - nw_config_host_agent
+        - sap_os_linux_user
+
+      sap_swpm_inifile_dictionary:
+
+        # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
+        sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
+        sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
+
+        # SAP Host Agent
+        sap_swpm_install_saphostagent: true
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+
+
   sap_s4hana_2023_distributed:
 
     softwarecenter_search_list_x86_64:

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_extravars.yml
@@ -24,7 +24,7 @@ sap_system_nwas_abap_aas_instance_nr: "11"  # SAP NetWeaver ABAP AAS instance nu
 
 ## SAP Product selection ##
 # Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_distributed).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2025_distributed).
 sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
@@ -179,6 +179,232 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
+
+  sap_s4hana_2025_distributed:
+
+    # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
+    softwarecenter_search_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
+
+    softwarecenter_search_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
+
+    software_files_hana_wildcard_list:
+      - 'SAPCAR*'
+      - 'IMDB_*'
+      - 'SAPHOSTAGENT*'
+
+    nwas_ascs_ha:
+
+      # SWPM product catalog ID for the installation (String).
+      sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2025.CORE.HDB.ABAPHA
+
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_other
+        - nw_config_central_services_abap
+        - nw_config_primary_application_server_instance
+        - nw_config_ports
+        - nw_config_host_agent
+        - sap_os_linux_user
+        - maintenance_plan_stack_tms_config
+        - maintenance_plan_stack_spam_config
+        - maintenance_plan_stack_sum_config
+
+      sap_swpm_inifile_dictionary:
+
+        # SAP SWPM using SAP Maintenance Planner Stack XML
+        # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
+        sap_swpm_configure_tms: true
+        sap_swpm_tmsadm_password: ''
+        sap_swpm_spam_update: false
+        sap_swpm_sum_prepare: true
+        sap_swpm_sum_start: true
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+        - 'MP_*.xml'
+
+    nwas_ers_ha:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_ERS:S4HANA2025.CORE.HDB.ABAPHA
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - credentials
+        - nw_config_other
+        - nw_config_ers
+        - sap_os_linux_user
+
+      sap_swpm_inifile_dictionary:
+
+        # SAP SWPM using SAP Maintenance Planner Stack XML
+        # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
+        sap_swpm_configure_tms: true
+        sap_swpm_tmsadm_password: ''
+        sap_swpm_spam_update: false
+        sap_swpm_sum_prepare: true
+        sap_swpm_sum_start: true
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+        - 'MP_*.xml'
+
+    nwas_pas_dbload_ha:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2025.CORE.HDB.ABAPHA
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_other
+        - nw_config_central_services_abap
+        - nw_config_primary_application_server_instance
+        - nw_config_ports
+        - nw_config_host_agent
+        - sap_os_linux_user
+        - maintenance_plan_stack_tms_config
+        - maintenance_plan_stack_spam_config
+        - maintenance_plan_stack_sum_config
+
+      sap_swpm_inifile_dictionary:
+
+        # SAP SWPM using SAP Maintenance Planner Stack XML
+        # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
+        sap_swpm_configure_tms: true
+        sap_swpm_tmsadm_password: ''
+        sap_swpm_spam_update: false
+        sap_swpm_sum_prepare: true
+        sap_swpm_sum_start: true
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+        - 'S4CORE*'
+        - 'S4HANAOP*'
+        - 'HANAUMML*'
+        - 'K-*'
+        - 'KD*'
+        - 'KE*'
+        - 'KIT*'
+        - 'SAPPAAPL*'
+        - 'SAP_BASIS*'
+        - 'MP_*.xml'
+
+    nwas_pas:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2025.CORE.HDB.ABAP
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_other
+        - nw_config_central_services_abap
+        - nw_config_primary_application_server_instance
+        - nw_config_ports
+        - nw_config_host_agent
+        - sap_os_linux_user
+        - maintenance_plan_stack_tms_config
+        - maintenance_plan_stack_spam_config
+        - maintenance_plan_stack_sum_config
+
+      sap_swpm_inifile_dictionary:
+
+        # SAP SWPM using SAP Maintenance Planner Stack XML
+        # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
+        sap_swpm_configure_tms: true
+        sap_swpm_tmsadm_password: ''
+        sap_swpm_spam_update: false
+        sap_swpm_sum_prepare: true
+        sap_swpm_sum_start: true
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+        - 'MP_*.xml'
+
+    nwas_aas:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_DI:S4HANA2025.CORE.HDB.PD
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_ports
+        - nw_config_other
+        - nw_config_additional_application_server_instance
+        - nw_config_host_agent
+        - sap_os_linux_user
+
+      sap_swpm_inifile_dictionary:
+
+        # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
+        sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
+        sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+
 
   sap_s4hana_2023_distributed:
 

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/optional/ansible_extravars_interactive.yml
@@ -48,6 +48,232 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
 
+  sap_s4hana_2025_distributed:
+
+    # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
+    softwarecenter_search_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
+
+    softwarecenter_search_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
+
+    software_files_hana_wildcard_list:
+      - 'SAPCAR*'
+      - 'IMDB_*'
+      - 'SAPHOSTAGENT*'
+
+    nwas_ascs_ha:
+
+      # SWPM product catalog ID for the installation (String).
+      sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2025.CORE.HDB.ABAPHA
+
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_other
+        - nw_config_central_services_abap
+        - nw_config_primary_application_server_instance
+        - nw_config_ports
+        - nw_config_host_agent
+        - sap_os_linux_user
+        - maintenance_plan_stack_tms_config
+        - maintenance_plan_stack_spam_config
+        - maintenance_plan_stack_sum_config
+
+      sap_swpm_inifile_dictionary:
+
+        # SAP SWPM using SAP Maintenance Planner Stack XML
+        # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
+        sap_swpm_configure_tms: true
+        sap_swpm_tmsadm_password: ''
+        sap_swpm_spam_update: false
+        sap_swpm_sum_prepare: true
+        sap_swpm_sum_start: true
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+        - 'MP_*.xml'
+
+    nwas_ers_ha:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_ERS:S4HANA2025.CORE.HDB.ABAPHA
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - credentials
+        - nw_config_other
+        - nw_config_ers
+        - sap_os_linux_user
+
+      sap_swpm_inifile_dictionary:
+
+        # SAP SWPM using SAP Maintenance Planner Stack XML
+        # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
+        sap_swpm_configure_tms: true
+        sap_swpm_tmsadm_password: ''
+        sap_swpm_spam_update: false
+        sap_swpm_sum_prepare: true
+        sap_swpm_sum_start: true
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+        - 'MP_*.xml'
+
+    nwas_pas_dbload_ha:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2025.CORE.HDB.ABAPHA
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_other
+        - nw_config_central_services_abap
+        - nw_config_primary_application_server_instance
+        - nw_config_ports
+        - nw_config_host_agent
+        - sap_os_linux_user
+        - maintenance_plan_stack_tms_config
+        - maintenance_plan_stack_spam_config
+        - maintenance_plan_stack_sum_config
+
+      sap_swpm_inifile_dictionary:
+
+        # SAP SWPM using SAP Maintenance Planner Stack XML
+        # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
+        sap_swpm_configure_tms: true
+        sap_swpm_tmsadm_password: ''
+        sap_swpm_spam_update: false
+        sap_swpm_sum_prepare: true
+        sap_swpm_sum_start: true
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+        - 'S4CORE*'
+        - 'S4HANAOP*'
+        - 'HANAUMML*'
+        - 'K-*'
+        - 'KD*'
+        - 'KE*'
+        - 'KIT*'
+        - 'SAPPAAPL*'
+        - 'SAP_BASIS*'
+        - 'MP_*.xml'
+
+    nwas_pas:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2025.CORE.HDB.ABAP
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_other
+        - nw_config_central_services_abap
+        - nw_config_primary_application_server_instance
+        - nw_config_ports
+        - nw_config_host_agent
+        - sap_os_linux_user
+        - maintenance_plan_stack_tms_config
+        - maintenance_plan_stack_spam_config
+        - maintenance_plan_stack_sum_config
+
+      sap_swpm_inifile_dictionary:
+
+        # SAP SWPM using SAP Maintenance Planner Stack XML
+        # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
+        sap_swpm_configure_tms: true
+        sap_swpm_tmsadm_password: ''
+        sap_swpm_spam_update: false
+        sap_swpm_sum_prepare: true
+        sap_swpm_sum_start: true
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+        - 'MP_*.xml'
+
+    nwas_aas:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_DI:S4HANA2025.CORE.HDB.PD
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_ports
+        - nw_config_other
+        - nw_config_additional_application_server_instance
+        - nw_config_host_agent
+        - sap_os_linux_user
+
+      sap_swpm_inifile_dictionary:
+
+        # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
+        sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
+        sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+
+
   sap_s4hana_2023_distributed:
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list

--- a/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_extravars.yml
@@ -23,7 +23,7 @@ sap_system_nwas_abap_aas_instance_nr: "11"  # SAP NetWeaver ABAP AAS instance nu
 
 ## SAP Product selection ##
 # Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_distributed).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2025_distributed).
 sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
@@ -134,6 +134,186 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
+
+  sap_s4hana_2025_distributed:
+
+    # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
+    softwarecenter_search_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
+
+    softwarecenter_search_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
+
+    software_files_hana_wildcard_list:
+      - 'SAPCAR*'
+      - 'IMDB_*'
+      - 'SAPHOSTAGENT*'
+
+    nwas_ascs:
+
+        # SWPM product catalog ID for the installation (String).
+      sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2025.CORE.HDB.ABAP
+
+        # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_other
+        - nw_config_central_services_abap
+        - nw_config_primary_application_server_instance
+        - nw_config_ports
+        - nw_config_host_agent
+        - sap_os_linux_user
+
+      sap_swpm_inifile_dictionary:
+
+        # SAP SWPM using SAP Maintenance Planner Stack XML
+        # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
+        sap_swpm_configure_tms: true
+        sap_swpm_tmsadm_password: ''
+        sap_swpm_spam_update: false
+        sap_swpm_sum_prepare: true
+        sap_swpm_sum_start: true
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+
+    nwas_pas_dbload:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2025.CORE.HDB.ABAP
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_other
+        - nw_config_central_services_abap
+        - nw_config_primary_application_server_instance
+        - nw_config_ports
+        - nw_config_host_agent
+        - sap_os_linux_user
+
+      sap_swpm_inifile_dictionary:
+
+        # SAP SWPM using SAP Maintenance Planner Stack XML
+        # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
+        sap_swpm_configure_tms: true
+        sap_swpm_tmsadm_password: ''
+        sap_swpm_spam_update: false
+        sap_swpm_sum_prepare: true
+        sap_swpm_sum_start: true
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+        - 'S4CORE*'
+        - 'S4HANAOP*'
+        - 'HANAUMML*'
+        - 'K-*'
+        - 'KD*'
+        - 'KE*'
+        - 'KIT*'
+        - 'SAPPAAPL*'
+        - 'SAP_BASIS*'
+
+    nwas_pas:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2025.CORE.HDB.ABAP
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_other
+        - nw_config_central_services_abap
+        - nw_config_primary_application_server_instance
+        - nw_config_ports
+        - nw_config_host_agent
+        - sap_os_linux_user
+
+      sap_swpm_inifile_dictionary:
+
+        # SAP SWPM using SAP Maintenance Planner Stack XML
+        # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
+        sap_swpm_configure_tms: true
+        sap_swpm_tmsadm_password: ''
+        sap_swpm_spam_update: false
+        sap_swpm_sum_prepare: true
+        sap_swpm_sum_start: true
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+
+    nwas_aas:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_DI:S4HANA2025.CORE.HDB.PD
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_ports
+        - nw_config_other
+        - nw_config_additional_application_server_instance
+        - nw_config_host_agent
+        - sap_os_linux_user
+
+      sap_swpm_inifile_dictionary:
+
+        # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
+        sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
+        sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+
 
   sap_s4hana_2023_distributed:
 

--- a/deploy_scenarios/sap_s4hana_distributed_maintplan/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_maintplan/optional/ansible_extravars_interactive.yml
@@ -44,6 +44,186 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
 
+  sap_s4hana_2025_distributed:
+
+    # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
+    softwarecenter_search_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
+
+    softwarecenter_search_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
+
+    software_files_hana_wildcard_list:
+      - 'SAPCAR*'
+      - 'IMDB_*'
+      - 'SAPHOSTAGENT*'
+
+    nwas_ascs:
+
+        # SWPM product catalog ID for the installation (String).
+      sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2025.CORE.HDB.ABAP
+
+        # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_other
+        - nw_config_central_services_abap
+        - nw_config_primary_application_server_instance
+        - nw_config_ports
+        - nw_config_host_agent
+        - sap_os_linux_user
+
+      sap_swpm_inifile_dictionary:
+
+        # SAP SWPM using SAP Maintenance Planner Stack XML
+        # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
+        sap_swpm_configure_tms: true
+        sap_swpm_tmsadm_password: ''
+        sap_swpm_spam_update: false
+        sap_swpm_sum_prepare: true
+        sap_swpm_sum_start: true
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+
+    nwas_pas_dbload:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2025.CORE.HDB.ABAP
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_other
+        - nw_config_central_services_abap
+        - nw_config_primary_application_server_instance
+        - nw_config_ports
+        - nw_config_host_agent
+        - sap_os_linux_user
+
+      sap_swpm_inifile_dictionary:
+
+        # SAP SWPM using SAP Maintenance Planner Stack XML
+        # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
+        sap_swpm_configure_tms: true
+        sap_swpm_tmsadm_password: ''
+        sap_swpm_spam_update: false
+        sap_swpm_sum_prepare: true
+        sap_swpm_sum_start: true
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+        - 'S4CORE*'
+        - 'S4HANAOP*'
+        - 'HANAUMML*'
+        - 'K-*'
+        - 'KD*'
+        - 'KE*'
+        - 'KIT*'
+        - 'SAPPAAPL*'
+        - 'SAP_BASIS*'
+
+    nwas_pas:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2025.CORE.HDB.ABAP
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_other
+        - nw_config_central_services_abap
+        - nw_config_primary_application_server_instance
+        - nw_config_ports
+        - nw_config_host_agent
+        - sap_os_linux_user
+
+      sap_swpm_inifile_dictionary:
+
+        # SAP SWPM using SAP Maintenance Planner Stack XML
+        # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
+        sap_swpm_configure_tms: true
+        sap_swpm_tmsadm_password: ''
+        sap_swpm_spam_update: false
+        sap_swpm_sum_prepare: true
+        sap_swpm_sum_start: true
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+
+    nwas_aas:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_DI:S4HANA2025.CORE.HDB.PD
+
+      sap_swpm_inifile_sections_list:
+        - swpm_installation_media
+        - swpm_installation_media_swpm2_hana
+        - credentials
+        - credentials_hana
+        - db_config_hana
+        - db_connection_nw_hana
+        - nw_config_ports
+        - nw_config_other
+        - nw_config_additional_application_server_instance
+        - nw_config_host_agent
+        - sap_os_linux_user
+
+      sap_swpm_inifile_dictionary:
+
+        # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
+        sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
+        sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
+
+      software_files_wildcard_list:
+        - 'SAPCAR*'
+        - 'IMDB_CLIENT*'
+        - 'SWPM20*'
+        - 'igsexe_*'
+        - 'igshelper_*'
+        - 'SAPEXE_*'
+        - 'SAPEXEDB_*'
+        - 'SUM*'
+        - 'SAPHOSTAGENT*'
+
+
   sap_s4hana_2023_distributed:
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list

--- a/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_extravars.yml
@@ -22,7 +22,7 @@ sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance nu
 
 ## SAP Product selection ##
 # Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_fndn_2023_sandbox).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_fndn_2025_sandbox).
 sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
@@ -123,6 +123,96 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
+
+  sap_s4hana_fndn_2025_sandbox:
+
+    # SWPM product catalog ID for the installation (String).
+    sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.FNDN.HDB.ABAP
+
+    # List of INI file sections to generate using sap_install.sap_swpm role (List).
+    sap_swpm_inifile_sections_list:
+      - swpm_installation_media
+      - swpm_installation_media_swpm2_hana
+      - credentials
+      - credentials_hana
+      - db_config_hana
+      - db_connection_nw_hana
+      - nw_config_other
+      - nw_config_central_services_abap
+      - nw_config_primary_application_server_instance
+      - nw_config_ports
+      - nw_config_host_agent
+      - sap_os_linux_user
+
+    softwarecenter_search_list_x86_64:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
+      # Media
+      - 'S4FND109_INST_EXPORT_1.zip'
+      - 'S4FND109_INST_EXPORT_2.zip'
+      - 'S4FND109_INST_EXPORT_3.zip'
+      - 'S4FND109_INST_EXPORT_4.zip'
+      - 'S4FND109_INST_EXPORT_5.zip'
+      - 'S4FND109_INST_EXPORT_6.zip'
+      - 'S4FND109_INST_EXPORT_7.zip'
+      - 'S4FND109_INST_EXPORT_8.zip'
+      - 'S4FND109_INST_EXPORT_9.zip'
+      - 'S4FND109_INST_EXPORT_10.zip'
+      - 'S4FND109_NW_LANG_EN.SAR'
+      - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007716.EXE'
+      - 'SWPM20SP23_2-80003424.SAR'
+      # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+
+    softwarecenter_search_list_ppc64le:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
+      # Media
+      - 'S4FND109_INST_EXPORT_1.zip'
+      - 'S4FND109_INST_EXPORT_2.zip'
+      - 'S4FND109_INST_EXPORT_3.zip'
+      - 'S4FND109_INST_EXPORT_4.zip'
+      - 'S4FND109_INST_EXPORT_5.zip'
+      - 'S4FND109_INST_EXPORT_6.zip'
+      - 'S4FND109_INST_EXPORT_7.zip'
+      - 'S4FND109_INST_EXPORT_8.zip'
+      - 'S4FND109_INST_EXPORT_9.zip'
+      - 'S4FND109_INST_EXPORT_10.zip'
+      - 'S4FND109_NW_LANG_EN.SAR'
+      - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007726.EXE'
+      - 'SWPM20SP23_2-80003426.SAR'
+      # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+
 
   sap_s4hana_fndn_2023_sandbox:
 

--- a/deploy_scenarios/sap_s4hana_foundation_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_sandbox/optional/ansible_extravars_interactive.yml
@@ -32,6 +32,96 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
 
+  sap_s4hana_fndn_2025_sandbox:
+
+    # SWPM product catalog ID for the installation (String).
+    sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.FNDN.HDB.ABAP
+
+    # List of INI file sections to generate using sap_install.sap_swpm role (List).
+    sap_swpm_inifile_sections_list:
+      - swpm_installation_media
+      - swpm_installation_media_swpm2_hana
+      - credentials
+      - credentials_hana
+      - db_config_hana
+      - db_connection_nw_hana
+      - nw_config_other
+      - nw_config_central_services_abap
+      - nw_config_primary_application_server_instance
+      - nw_config_ports
+      - nw_config_host_agent
+      - sap_os_linux_user
+
+    softwarecenter_search_list_x86_64:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
+      # Media
+      - 'S4FND109_INST_EXPORT_1.zip'
+      - 'S4FND109_INST_EXPORT_2.zip'
+      - 'S4FND109_INST_EXPORT_3.zip'
+      - 'S4FND109_INST_EXPORT_4.zip'
+      - 'S4FND109_INST_EXPORT_5.zip'
+      - 'S4FND109_INST_EXPORT_6.zip'
+      - 'S4FND109_INST_EXPORT_7.zip'
+      - 'S4FND109_INST_EXPORT_8.zip'
+      - 'S4FND109_INST_EXPORT_9.zip'
+      - 'S4FND109_INST_EXPORT_10.zip'
+      - 'S4FND109_NW_LANG_EN.SAR'
+      - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007716.EXE'
+      - 'SWPM20SP23_2-80003424.SAR'
+      # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+
+    softwarecenter_search_list_ppc64le:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
+      # Media
+      - 'S4FND109_INST_EXPORT_1.zip'
+      - 'S4FND109_INST_EXPORT_2.zip'
+      - 'S4FND109_INST_EXPORT_3.zip'
+      - 'S4FND109_INST_EXPORT_4.zip'
+      - 'S4FND109_INST_EXPORT_5.zip'
+      - 'S4FND109_INST_EXPORT_6.zip'
+      - 'S4FND109_INST_EXPORT_7.zip'
+      - 'S4FND109_INST_EXPORT_8.zip'
+      - 'S4FND109_INST_EXPORT_9.zip'
+      - 'S4FND109_INST_EXPORT_10.zip'
+      - 'S4FND109_NW_LANG_EN.SAR'
+      - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007726.EXE'
+      - 'SWPM20SP23_2-80003426.SAR'
+      # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+
+
   sap_s4hana_fndn_2023_sandbox:
 
     # SWPM product catalog ID for the installation (String).

--- a/deploy_scenarios/sap_s4hana_foundation_standard/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_standard/ansible_extravars.yml
@@ -22,7 +22,7 @@ sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance nu
 
 ## SAP Product selection ##
 # Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_fndn_2023_standard).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_fndn_2025_standard).
 sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
@@ -126,6 +126,101 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
+
+  sap_s4hana_fndn_2025_standard:
+
+    # SWPM product catalog ID for the installation (String).
+    sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.FNDN.HDB.ABAP
+
+    # List of INI file sections to generate using sap_install.sap_swpm role (List).
+    sap_swpm_inifile_sections_list:
+      - swpm_installation_media
+      - swpm_installation_media_swpm2_hana
+      - credentials
+      - credentials_hana
+      - db_config_hana
+      - db_connection_nw_hana
+      - nw_config_other
+      - nw_config_central_services_abap
+      - nw_config_primary_application_server_instance
+      - nw_config_ports
+      - nw_config_host_agent
+      - sap_os_linux_user
+
+    softwarecenter_search_list_x86_64:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
+      # Media
+      - 'S4FND109_INST_EXPORT_1.zip'
+      - 'S4FND109_INST_EXPORT_2.zip'
+      - 'S4FND109_INST_EXPORT_3.zip'
+      - 'S4FND109_INST_EXPORT_4.zip'
+      - 'S4FND109_INST_EXPORT_5.zip'
+      - 'S4FND109_INST_EXPORT_6.zip'
+      - 'S4FND109_INST_EXPORT_7.zip'
+      - 'S4FND109_INST_EXPORT_8.zip'
+      - 'S4FND109_INST_EXPORT_9.zip'
+      - 'S4FND109_INST_EXPORT_10.zip'
+      - 'S4FND109_NW_LANG_EN.SAR'
+      - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007716.EXE'
+      - 'SWPM20SP23_2-80003424.SAR'
+      # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+
+    softwarecenter_search_list_ppc64le:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
+      # Media
+      - 'S4FND109_INST_EXPORT_1.zip'
+      - 'S4FND109_INST_EXPORT_2.zip'
+      - 'S4FND109_INST_EXPORT_3.zip'
+      - 'S4FND109_INST_EXPORT_4.zip'
+      - 'S4FND109_INST_EXPORT_5.zip'
+      - 'S4FND109_INST_EXPORT_6.zip'
+      - 'S4FND109_INST_EXPORT_7.zip'
+      - 'S4FND109_INST_EXPORT_8.zip'
+      - 'S4FND109_INST_EXPORT_9.zip'
+      - 'S4FND109_INST_EXPORT_10.zip'
+      - 'S4FND109_NW_LANG_EN.SAR'
+      - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007726.EXE'
+      - 'SWPM20SP23_2-80003426.SAR'
+      # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+
+    software_files_hana_wildcard_list:
+      - 'SAPCAR*'
+      - 'IMDB_*'
+      - 'SAPHOSTAGENT*'
+
 
   sap_s4hana_fndn_2023_standard:
 

--- a/deploy_scenarios/sap_s4hana_foundation_standard/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_standard/optional/ansible_extravars_interactive.yml
@@ -35,6 +35,101 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
 
+  sap_s4hana_fndn_2025_standard:
+
+    # SWPM product catalog ID for the installation (String).
+    sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.FNDN.HDB.ABAP
+
+    # List of INI file sections to generate using sap_install.sap_swpm role (List).
+    sap_swpm_inifile_sections_list:
+      - swpm_installation_media
+      - swpm_installation_media_swpm2_hana
+      - credentials
+      - credentials_hana
+      - db_config_hana
+      - db_connection_nw_hana
+      - nw_config_other
+      - nw_config_central_services_abap
+      - nw_config_primary_application_server_instance
+      - nw_config_ports
+      - nw_config_host_agent
+      - sap_os_linux_user
+
+    softwarecenter_search_list_x86_64:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
+      # Media
+      - 'S4FND109_INST_EXPORT_1.zip'
+      - 'S4FND109_INST_EXPORT_2.zip'
+      - 'S4FND109_INST_EXPORT_3.zip'
+      - 'S4FND109_INST_EXPORT_4.zip'
+      - 'S4FND109_INST_EXPORT_5.zip'
+      - 'S4FND109_INST_EXPORT_6.zip'
+      - 'S4FND109_INST_EXPORT_7.zip'
+      - 'S4FND109_INST_EXPORT_8.zip'
+      - 'S4FND109_INST_EXPORT_9.zip'
+      - 'S4FND109_INST_EXPORT_10.zip'
+      - 'S4FND109_NW_LANG_EN.SAR'
+      - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007716.EXE'
+      - 'SWPM20SP23_2-80003424.SAR'
+      # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+
+    softwarecenter_search_list_ppc64le:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
+      # Media
+      - 'S4FND109_INST_EXPORT_1.zip'
+      - 'S4FND109_INST_EXPORT_2.zip'
+      - 'S4FND109_INST_EXPORT_3.zip'
+      - 'S4FND109_INST_EXPORT_4.zip'
+      - 'S4FND109_INST_EXPORT_5.zip'
+      - 'S4FND109_INST_EXPORT_6.zip'
+      - 'S4FND109_INST_EXPORT_7.zip'
+      - 'S4FND109_INST_EXPORT_8.zip'
+      - 'S4FND109_INST_EXPORT_9.zip'
+      - 'S4FND109_INST_EXPORT_10.zip'
+      - 'S4FND109_NW_LANG_EN.SAR'
+      - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007726.EXE'
+      - 'SWPM20SP23_2-80003426.SAR'
+      # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+
+    software_files_hana_wildcard_list:
+      - 'SAPCAR*'
+      - 'IMDB_*'
+      - 'SAPHOSTAGENT*'
+
+
   sap_s4hana_fndn_2023_standard:
 
     # SWPM product catalog ID for the installation (String).

--- a/deploy_scenarios/sap_s4hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox/ansible_extravars.yml
@@ -22,7 +22,7 @@ sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance nu
 
 ## SAP Product selection ##
 # Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_sandbox).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2025_sandbox).
 sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
@@ -123,6 +123,151 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
+
+  sap_s4hana_2025_sandbox:
+
+    # SWPM product catalog ID for the installation (String).
+    sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.CORE.HDB.ABAP
+
+    # List of INI file sections to generate using sap_install.sap_swpm role (List).
+    sap_swpm_inifile_sections_list:
+      - swpm_installation_media
+      - swpm_installation_media_swpm2_hana
+      - credentials
+      - credentials_hana
+      - db_config_hana
+      - db_connection_nw_hana
+      - nw_config_other
+      - nw_config_central_services_abap
+      - nw_config_primary_application_server_instance
+      - nw_config_ports
+      - nw_config_host_agent
+      - sap_os_linux_user
+
+    softwarecenter_search_list_x86_64:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'SAPPAAPL4_2405_0-80004547.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
+      # Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007716.EXE'
+      - 'SWPM20SP23_2-80003424.SAR'
+      # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    softwarecenter_search_list_ppc64le:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
+      # Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007726.EXE'
+      - 'SWPM20SP23_2-80003426.SAR'
+      # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
 
   sap_s4hana_2023_sandbox:
 

--- a/deploy_scenarios/sap_s4hana_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox/optional/ansible_extravars_interactive.yml
@@ -32,6 +32,151 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
 
+  sap_s4hana_2025_sandbox:
+
+    # SWPM product catalog ID for the installation (String).
+    sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.CORE.HDB.ABAP
+
+    # List of INI file sections to generate using sap_install.sap_swpm role (List).
+    sap_swpm_inifile_sections_list:
+      - swpm_installation_media
+      - swpm_installation_media_swpm2_hana
+      - credentials
+      - credentials_hana
+      - db_config_hana
+      - db_connection_nw_hana
+      - nw_config_other
+      - nw_config_central_services_abap
+      - nw_config_primary_application_server_instance
+      - nw_config_ports
+      - nw_config_host_agent
+      - sap_os_linux_user
+
+    softwarecenter_search_list_x86_64:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'SAPPAAPL4_2405_0-80004547.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
+      # Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007716.EXE'
+      - 'SWPM20SP23_2-80003424.SAR'
+      # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    softwarecenter_search_list_ppc64le:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
+      # Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007726.EXE'
+      - 'SWPM20SP23_2-80003426.SAR'
+      # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+
   sap_s4hana_2023_sandbox:
 
     # SWPM product catalog ID for the installation (String).

--- a/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_extravars.yml
@@ -22,7 +22,7 @@ sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance nu
 
 ## SAP Product selection ##
 # Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_sandbox).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2025_sandbox).
 sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
@@ -126,6 +126,52 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
+
+  sap_s4hana_2025_sandbox:
+
+    # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
+    softwarecenter_search_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
+
+    softwarecenter_search_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
+
+    software_files_hana_wildcard_list:
+      - 'SAPCAR*'
+      - 'IMDB_*'
+      - 'SAPHOSTAGENT*'
+
+    # SWPM product catalog ID for the installation (String).
+    sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.CORE.HDB.ABAP
+
+    # List of INI file sections to generate using sap_install.sap_swpm role (List).
+    sap_swpm_inifile_sections_list:
+      - swpm_installation_media
+      - swpm_installation_media_swpm2_hana
+      - credentials
+      - credentials_hana
+      - db_config_hana
+      - db_connection_nw_hana
+      - nw_config_other
+      - nw_config_central_services_abap
+      - nw_config_primary_application_server_instance
+      - nw_config_ports
+      - nw_config_host_agent
+      - sap_os_linux_user
+      - maintenance_plan_stack_tms_config
+      - maintenance_plan_stack_spam_config
+      - maintenance_plan_stack_sum_config
+
+    sap_swpm_inifile_dictionary:
+
+      # SAP SWPM using SAP Maintenance Planner Stack XML
+      # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
+      sap_swpm_configure_tms: true
+      sap_swpm_tmsadm_password: ''
+      sap_swpm_spam_update: false
+      sap_swpm_sum_prepare: true
+      sap_swpm_sum_start: true
+
 
   sap_s4hana_2023_sandbox:
 

--- a/deploy_scenarios/sap_s4hana_sandbox_maintplan/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_maintplan/optional/ansible_extravars_interactive.yml
@@ -38,6 +38,52 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
 
+  sap_s4hana_2025_sandbox:
+
+    # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
+    softwarecenter_search_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
+
+    softwarecenter_search_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
+
+    software_files_hana_wildcard_list:
+      - 'SAPCAR*'
+      - 'IMDB_*'
+      - 'SAPHOSTAGENT*'
+
+    # SWPM product catalog ID for the installation (String).
+    sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.CORE.HDB.ABAP
+
+    # List of INI file sections to generate using sap_install.sap_swpm role (List).
+    sap_swpm_inifile_sections_list:
+      - swpm_installation_media
+      - swpm_installation_media_swpm2_hana
+      - credentials
+      - credentials_hana
+      - db_config_hana
+      - db_connection_nw_hana
+      - nw_config_other
+      - nw_config_central_services_abap
+      - nw_config_primary_application_server_instance
+      - nw_config_ports
+      - nw_config_host_agent
+      - sap_os_linux_user
+      - maintenance_plan_stack_tms_config
+      - maintenance_plan_stack_spam_config
+      - maintenance_plan_stack_sum_config
+
+    sap_swpm_inifile_dictionary:
+
+      # SAP SWPM using SAP Maintenance Planner Stack XML
+      # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
+      sap_swpm_configure_tms: true
+      sap_swpm_tmsadm_password: ''
+      sap_swpm_spam_update: false
+      sap_swpm_sum_prepare: true
+      sap_swpm_sum_start: true
+
+
   sap_s4hana_2023_sandbox:
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list

--- a/deploy_scenarios/sap_s4hana_sandbox_syscopy/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_syscopy/ansible_extravars.yml
@@ -22,7 +22,7 @@ sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance nu
 
 ## SAP Product selection ##
 # Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_sandbox).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2025_sandbox).
 sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
@@ -133,6 +133,153 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
+
+  sap_s4hana_2025_sandbox:
+
+    # SWPM product catalog ID for the installation (String).
+    sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.CORE.HDB.CP
+
+    # List of INI file sections to generate using sap_install.sap_swpm role (List).
+    sap_swpm_inifile_sections_list:
+      - swpm_installation_media
+      - swpm_installation_media_swpm2_hana
+      - credentials
+      - credentials_hana
+      - credentials_syscopy
+      - db_config_hana
+      - db_connection_nw_hana
+      - db_restore_hana
+      - nw_config_other
+      - nw_config_central_services_abap
+      - nw_config_primary_application_server_instance
+      - nw_config_ports
+      - nw_config_host_agent
+      - sap_os_linux_user
+
+    softwarecenter_search_list_x86_64:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'SAPPAAPL4_2405_0-80004547.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
+      # Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007716.EXE'
+      - 'SWPM20SP23_2-80003424.SAR'
+      # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    softwarecenter_search_list_ppc64le:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
+      # Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007726.EXE'
+      - 'SWPM20SP23_2-80003426.SAR'
+      # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
 
   sap_s4hana_2023_sandbox:
 

--- a/deploy_scenarios/sap_s4hana_sandbox_syscopy/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_syscopy/optional/ansible_extravars_interactive.yml
@@ -32,6 +32,153 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
 
+  sap_s4hana_2025_sandbox:
+
+    # SWPM product catalog ID for the installation (String).
+    sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.CORE.HDB.CP
+
+    # List of INI file sections to generate using sap_install.sap_swpm role (List).
+    sap_swpm_inifile_sections_list:
+      - swpm_installation_media
+      - swpm_installation_media_swpm2_hana
+      - credentials
+      - credentials_hana
+      - credentials_syscopy
+      - db_config_hana
+      - db_connection_nw_hana
+      - db_restore_hana
+      - nw_config_other
+      - nw_config_central_services_abap
+      - nw_config_primary_application_server_instance
+      - nw_config_ports
+      - nw_config_host_agent
+      - sap_os_linux_user
+
+    softwarecenter_search_list_x86_64:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'SAPPAAPL4_2405_0-80004547.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
+      # Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007716.EXE'
+      - 'SWPM20SP23_2-80003424.SAR'
+      # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    softwarecenter_search_list_ppc64le:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
+      # Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007726.EXE'
+      - 'SWPM20SP23_2-80003426.SAR'
+      # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+
   sap_s4hana_2023_sandbox:
 
     # SWPM product catalog ID for the installation (String).

--- a/deploy_scenarios/sap_s4hana_standard/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_standard/ansible_extravars.yml
@@ -22,7 +22,7 @@ sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance nu
 
 ## SAP Product selection ##
 # Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_standard).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2025_standard).
 sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
@@ -126,6 +126,156 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
+
+  sap_s4hana_2025_standard:
+
+    # SWPM product catalog ID for the installation (String).
+    sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.CORE.HDB.ABAP
+
+    # List of INI file sections to generate using sap_install.sap_swpm role (List).
+    sap_swpm_inifile_sections_list:
+      - swpm_installation_media
+      - swpm_installation_media_swpm2_hana
+      - credentials
+      - credentials_hana
+      - db_config_hana
+      - db_connection_nw_hana
+      - nw_config_other
+      - nw_config_central_services_abap
+      - nw_config_primary_application_server_instance
+      - nw_config_ports
+      - nw_config_host_agent
+      - sap_os_linux_user
+
+    softwarecenter_search_list_x86_64:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'SAPPAAPL4_2405_0-80004547.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
+      # Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007716.EXE'
+      - 'SWPM20SP23_2-80003424.SAR'
+      # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    softwarecenter_search_list_ppc64le:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
+      # Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007726.EXE'
+      - 'SWPM20SP23_2-80003426.SAR'
+      # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    software_files_hana_wildcard_list:
+      - 'SAPCAR*'
+      - 'IMDB_*'
+      - 'SAPHOSTAGENT*'
+
 
   sap_s4hana_2023_standard:
 

--- a/deploy_scenarios/sap_s4hana_standard/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_standard/optional/ansible_extravars_interactive.yml
@@ -35,6 +35,156 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
 
+  sap_s4hana_2025_standard:
+
+    # SWPM product catalog ID for the installation (String).
+    sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.CORE.HDB.ABAP
+
+    # List of INI file sections to generate using sap_install.sap_swpm role (List).
+    sap_swpm_inifile_sections_list:
+      - swpm_installation_media
+      - swpm_installation_media_swpm2_hana
+      - credentials
+      - credentials_hana
+      - db_config_hana
+      - db_connection_nw_hana
+      - nw_config_other
+      - nw_config_central_services_abap
+      - nw_config_primary_application_server_instance
+      - nw_config_ports
+      - nw_config_host_agent
+      - sap_os_linux_user
+
+    softwarecenter_search_list_x86_64:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'SAPPAAPL4_2405_0-80004547.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
+      # Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007716.EXE'
+      - 'SWPM20SP23_2-80003424.SAR'
+      # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    softwarecenter_search_list_ppc64le:
+      # Database
+      - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
+      - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
+      - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application
+      - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
+      # Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Tools
+      - 'SAPCAR_1400-70007726.EXE'
+      - 'SWPM20SP23_2-80003426.SAR'
+      # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    software_files_hana_wildcard_list:
+      - 'SAPCAR*'
+      - 'IMDB_*'
+      - 'SAPHOSTAGENT*'
+
+
   sap_s4hana_2023_standard:
 
     # SWPM product catalog ID for the installation (String).

--- a/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_extravars.yml
@@ -22,7 +22,7 @@ sap_system_nwas_abap_pas_instance_nr: "01"  # SAP NetWeaver ABAP PAS instance nu
 
 ## SAP Product selection ##
 # Name of the SAP product to install (String).
-# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2023_standard).
+# Options: Defined in sap_software_install_dictionary (e.g. sap_s4hana_2025_standard).
 sap_software_product: "ENTER_STRING_VALUE_HERE"
 
 
@@ -129,6 +129,52 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
+
+  sap_s4hana_2025_standard:
+
+    # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
+    softwarecenter_search_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
+
+    softwarecenter_search_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
+
+    software_files_hana_wildcard_list:
+      - 'SAPCAR*'
+      - 'IMDB_*'
+      - 'SAPHOSTAGENT*'
+
+    # SWPM product catalog ID for the installation (String).
+    sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.CORE.HDB.ABAP
+
+    # List of INI file sections to generate using sap_install.sap_swpm role (List).
+    sap_swpm_inifile_sections_list:
+      - swpm_installation_media
+      - swpm_installation_media_swpm2_hana
+      - credentials
+      - credentials_hana
+      - db_config_hana
+      - db_connection_nw_hana
+      - nw_config_other
+      - nw_config_central_services_abap
+      - nw_config_primary_application_server_instance
+      - nw_config_ports
+      - nw_config_host_agent
+      - sap_os_linux_user
+      - maintenance_plan_stack_tms_config
+      - maintenance_plan_stack_spam_config
+      - maintenance_plan_stack_sum_config
+
+    sap_swpm_inifile_dictionary:
+
+      # SAP SWPM using SAP Maintenance Planner Stack XML
+      # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
+      sap_swpm_configure_tms: true
+      sap_swpm_tmsadm_password: ''
+      sap_swpm_spam_update: false
+      sap_swpm_sum_prepare: true
+      sap_swpm_sum_start: true
+
 
   sap_s4hana_2023_standard:
 

--- a/deploy_scenarios/sap_s4hana_standard_maintplan/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_standard_maintplan/optional/ansible_extravars_interactive.yml
@@ -41,6 +41,52 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
 
+  sap_s4hana_2025_standard:
+
+    # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
+    softwarecenter_search_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
+
+    softwarecenter_search_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
+
+    software_files_hana_wildcard_list:
+      - 'SAPCAR*'
+      - 'IMDB_*'
+      - 'SAPHOSTAGENT*'
+
+    # SWPM product catalog ID for the installation (String).
+    sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.CORE.HDB.ABAP
+
+    # List of INI file sections to generate using sap_install.sap_swpm role (List).
+    sap_swpm_inifile_sections_list:
+      - swpm_installation_media
+      - swpm_installation_media_swpm2_hana
+      - credentials
+      - credentials_hana
+      - db_config_hana
+      - db_connection_nw_hana
+      - nw_config_other
+      - nw_config_central_services_abap
+      - nw_config_primary_application_server_instance
+      - nw_config_ports
+      - nw_config_host_agent
+      - sap_os_linux_user
+      - maintenance_plan_stack_tms_config
+      - maintenance_plan_stack_spam_config
+      - maintenance_plan_stack_sum_config
+
+    sap_swpm_inifile_dictionary:
+
+      # SAP SWPM using SAP Maintenance Planner Stack XML
+      # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
+      sap_swpm_configure_tms: true
+      sap_swpm_tmsadm_password: ''
+      sap_swpm_spam_update: false
+      sap_swpm_sum_prepare: true
+      sap_swpm_sum_start: true
+
+
   sap_s4hana_2023_standard:
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list


### PR DESCRIPTION
## Changes
SAP Released S/4HANA 2025 and this PR adds updated software lists to playbook extravars.

## NOTE
As it always goes with SAP Maintenance Planner, it shows media that cannot be downloaded directly.
These items are commented out with explanation:
`Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.`

Thank you @sean-freeman  for notifying me about new version release and prompting this PR.