### PR TITLE
all: Refactor product dictionary to reuse same contents when possible 

### DIFF
--- a/common_fragments/vars/platform_vars_ibmpowervm_vm.yml
+++ b/common_fragments/vars/platform_vars_ibmpowervm_vm.yml
@@ -16,7 +16,7 @@ sap_vm_provision_iac_platform: "ibmpowervm_vm"  # Name of the provisioning platf
 # IBM Power Virtualization Center authentication endpoint (String). e.g https://POWERVC_HOST:5000/v3/
 sap_vm_provision_ibmpowervm_vc_auth_endpoint: "ENTER_STRING_VALUE_HERE"
 sap_vm_provision_ibmpowervm_vc_user: "ENTER_STRING_VALUE_HERE"  # Virtualization Center user (String).
-sap_vm_provision_ibmpowervm_vc_user_password: "ENTER_STRING_VALUE_HERE"  # Virtualization Center user password (String).
+sap_vm_provision_ibmpowervm_vc_user_password: ''  # Virtualization Center user password (String).
 sap_vm_provision_ibmpowervm_vc_project_name: "ENTER_STRING_VALUE_HERE"  # Virtualization Center Project Name (String).
 sap_vm_provision_ibmpowervm_host_group_name: "ENTER_STRING_VALUE_HERE"  # Host group name (String).
 sap_vm_provision_ibmpowervm_host_group_shared_procesor_pool_name: "ENTER_STRING_VALUE_HERE"  # Host group shared pool name (String). e.g. DefaultPool

--- a/common_fragments/vars/platform_vars_kubevirt_vm.yml
+++ b/common_fragments/vars/platform_vars_kubevirt_vm.yml
@@ -17,8 +17,8 @@ sap_vm_provision_kubevirt_api_key: "ENTER_STRING_VALUE_HERE"  # Cluster API key 
 sap_vm_provision_kubevirt_target_namespace: "ENTER_STRING_VALUE_HERE"  # Target namespace (String).
 sap_vm_provision_kubevirt_vm_host_os_image_url: "ENTER_STRING_VALUE_HERE" # Image URL (String). "docker://registry.redhat.io/rhel8/rhel-guest-image:8.6.0"
 # Optional, create OS User and Password. Otherwise only 'root' will exist using the SSH Key
-sap_vm_provision_kubevirt_os_user: "ENTER_STRING_VALUE_HERE"  # Optional OS user name (String).
-sap_vm_provision_kubevirt_os_user_password: "ENTER_STRING_VALUE_HERE"  # Optional OS user password (String).
+# sap_vm_provision_kubevirt_vm_os_user: "ENTER_STRING_VALUE_HERE"  # Optional OS user name (String).
+# sap_vm_provision_kubevirt_vm_os_user_password: ''  # Optional OS user password (String).
 
 sap_vm_provision_dns_root_domain: "ENTER_STRING_VALUE_HERE"  # Root domain for DNS entries (e.g., example.com) (String).
 

--- a/common_fragments/vars/platform_vars_ovirt_vm.yml
+++ b/common_fragments/vars/platform_vars_ovirt_vm.yml
@@ -16,7 +16,7 @@ sap_vm_provision_ovirt_engine_insecure_bool: true  # Enables insecure authentica
 sap_vm_provision_ovirt_engine_url: "ENTER_STRING_VALUE_HERE"  # URL (String).
 sap_vm_provision_ovirt_engine_fqdn: "ENTER_STRING_VALUE_HERE"  # FQDN (String).
 sap_vm_provision_ovirt_engine_user: "ENTER_STRING_VALUE_HERE"  # User name (String).
-sap_vm_provision_ovirt_engine_password: "ENTER_STRING_VALUE_HERE"  # User password (String).
+sap_vm_provision_ovirt_engine_password: ''  # User password (String). Defaults to OVIRT_PASSWORD environment variable if not set.
 sap_vm_provision_ovirt_engine_cafile: "ENTER_STRING_VALUE_HERE"  # CA file path (String).
 
 sap_vm_provision_ovirt_hypervisor_cluster_name: "ENTER_STRING_VALUE_HERE"  # Hypervisor cluster name (String).

--- a/deploy_scenarios/sap_bw4hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_bw4hana_sandbox/ansible_extravars.yml
@@ -30,7 +30,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -130,128 +130,122 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BW4HANA2023.CORE.HDB.ABAP
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      # Database
+    sap_software_list_independent:
+      # Application Media
+      - 'BW4HANA400_INST_EXPORT_1.zip'
+      - 'BW4HANA400_INST_EXPORT_2.zip'
+      - 'BW4HANA400_INST_EXPORT_3.zip'
+      - 'BW4HANA400_INST_EXPORT_4.zip'
+      - 'BW4HANA400_INST_EXPORT_5.zip'
+      - 'BW4HANA400_INST_EXPORT_6.zip'
+      - 'BW4HANA400_INST_EXPORT_7.zip'
+      - 'BW4HANA400_INST_EXPORT_8.zip'
+      - 'BW4HANA400_INST_EXPORT_9.zip'
+      # - 'BW4HANA400_NW_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
       - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
       - 'IMDB_CLIENT20_028_17-80002082.SAR'
-      # Application
+      # Application Server
       - 'SAPEXE_51-70007807.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (785), SAP HANA 2.0
       - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent 7.22
-      - 'BW4HANA400_INST_EXPORT_1.zip'
-      - 'BW4HANA400_INST_EXPORT_2.zip'
-      - 'BW4HANA400_INST_EXPORT_3.zip'
-      - 'BW4HANA400_INST_EXPORT_4.zip'
-      - 'BW4HANA400_INST_EXPORT_5.zip'
-      - 'BW4HANA400_INST_EXPORT_6.zip'
-      - 'BW4HANA400_INST_EXPORT_7.zip'
-      - 'BW4HANA400_INST_EXPORT_8.zip'
-      - 'BW4HANA400_INST_EXPORT_9.zip'
-      # - 'BW4HANA400_NW_LANG_EN.SAR'
       - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
       # Tools
       - 'SAPCAR_1300-70007716.EXE'
       - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
       - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
       - 'IMDB_CLIENT20_028_17-80002095.SAR'
-      # Application
+      # Application Server
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (785), SAP HANA 2.0
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent 7.22
-      - 'BW4HANA400_INST_EXPORT_1.zip'
-      - 'BW4HANA400_INST_EXPORT_2.zip'
-      - 'BW4HANA400_INST_EXPORT_3.zip'
-      - 'BW4HANA400_INST_EXPORT_4.zip'
-      - 'BW4HANA400_INST_EXPORT_5.zip'
-      - 'BW4HANA400_INST_EXPORT_6.zip'
-      - 'BW4HANA400_INST_EXPORT_7.zip'
-      - 'BW4HANA400_INST_EXPORT_8.zip'
-      - 'BW4HANA400_INST_EXPORT_9.zip'
-      # - 'BW4HANA400_NW_LANG_EN.SAR'
       - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
       # Tools
       - 'SAPCAR_1300-70007726.EXE'
       - 'SWPM20SP20_1-80003426.SAR'
+
 
   sap_bw4hana_2021_sandbox:
 
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BW4HANA2021.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - sap_os_linux_user
+    # List of INI file sections to generate using sap_install.sap_swpm role (List).
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'BW4HANA300_INST_EXPORT_1.zip'
+      - 'BW4HANA300_INST_EXPORT_2.zip'
+      - 'BW4HANA300_INST_EXPORT_3.zip'
+      - 'BW4HANA300_INST_EXPORT_4.zip'
+      - 'BW4HANA300_INST_EXPORT_5.zip'
+      - 'BW4HANA300_INST_EXPORT_6.zip'
+      - 'BW4HANA300_INST_EXPORT_7.zip'
+      - 'BW4HANA300_INST_EXPORT_8.zip'
+      # - 'BW4HANA300_NW_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
       - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785), SAP HANA 2.0
       - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
-      - 'BW4HANA300_INST_EXPORT_1.zip'
-      - 'BW4HANA300_INST_EXPORT_2.zip'
-      - 'BW4HANA300_INST_EXPORT_3.zip'
-      - 'BW4HANA300_INST_EXPORT_4.zip'
-      - 'BW4HANA300_INST_EXPORT_5.zip'
-      - 'BW4HANA300_INST_EXPORT_6.zip'
-      - 'BW4HANA300_INST_EXPORT_7.zip'
-      - 'BW4HANA300_INST_EXPORT_8.zip'
-      # - 'BW4HANA300_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
       - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785), SAP HANA 2.0
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
-      - 'BW4HANA300_INST_EXPORT_1.zip'
-      - 'BW4HANA300_INST_EXPORT_2.zip'
-      - 'BW4HANA300_INST_EXPORT_3.zip'
-      - 'BW4HANA300_INST_EXPORT_4.zip'
-      - 'BW4HANA300_INST_EXPORT_5.zip'
-      - 'BW4HANA300_INST_EXPORT_6.zip'
-      - 'BW4HANA300_INST_EXPORT_7.zip'
-      - 'BW4HANA300_INST_EXPORT_8.zip'
-      # - 'BW4HANA300_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  sandbox:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - sap_os_linux_user

--- a/deploy_scenarios/sap_bw4hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_bw4hana_sandbox/ansible_extravars.yml
@@ -133,6 +133,7 @@ sap_software_install_dictionary:
     # This list assigned from dictionary below, because it is same with other products or host types.
     sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
+    # List of product specific software files that are architecture independent.
     sap_software_list_independent:
       # Application Media
       - 'BW4HANA400_INST_EXPORT_1.zip'
@@ -148,6 +149,7 @@ sap_software_install_dictionary:
       # Application Server
       - 'igshelper_17-10010245.sar'
 
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
     sap_software_list_x86_64:
       # Database Server
       - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
@@ -163,6 +165,7 @@ sap_software_install_dictionary:
       - 'SAPCAR_1300-70007716.EXE'
       - 'SWPM20SP20_1-80003424.SAR'
 
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
     sap_software_list_ppc64le:
       # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
@@ -180,11 +183,10 @@ sap_software_install_dictionary:
 
 
   sap_bw4hana_2021_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BW4HANA2021.CORE.HDB.ABAP
 
-    # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    # This list assigned from dictionary below, because it is same with other products or host types.
     sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
     sap_software_list_independent:

--- a/deploy_scenarios/sap_bw4hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_bw4hana_sandbox/ansible_playbook.yml
@@ -255,8 +255,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 

--- a/deploy_scenarios/sap_bw4hana_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_bw4hana_sandbox/optional/ansible_extravars_interactive.yml
@@ -34,135 +34,131 @@ sap_software_install_dictionary:
 
   sap_bw4hana_2023_sandbox:
 
-    # SWPM product catalog ID for the installation (String)
+    # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BW4HANA2023.CORE.HDB.ABAP
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      # Database
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Media
+      - 'BW4HANA400_INST_EXPORT_1.zip'
+      - 'BW4HANA400_INST_EXPORT_2.zip'
+      - 'BW4HANA400_INST_EXPORT_3.zip'
+      - 'BW4HANA400_INST_EXPORT_4.zip'
+      - 'BW4HANA400_INST_EXPORT_5.zip'
+      - 'BW4HANA400_INST_EXPORT_6.zip'
+      - 'BW4HANA400_INST_EXPORT_7.zip'
+      - 'BW4HANA400_INST_EXPORT_8.zip'
+      - 'BW4HANA400_INST_EXPORT_9.zip'
+      # - 'BW4HANA400_NW_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
       - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
       - 'IMDB_CLIENT20_028_17-80002082.SAR'
-      # Application
+      # Application Server
       - 'SAPEXE_51-70007807.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (785), SAP HANA 2.0
       - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent 7.22
-      - 'BW4HANA400_INST_EXPORT_1.zip'
-      - 'BW4HANA400_INST_EXPORT_2.zip'
-      - 'BW4HANA400_INST_EXPORT_3.zip'
-      - 'BW4HANA400_INST_EXPORT_4.zip'
-      - 'BW4HANA400_INST_EXPORT_5.zip'
-      - 'BW4HANA400_INST_EXPORT_6.zip'
-      - 'BW4HANA400_INST_EXPORT_7.zip'
-      - 'BW4HANA400_INST_EXPORT_8.zip'
-      - 'BW4HANA400_INST_EXPORT_9.zip'
-      # - 'BW4HANA400_NW_LANG_EN.SAR'
       - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
       # Tools
       - 'SAPCAR_1300-70007716.EXE'
       - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
       - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
       - 'IMDB_CLIENT20_028_17-80002095.SAR'
-      # Application
+      # Application Server
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (785), SAP HANA 2.0
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent 7.22
-      - 'BW4HANA400_INST_EXPORT_1.zip'
-      - 'BW4HANA400_INST_EXPORT_2.zip'
-      - 'BW4HANA400_INST_EXPORT_3.zip'
-      - 'BW4HANA400_INST_EXPORT_4.zip'
-      - 'BW4HANA400_INST_EXPORT_5.zip'
-      - 'BW4HANA400_INST_EXPORT_6.zip'
-      - 'BW4HANA400_INST_EXPORT_7.zip'
-      - 'BW4HANA400_INST_EXPORT_8.zip'
-      - 'BW4HANA400_INST_EXPORT_9.zip'
-      # - 'BW4HANA400_NW_LANG_EN.SAR'
       - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
       # Tools
       - 'SAPCAR_1300-70007726.EXE'
       - 'SWPM20SP20_1-80003426.SAR'
 
+
   sap_bw4hana_2021_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BW4HANA2021.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'BW4HANA300_INST_EXPORT_1.zip'
+      - 'BW4HANA300_INST_EXPORT_2.zip'
+      - 'BW4HANA300_INST_EXPORT_3.zip'
+      - 'BW4HANA300_INST_EXPORT_4.zip'
+      - 'BW4HANA300_INST_EXPORT_5.zip'
+      - 'BW4HANA300_INST_EXPORT_6.zip'
+      - 'BW4HANA300_INST_EXPORT_7.zip'
+      - 'BW4HANA300_INST_EXPORT_8.zip'
+      # - 'BW4HANA300_NW_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
       - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785), SAP HANA 2.0
       - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
-      - 'BW4HANA300_INST_EXPORT_1.zip'
-      - 'BW4HANA300_INST_EXPORT_2.zip'
-      - 'BW4HANA300_INST_EXPORT_3.zip'
-      - 'BW4HANA300_INST_EXPORT_4.zip'
-      - 'BW4HANA300_INST_EXPORT_5.zip'
-      - 'BW4HANA300_INST_EXPORT_6.zip'
-      - 'BW4HANA300_INST_EXPORT_7.zip'
-      - 'BW4HANA300_INST_EXPORT_8.zip'
-    #  - 'BW4HANA400_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
       - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785), SAP HANA 2.0
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
-      - 'BW4HANA300_INST_EXPORT_1.zip'
-      - 'BW4HANA300_INST_EXPORT_2.zip'
-      - 'BW4HANA300_INST_EXPORT_3.zip'
-      - 'BW4HANA300_INST_EXPORT_4.zip'
-      - 'BW4HANA300_INST_EXPORT_5.zip'
-      - 'BW4HANA300_INST_EXPORT_6.zip'
-      - 'BW4HANA300_INST_EXPORT_7.zip'
-      - 'BW4HANA300_INST_EXPORT_8.zip'
-    #  - 'BW4HANA400_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  sandbox:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - sap_os_linux_user
 
 
 #### Interactive Prompt Control Variables ####

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_extravars.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_extravars.yml
@@ -147,6 +147,7 @@ sap_software_install_dictionary:
     # This list assigned from dictionary below, because it is same with other products or host types.
     sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['pas'] }}"
 
+    # List of product specific software files that are architecture independent.
     sap_software_list_independent:
       # Application Media
       - 'BW4HANA400_INST_EXPORT_1.zip'
@@ -162,6 +163,7 @@ sap_software_install_dictionary:
       # Application Server
       - 'igshelper_17-10010245.sar'
 
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
     sap_software_list_x86_64:
       # Database Server - SPS07 is used because NFS for /lss/shared is not enforced like in SPS08.
       - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
@@ -177,6 +179,7 @@ sap_software_install_dictionary:
       - 'SAPCAR_1300-70007716.EXE'
       - 'SWPM20SP20_1-80003424.SAR'
 
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
     sap_software_list_ppc64le:
       # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
@@ -187,7 +190,7 @@ sap_software_install_dictionary:
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (785), SAP HANA 2.0
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent 7.22
-      - 'igsexe_6-70005446.sar'  # Support Package SAP IGS 7.81 Linux on x86_64 64bit
+      - 'igsexe_6-70005446.sar'  # Support Package SAP IGS 7.81 Linux on Power LE 64bit
       # Tools
       - 'SAPCAR_1300-70007726.EXE'
       - 'SWPM20SP20_1-80003426.SAR'
@@ -197,11 +200,10 @@ sap_software_install_dictionary:
 
 
   sap_bw4hana_2021_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BW4HANA2021.CORE.HDB.ABAP
 
-    # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    # This list assigned from dictionary below, because it is same with other products or host types.
     sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['pas'] }}"
 
     sap_software_list_independent:
@@ -248,7 +250,6 @@ sap_software_install_dictionary:
       - 'SAPCAR_1300-70007726.EXE'
       - 'SWPM20SP20_1-80003426.SAR'
 
-    # This list assigned from dictionary below, because it is same with other products or host types.
     sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
 

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_extravars.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_extravars.yml
@@ -35,7 +35,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -144,141 +144,137 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BW4HANA2023.CORE.HDB.ABAP
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['pas'] }}"
 
-    softwarecenter_search_list_x86_64:
-      # Database - SPS07 is used because NFS for /lss/shared is not enforced like in SPS08.
+    sap_software_list_independent:
+      # Application Media
+      - 'BW4HANA400_INST_EXPORT_1.zip'
+      - 'BW4HANA400_INST_EXPORT_2.zip'
+      - 'BW4HANA400_INST_EXPORT_3.zip'
+      - 'BW4HANA400_INST_EXPORT_4.zip'
+      - 'BW4HANA400_INST_EXPORT_5.zip'
+      - 'BW4HANA400_INST_EXPORT_6.zip'
+      - 'BW4HANA400_INST_EXPORT_7.zip'
+      - 'BW4HANA400_INST_EXPORT_8.zip'
+      - 'BW4HANA400_INST_EXPORT_9.zip'
+      # - 'BW4HANA400_NW_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server - SPS07 is used because NFS for /lss/shared is not enforced like in SPS08.
       - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
       - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_51-70007807.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (785), SAP HANA 2.0
       - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent 7.22
-      - 'BW4HANA400_INST_EXPORT_1.zip'
-      - 'BW4HANA400_INST_EXPORT_2.zip'
-      - 'BW4HANA400_INST_EXPORT_3.zip'
-      - 'BW4HANA400_INST_EXPORT_4.zip'
-      - 'BW4HANA400_INST_EXPORT_5.zip'
-      - 'BW4HANA400_INST_EXPORT_6.zip'
-      - 'BW4HANA400_INST_EXPORT_7.zip'
-      - 'BW4HANA400_INST_EXPORT_8.zip'
-      - 'BW4HANA400_INST_EXPORT_9.zip'
-      # - 'BW4HANA400_NW_LANG_EN.SAR'
       - 'igsexe_6-70005417.sar'  # Support Package SAP IGS 7.81 Linux on x86_64 64bit
-      - 'igshelper_17-10010245.sar'
       # Tools
       - 'SAPCAR_1300-70007716.EXE'
       - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
       - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (785), SAP HANA 2.0
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent 7.22
-      - 'BW4HANA400_INST_EXPORT_1.zip'
-      - 'BW4HANA400_INST_EXPORT_2.zip'
-      - 'BW4HANA400_INST_EXPORT_3.zip'
-      - 'BW4HANA400_INST_EXPORT_4.zip'
-      - 'BW4HANA400_INST_EXPORT_5.zip'
-      - 'BW4HANA400_INST_EXPORT_6.zip'
-      - 'BW4HANA400_INST_EXPORT_7.zip'
-      - 'BW4HANA400_INST_EXPORT_8.zip'
-      - 'BW4HANA400_INST_EXPORT_9.zip'
-      # - 'BW4HANA400_NW_LANG_EN.SAR'
       - 'igsexe_6-70005446.sar'  # Support Package SAP IGS 7.81 Linux on x86_64 64bit
-      - 'igshelper_17-10010245.sar'
       # Tools
       - 'SAPCAR_1300-70007726.EXE'
       - 'SWPM20SP20_1-80003426.SAR'
 
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
 
   sap_bw4hana_2021_standard:
 
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BW4HANA2021.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # List of INI file sections to generate using sap_install.sap_swpm role (List).
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['pas'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'BW4HANA300_INST_EXPORT_1.zip'
+      - 'BW4HANA300_INST_EXPORT_2.zip'
+      - 'BW4HANA300_INST_EXPORT_3.zip'
+      - 'BW4HANA300_INST_EXPORT_4.zip'
+      - 'BW4HANA300_INST_EXPORT_5.zip'
+      - 'BW4HANA300_INST_EXPORT_6.zip'
+      - 'BW4HANA300_INST_EXPORT_7.zip'
+      - 'BW4HANA300_INST_EXPORT_8.zip'
+      # - 'BW4HANA300_NW_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
       - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785), SAP HANA 2.0
       - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
-      - 'BW4HANA300_INST_EXPORT_1.zip'
-      - 'BW4HANA300_INST_EXPORT_2.zip'
-      - 'BW4HANA300_INST_EXPORT_3.zip'
-      - 'BW4HANA300_INST_EXPORT_4.zip'
-      - 'BW4HANA300_INST_EXPORT_5.zip'
-      - 'BW4HANA300_INST_EXPORT_6.zip'
-      - 'BW4HANA300_INST_EXPORT_7.zip'
-      - 'BW4HANA300_INST_EXPORT_8.zip'
-    #  - 'BW4HANA400_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
       - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785), SAP HANA 2.0
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
-      - 'BW4HANA300_INST_EXPORT_1.zip'
-      - 'BW4HANA300_INST_EXPORT_2.zip'
-      - 'BW4HANA300_INST_EXPORT_3.zip'
-      - 'BW4HANA300_INST_EXPORT_4.zip'
-      - 'BW4HANA300_INST_EXPORT_5.zip'
-      - 'BW4HANA300_INST_EXPORT_6.zip'
-      - 'BW4HANA300_INST_EXPORT_7.zip'
-      - 'BW4HANA300_INST_EXPORT_8.zip'
-    #  - 'BW4HANA400_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  pas:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
+
+# Dictionary of lists for software filename wildcard patterns that is used during rsync operations.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_software_wildcards:
+  hana:
+    - 'SAPCAR*'
+    - 'IMDB_*'
+    - 'SAPHOSTAGENT*'

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml
@@ -305,8 +305,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
@@ -314,7 +315,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['software_files_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['sap_software_files_hana_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_hana_install_media_files
 

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/optional/ansible_extravars_interactive.yml
@@ -46,145 +46,141 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BW4HANA2023.CORE.HDB.ABAP
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['pas'] }}"
 
-    softwarecenter_search_list_x86_64:
-      # Database - SPS07 is used because NFS for /lss/shared is not enforced like in SPS08.
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Media
+      - 'BW4HANA400_INST_EXPORT_1.zip'
+      - 'BW4HANA400_INST_EXPORT_2.zip'
+      - 'BW4HANA400_INST_EXPORT_3.zip'
+      - 'BW4HANA400_INST_EXPORT_4.zip'
+      - 'BW4HANA400_INST_EXPORT_5.zip'
+      - 'BW4HANA400_INST_EXPORT_6.zip'
+      - 'BW4HANA400_INST_EXPORT_7.zip'
+      - 'BW4HANA400_INST_EXPORT_8.zip'
+      - 'BW4HANA400_INST_EXPORT_9.zip'
+      # - 'BW4HANA400_NW_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server - SPS07 is used because NFS for /lss/shared is not enforced like in SPS08.
       - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
       - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_51-70007807.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (785), SAP HANA 2.0
       - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent 7.22
-      - 'BW4HANA400_INST_EXPORT_1.zip'
-      - 'BW4HANA400_INST_EXPORT_2.zip'
-      - 'BW4HANA400_INST_EXPORT_3.zip'
-      - 'BW4HANA400_INST_EXPORT_4.zip'
-      - 'BW4HANA400_INST_EXPORT_5.zip'
-      - 'BW4HANA400_INST_EXPORT_6.zip'
-      - 'BW4HANA400_INST_EXPORT_7.zip'
-      - 'BW4HANA400_INST_EXPORT_8.zip'
-      - 'BW4HANA400_INST_EXPORT_9.zip'
-      # - 'BW4HANA400_NW_LANG_EN.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'igsexe_6-70005417.sar'  # Support Package SAP IGS 7.81 Linux on x86_64 64bit
       # Tools
       - 'SAPCAR_1300-70007716.EXE'
       - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
       - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (785), SAP HANA 2.0
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent 7.22
-      - 'BW4HANA400_INST_EXPORT_1.zip'
-      - 'BW4HANA400_INST_EXPORT_2.zip'
-      - 'BW4HANA400_INST_EXPORT_3.zip'
-      - 'BW4HANA400_INST_EXPORT_4.zip'
-      - 'BW4HANA400_INST_EXPORT_5.zip'
-      - 'BW4HANA400_INST_EXPORT_6.zip'
-      - 'BW4HANA400_INST_EXPORT_7.zip'
-      - 'BW4HANA400_INST_EXPORT_8.zip'
-      - 'BW4HANA400_INST_EXPORT_9.zip'
-      # - 'BW4HANA400_NW_LANG_EN.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'igsexe_6-70005446.sar'  # Support Package SAP IGS 7.81 Linux on Power LE 64bit
       # Tools
       - 'SAPCAR_1300-70007726.EXE'
       - 'SWPM20SP20_1-80003426.SAR'
 
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
 
   sap_bw4hana_2021_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BW4HANA2021.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['pas'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'BW4HANA300_INST_EXPORT_1.zip'
+      - 'BW4HANA300_INST_EXPORT_2.zip'
+      - 'BW4HANA300_INST_EXPORT_3.zip'
+      - 'BW4HANA300_INST_EXPORT_4.zip'
+      - 'BW4HANA300_INST_EXPORT_5.zip'
+      - 'BW4HANA300_INST_EXPORT_6.zip'
+      - 'BW4HANA300_INST_EXPORT_7.zip'
+      - 'BW4HANA300_INST_EXPORT_8.zip'
+      # - 'BW4HANA300_NW_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
       - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785), SAP HANA 2.0
       - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
-      - 'BW4HANA300_INST_EXPORT_1.zip'
-      - 'BW4HANA300_INST_EXPORT_2.zip'
-      - 'BW4HANA300_INST_EXPORT_3.zip'
-      - 'BW4HANA300_INST_EXPORT_4.zip'
-      - 'BW4HANA300_INST_EXPORT_5.zip'
-      - 'BW4HANA300_INST_EXPORT_6.zip'
-      - 'BW4HANA300_INST_EXPORT_7.zip'
-      - 'BW4HANA300_INST_EXPORT_8.zip'
-    #  - 'BW4HANA400_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
       - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785), SAP HANA 2.0
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
-      - 'BW4HANA300_INST_EXPORT_1.zip'
-      - 'BW4HANA300_INST_EXPORT_2.zip'
-      - 'BW4HANA300_INST_EXPORT_3.zip'
-      - 'BW4HANA300_INST_EXPORT_4.zip'
-      - 'BW4HANA300_INST_EXPORT_5.zip'
-      - 'BW4HANA300_INST_EXPORT_6.zip'
-      - 'BW4HANA300_INST_EXPORT_7.zip'
-      - 'BW4HANA300_INST_EXPORT_8.zip'
-    #  - 'BW4HANA400_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  pas:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
+
+# Dictionary of lists for software filename wildcard patterns that is used during rsync operations.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_software_wildcards:
+  hana:
+    - 'SAPCAR*'
+    - 'IMDB_*'
+    - 'SAPHOSTAGENT*'
 
 
 #### Interactive Prompt Control Variables ####

--- a/deploy_scenarios/sap_ecc_hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_hana_sandbox/ansible_extravars.yml
@@ -30,7 +30,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -136,152 +136,141 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BS2016.ERP608.HDB.PD
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1
-      - swpm_installation_media_swpm1_exportfiles
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Media
+      - '51050708_1' # SAP ERP 6.0 EHP8 Installation Export 1/4, Self-extract RAR EXE
+      - '51050708_2'
+      - '51050708_3'
+      - '51050708_4'
+    #  - '51050610_1' # SAP ERP 6.0 EHP8 Language I 1/3, Self-extract RAR EXE
+    #  - '51050610_2'
+    #  - '51050610_3'
+    #  - '51050610_4' # SAP ERP 6.0 EHP8 Language II 1/2, Self-extract RAR EXE
+    #  - '51050610_5'
+    #  - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
+    #  - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
+    #  - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+      - 'SAPKD75090' # SPAM/SAINT Update - Version 750/0090
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # - 'VCH202300_2085_0-70007416.SAR'  # Not mandatory
-      - 'SWPM10SP43_3-20009701.SAR'
-      - 'igsexe_5-80007786.sar' # IGS 7.54
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_500-80007612.SAR'  # Kernel Part I (754)
       - 'SAPEXEDB_500-80007611.SAR'  # Kernel Part II (754)
       - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP HOST AGENT 7.22 SP67
+      # - 'VCH202300_2085_0-70007416.SAR'  # Not mandatory
+      - 'igsexe_5-80007786.sar' # IGS 7.54
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_3-20009701.SAR'
       - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
-      - 'SAPKD75090' # SPAM/SAINT Update - Version 750/0090
-      - '51050708_1' # SAP ERP 6.0 EHP8 Installation Export 1/4, Self-extract RAR EXE
-      - '51050708_2'
-      - '51050708_3'
-      - '51050708_4'
-    #  - '51050610_1' # SAP ERP 6.0 EHP8 Language I 1/3, Self-extract RAR EXE
-    #  - '51050610_2'
-    #  - '51050610_3'
-    #  - '51050610_4' # SAP ERP 6.0 EHP8 Language II 1/2, Self-extract RAR EXE
-    #  - '51050610_5'
-    #  - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
-    #  - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
-    #  - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # - 'VCH202300_2085_0-70007417.SAR'  # Not mandatory
-      - 'SWPM10SP43_3-70002492.SAR'
-      - 'igsexe_5-80007795.sar' # IGS 7.54
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_500-80007669.SAR' # Kernel Part I (754)
       - 'SAPEXEDB_500-80007668.SAR' # Kernel Part II (754), SAP HANA
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP HOST AGENT 7.22 SP67
+      # - 'VCH202300_2085_0-70007417.SAR'  # Not mandatory
+      - 'igsexe_5-80007795.sar' # IGS 7.54
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM10SP43_3-70002492.SAR'
       - 'SUM20SP22_7-80002470.SAR' # SUM 2.0
-      - 'SAPKD75090' # SPAM/SAINT Update - Version 750/0083
-      - '51050708_1' # SAP ERP 6.0 EHP8 Installation Export 1/4, Self-extract RAR EXE
-      - '51050708_2'
-      - '51050708_3'
-      - '51050708_4'
-    #  - '51050610_1' # SAP ERP 6.0 EHP8 Language I 1/3, Self-extract RAR EXE
-    #  - '51050610_2'
-    #  - '51050610_3'
-    #  - '51050610_4' # SAP ERP 6.0 EHP8 Language II 1/2, Self-extract RAR EXE
-    #  - '51050610_5'
-    #  - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
-    #  - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
-    #  - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
+
 
   # SAP Business Suite 7i 2013 Support Release 2 > EHP7 for SAP ERP 6.0 ABAP Support Release 2
   # uses SAP NetWeaver 7.5
   sap_ecc6_ehp7_hana_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BS2013SR2.ERP607SR2.HDB.PD
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1
-      - swpm_installation_media_swpm1_exportfiles
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # List of INI file sections to generate using sap_install.sap_swpm role (List).
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - '51050036_1' # SAP ERP 6.0 on HANA EHP7 Installation Export 1/18
+      - '51050036_2'
+      - '51050036_3'
+      - '51050036_4'
+      - '51050036_5'
+      - '51050036_6'
+      - '51050036_7'
+      - '51050036_8'
+      - '51050036_9'
+      - '51050036_10'
+      - '51050036_11'
+      - '51050036_12'
+      - '51050036_13'
+      - '51050036_14'
+      - '51050036_15'
+      - '51050036_16'
+      - '51050036_17'
+      - '51050036_18'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+      - 'SAPKD74083' # SPAM/SAINT Update - Version 740/0083
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_059_17-80002031.SAR'
       - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_1100-80002573.SAR' # Kernel Part I (753)
       - 'SAPEXEDB_1100-80002572.SAR' # Kernel Part II (753), SAP HANA
       - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
       - 'SUM11SP04_3-80006800.SAR' # SUM 1.1
-      - 'SAPKD74083' # SPAM/SAINT Update - Version 740/0083
-      - '51050036_1' # SAP ERP 6.0 on HANA EHP7 Installation Export 1/18
-      - '51050036_2'
-      - '51050036_3'
-      - '51050036_4'
-      - '51050036_5'
-      - '51050036_6'
-      - '51050036_7'
-      - '51050036_8'
-      - '51050036_9'
-      - '51050036_10'
-      - '51050036_11'
-      - '51050036_12'
-      - '51050036_13'
-      - '51050036_14'
-      - '51050036_15'
-      - '51050036_16'
-      - '51050036_17'
-      - '51050036_18'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_059_17-80002046.SAR'
       - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM10SP43_2-70002492.SAR'
-      - 'igsexe_13-80003246.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_1100-80002630.SAR' # Kernel Part I (753)
       - 'SAPEXEDB_1100-80002629.SAR' # Kernel Part II (753), SAP HANA
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
+      - 'igsexe_13-80003246.sar' # IGS 7.53
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM10SP43_2-70002492.SAR'
       - 'SUM11SP04_3-80006861.SAR' # SUM 1.1
-      - 'SAPKD74083' # SPAM/SAINT Update - Version 740/0083
-      - '51050036_1' # SAP ERP 6.0 on HANA EHP7 Installation Export 1/18
-      - '51050036_2'
-      - '51050036_3'
-      - '51050036_4'
-      - '51050036_5'
-      - '51050036_6'
-      - '51050036_7'
-      - '51050036_8'
-      - '51050036_9'
-      - '51050036_10'
-      - '51050036_11'
-      - '51050036_12'
-      - '51050036_13'
-      - '51050036_14'
-      - '51050036_15'
-      - '51050036_16'
-      - '51050036_17'
-      - '51050036_18'
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  sandbox:
+    - swpm_installation_media
+    - swpm_installation_media_swpm1
+    - swpm_installation_media_swpm1_exportfiles
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user

--- a/deploy_scenarios/sap_ecc_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_hana_sandbox/ansible_playbook.yml
@@ -255,8 +255,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 

--- a/deploy_scenarios/sap_ecc_hana_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_ecc_hana_sandbox/optional/ansible_extravars_interactive.yml
@@ -44,155 +44,144 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BS2016.ERP608.HDB.PD
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1
-      - swpm_installation_media_swpm1_exportfiles
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Media
+      - '51050708_1' # SAP ERP 6.0 EHP8 Installation Export 1/4, Self-extract RAR EXE
+      - '51050708_2'
+      - '51050708_3'
+      - '51050708_4'
+    #  - '51050610_1' # SAP ERP 6.0 EHP8 Language I 1/3, Self-extract RAR EXE
+    #  - '51050610_2'
+    #  - '51050610_3'
+    #  - '51050610_4' # SAP ERP 6.0 EHP8 Language II 1/2, Self-extract RAR EXE
+    #  - '51050610_5'
+    #  - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
+    #  - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
+    #  - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+      - 'SAPKD75090' # SPAM/SAINT Update - Version 750/0090
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # - 'VCH202300_2085_0-70007416.SAR'  # Not mandatory
-      - 'SWPM10SP43_3-20009701.SAR'
-      - 'igsexe_5-80007786.sar' # IGS 7.54
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_500-80007612.SAR'  # Kernel Part I (754)
       - 'SAPEXEDB_500-80007611.SAR'  # Kernel Part II (754)
       - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP HOST AGENT 7.22 SP67
+      # - 'VCH202300_2085_0-70007416.SAR'  # Not mandatory
+      - 'igsexe_5-80007786.sar' # IGS 7.54
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_3-20009701.SAR'
       - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
-      - 'SAPKD75090' # SPAM/SAINT Update - Version 750/0090
-      - '51050708_1' # SAP ERP 6.0 EHP8 Installation Export 1/4, Self-extract RAR EXE
-      - '51050708_2'
-      - '51050708_3'
-      - '51050708_4'
-    #  - '51050610_1' # SAP ERP 6.0 EHP8 Language I 1/3, Self-extract RAR EXE
-    #  - '51050610_2'
-    #  - '51050610_3'
-    #  - '51050610_4' # SAP ERP 6.0 EHP8 Language II 1/2, Self-extract RAR EXE
-    #  - '51050610_5'
-    #  - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
-    #  - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
-    #  - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # - 'VCH202300_2085_0-70007417.SAR'  # Not mandatory
-      - 'SWPM10SP43_3-70002492.SAR'
-      - 'igsexe_5-80007795.sar' # IGS 7.54
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_500-80007669.SAR' # Kernel Part I (754)
       - 'SAPEXEDB_500-80007668.SAR' # Kernel Part II (754), SAP HANA
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP HOST AGENT 7.22 SP67
+      # - 'VCH202300_2085_0-70007417.SAR'  # Not mandatory
+      - 'igsexe_5-80007795.sar' # IGS 7.54
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM10SP43_3-70002492.SAR'
       - 'SUM20SP22_7-80002470.SAR' # SUM 2.0
-      - 'SAPKD75090' # SPAM/SAINT Update - Version 750/0083
-      - '51050708_1' # SAP ERP 6.0 EHP8 Installation Export 1/4, Self-extract RAR EXE
-      - '51050708_2'
-      - '51050708_3'
-      - '51050708_4'
-    #  - '51050610_1' # SAP ERP 6.0 EHP8 Language I 1/3, Self-extract RAR EXE
-    #  - '51050610_2'
-    #  - '51050610_3'
-    #  - '51050610_4' # SAP ERP 6.0 EHP8 Language II 1/2, Self-extract RAR EXE
-    #  - '51050610_5'
-    #  - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
-    #  - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
-    #  - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
+
 
   # SAP Business Suite 7i 2013 Support Release 2 > EHP7 for SAP ERP 6.0 ABAP Support Release 2
   # uses SAP NetWeaver 7.5
   sap_ecc6_ehp7_hana_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BS2013SR2.ERP607SR2.HDB.PD
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1
-      - swpm_installation_media_swpm1_exportfiles
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # List of INI file sections to generate using sap_install.sap_swpm role (List).
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - '51050036_1' # SAP ERP 6.0 on HANA EHP7 Installation Export 1/18
+      - '51050036_2'
+      - '51050036_3'
+      - '51050036_4'
+      - '51050036_5'
+      - '51050036_6'
+      - '51050036_7'
+      - '51050036_8'
+      - '51050036_9'
+      - '51050036_10'
+      - '51050036_11'
+      - '51050036_12'
+      - '51050036_13'
+      - '51050036_14'
+      - '51050036_15'
+      - '51050036_16'
+      - '51050036_17'
+      - '51050036_18'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+      - 'SAPKD74083' # SPAM/SAINT Update - Version 740/0083
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_059_17-80002031.SAR'
       - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_1100-80002573.SAR' # Kernel Part I (753)
       - 'SAPEXEDB_1100-80002572.SAR' # Kernel Part II (753), SAP HANA
       - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
       - 'SUM11SP04_3-80006800.SAR' # SUM 1.1
-      - 'SAPKD74083' # SPAM/SAINT Update - Version 740/0083
-      - '51050036_1' # SAP ERP 6.0 on HANA EHP7 Installation Export 1/18
-      - '51050036_2'
-      - '51050036_3'
-      - '51050036_4'
-      - '51050036_5'
-      - '51050036_6'
-      - '51050036_7'
-      - '51050036_8'
-      - '51050036_9'
-      - '51050036_10'
-      - '51050036_11'
-      - '51050036_12'
-      - '51050036_13'
-      - '51050036_14'
-      - '51050036_15'
-      - '51050036_16'
-      - '51050036_17'
-      - '51050036_18'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_059_17-80002046.SAR'
       - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM10SP43_2-70002492.SAR'
-      - 'igsexe_13-80003246.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_1100-80002630.SAR' # Kernel Part I (753)
       - 'SAPEXEDB_1100-80002629.SAR' # Kernel Part II (753), SAP HANA
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
+      - 'igsexe_13-80003246.sar' # IGS 7.53
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM10SP43_2-70002492.SAR'
       - 'SUM11SP04_3-80006861.SAR' # SUM 1.1
-      - 'SAPKD74083' # SPAM/SAINT Update - Version 740/0083
-      - '51050036_1' # SAP ERP 6.0 on HANA EHP7 Installation Export 1/18
-      - '51050036_2'
-      - '51050036_3'
-      - '51050036_4'
-      - '51050036_5'
-      - '51050036_6'
-      - '51050036_7'
-      - '51050036_8'
-      - '51050036_9'
-      - '51050036_10'
-      - '51050036_11'
-      - '51050036_12'
-      - '51050036_13'
-      - '51050036_14'
-      - '51050036_15'
-      - '51050036_16'
-      - '51050036_17'
-      - '51050036_18'
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  sandbox:
+    - swpm_installation_media
+    - swpm_installation_media_swpm1
+    - swpm_installation_media_swpm1_exportfiles
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
 
 
 #### Interactive Prompt Control Variables ####

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_extravars.yml
@@ -30,7 +30,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -93,16 +93,16 @@ sap_software_install_dictionary:
 
   sap_ecc6_ehp8_ibmdb2_distributed:
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
-      - '51056772' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - '73554900102000002424' # IBM DB2 LUW 11.5 SAP OEM license (Note 816773), ZIP
+      - '51056772' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
+      # Application Server
       - '51056774' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 Client, ZIP
       - '51050708_1' # SAP ERP 6.0 EHP8 Installation Export 1/4, Self-extract RAR EXE
       - '51050708_2'
@@ -116,11 +116,19 @@ sap_software_install_dictionary:
       # - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
       # - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
       # - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
-
 
     # SAP Business Suite 7i 2016 > EHP8 for SAP ERP 6.0 ABAP > IBM Db2 for Linux, UNIX, and Windows (LUW)
     # > Installation > Application Server ABAP > Standard System > Database Instance
@@ -145,8 +153,10 @@ sap_software_install_dictionary:
 
     nwas_ascs:
 
+      # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:BS2016.ERP608.DB6.PD
 
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
       sap_swpm_inifile_sections_list:
         - swpm_installation_media
         - swpm_installation_media_swpm1_ibmdb2
@@ -163,7 +173,8 @@ sap_software_install_dictionary:
         - nw_config_host_agent
         - sap_os_linux_user
 
-      software_files_wildcard_list:
+      # List of file name patterns relevant to host type.
+      sap_software_files_wildcard_list:
         - 'SAPCAR*'
         - 'IMDB_CLIENT*'
         - 'SWPM10*'
@@ -176,8 +187,10 @@ sap_software_install_dictionary:
 
     nwas_pas:
 
+      # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_ABAP_CI:BS2016.ERP608.DB6.PD
 
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
       sap_swpm_inifile_sections_list:
         - swpm_installation_media
         - swpm_installation_media_swpm1_exportfiles
@@ -197,8 +210,10 @@ sap_software_install_dictionary:
 
     nwas_aas:
 
+      # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_DI:BS2016.ERP608.DB6.PD
 
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
       sap_swpm_inifile_sections_list:
         - swpm_installation_media
         - swpm_installation_media_swpm1_ibmdb2
@@ -214,7 +229,8 @@ sap_software_install_dictionary:
         - nw_config_host_agent
         - sap_os_linux_user
 
-      software_files_wildcard_list:
+      # List of file name patterns relevant to host type.
+      sap_software_files_wildcard_list:
         - 'SAPCAR*'
         - 'IMDB_CLIENT*'
         - 'SWPM10*'

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_playbook.yml
@@ -270,8 +270,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
@@ -279,7 +280,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_ascs']['software_files_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_ascs']['sap_software_files_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_nwas_ascs_install_media_files
 
@@ -287,7 +288,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_aas']['software_files_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_aas']['sap_software_files_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_nwas_aas_install_media_files
 

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed/optional/ansible_extravars_interactive.yml
@@ -36,34 +36,42 @@ sap_software_install_dictionary:
 
   sap_ecc6_ehp8_ibmdb2_distributed:
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
-      - '51056772' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - '73554900102000002424' # IBM DB2 LUW 11.5 SAP OEM license (Note 816773), ZIP
+      - '51056772' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
+      # Application Server
       - '51056774' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 Client, ZIP
       - '51050708_1' # SAP ERP 6.0 EHP8 Installation Export 1/4, Self-extract RAR EXE
       - '51050708_2'
       - '51050708_3'
       - '51050708_4'
-    #  - '51050610_1' # SAP ERP 6.0 EHP8 Language I 1/3, Self-extract RAR EXE
-    #  - '51050610_2'
-    #  - '51050610_3'
-    #  - '51050610_4' # SAP ERP 6.0 EHP8 Language II 1/2, Self-extract RAR EXE
-    #  - '51050610_5'
-    #  - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
-    #  - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
-    #  - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
+      # - '51050610_1' # SAP ERP 6.0 EHP8 Language I 1/3, Self-extract RAR EXE
+      # - '51050610_2'
+      # - '51050610_3'
+      # - '51050610_4' # SAP ERP 6.0 EHP8 Language II 1/2, Self-extract RAR EXE
+      # - '51050610_5'
+      # - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
+      # - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
+      # - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
-
 
     # SAP Business Suite 7i 2016 > EHP8 for SAP ERP 6.0 ABAP > IBM Db2 for Linux, UNIX, and Windows (LUW)
     # > Installation > Application Server ABAP > Standard System > Database Instance
@@ -88,8 +96,10 @@ sap_software_install_dictionary:
 
     nwas_ascs:
 
+      # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:BS2016.ERP608.DB6.PD
 
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
       sap_swpm_inifile_sections_list:
         - swpm_installation_media
         - swpm_installation_media_swpm1_ibmdb2
@@ -106,7 +116,8 @@ sap_software_install_dictionary:
         - nw_config_host_agent
         - sap_os_linux_user
 
-      software_files_wildcard_list:
+      # List of file name patterns relevant to host type.
+      sap_software_files_wildcard_list:
         - 'SAPCAR*'
         - 'IMDB_CLIENT*'
         - 'SWPM10*'
@@ -119,8 +130,10 @@ sap_software_install_dictionary:
 
     nwas_pas:
 
+      # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_ABAP_CI:BS2016.ERP608.DB6.PD
 
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
       sap_swpm_inifile_sections_list:
         - swpm_installation_media
         - swpm_installation_media_swpm1_exportfiles
@@ -140,8 +153,10 @@ sap_software_install_dictionary:
 
     nwas_aas:
 
+      # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_DI:BS2016.ERP608.DB6.PD
 
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
       sap_swpm_inifile_sections_list:
         - swpm_installation_media
         - swpm_installation_media_swpm1_ibmdb2
@@ -157,7 +172,8 @@ sap_software_install_dictionary:
         - nw_config_host_agent
         - sap_os_linux_user
 
-      software_files_wildcard_list:
+      # List of file name patterns relevant to host type.
+      sap_software_files_wildcard_list:
         - 'SAPCAR*'
         - 'IMDB_CLIENT*'
         - 'SWPM10*'

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_extravars.yml
@@ -31,7 +31,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -136,19 +136,17 @@ sap_software_install_dictionary:
 
   sap_ecc6_ehp8_ibmdb2_distributed:
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
-      # - '51056772' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
-      # - '51056774' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 Client, ZIP
-      - '51057972' # IBM DB2 FOR LUW 11.5 MP9 FP0 SAP4 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
-      - '51057974' # IBM DB2 FOR LUW 11.5 MP9 FP0 SAP4 Client, ZIP
-      - '73554900102000002424' # IBM DB2 FOR LUW 11.5 SAP OEM license (Note 816773), ZIP
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
+      - '73554900102000002424' # IBM DB2 LUW 11.5 SAP OEM license (Note 816773), ZIP
+      - '51056772' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
+      # Application Server
+      - '51056774' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 Client, ZIP
       - '51050708_1' # SAP ERP 6.0 EHP8 Installation Export 1/4, Self-extract RAR EXE
       - '51050708_2'
       - '51050708_3'
@@ -161,9 +159,18 @@ sap_software_install_dictionary:
       # - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
       # - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
       # - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
 
 
@@ -176,37 +183,22 @@ sap_software_install_dictionary:
       sap_swpm_product_catalog_id: NW_ABAP_DB:BS2016.ERP608.DB6.HA
 
       # List of INI file sections to generate using sap_install.sap_swpm role (List).
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm1_exportfiles
-        - swpm_installation_media_swpm1_ibmdb2
-        - credentials
-        - credentials_anydb_ibmdb2
-        - db_config_anydb_all
-        - db_config_anydb_ibmdb2
-        - db_connection_nw_anydb_ibmdb2
-        - nw_config_other
-        - sap_os_linux_user
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ibmdb2'] }}"
 
     # SAP Business Suite 7i 2016 > EHP8 for SAP ERP 6.0 ABAP > IBM Db2 for Linux, UNIX, and Windows
     # > System Copy > Target System > Distributed System > Based on AS ABAP > Database Instance
     anydb_ha_secondary_ibmdb2:
 
+      # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_ABAP_DB:BS2016.ERP608.DB6.HACP
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm1_exportfiles
-        - swpm_installation_media_swpm1_ibmdb2
-        - credentials
-        - credentials_anydb_ibmdb2
-        - db_config_anydb_all
-        - db_config_anydb_ibmdb2
-        - db_connection_nw_anydb_ibmdb2
-        - nw_config_other
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ibmdb2'] }}"
 
-      software_files_wildcard_list:
+      # List of file name patterns relevant to host type.
+      sap_software_files_wildcard_list:
         - 'SAPCAR*'
         - 'IMDB_CLIENT*'
         - 'SWPM10*'
@@ -221,13 +213,14 @@ sap_software_install_dictionary:
         - '51058*' # IBM DB2 FOR LUW files
         - '73554900102000002424*' # IBM DB2 LUW 11.5 SAP OEM license (Note 816773), ZIP
 
-
     # SAP Business Suite 7i 2016 > EHP8 for SAP ERP 6.0 ABAP > IBM Db2 for Linux, UNIX, and Windows
     # > System Copy > Target System > High-Availability System > Based on AS ABAP > Database Instance
     anydb_ha_syscopy_import_secondary:
 
+      # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_ABAP_DB:BS2016.ERP608.DB6.HACP
 
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
       sap_swpm_inifile_sections_list:
         - swpm_installation_media
         - swpm_installation_media_swpm1_ibmdb2
@@ -242,11 +235,12 @@ sap_software_install_dictionary:
         # AnyDB Instance Parameters
         sap_swpm_load_type: DB6BR
 
-
     nwas_ascs_ha:
 
+      # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:BS2016.ERP608.DB6.HA
 
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
       sap_swpm_inifile_sections_list:
         - swpm_installation_media
         - swpm_installation_media_swpm1_ibmdb2
@@ -263,22 +257,16 @@ sap_software_install_dictionary:
         - nw_config_host_agent
         - sap_os_linux_user
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM10*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I
-        - 'SAPEXEDB_*' # Kernel Part II
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['ascs_ers'] }}"
 
     nwas_ers_ha:
 
+      # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_ERS:BS2016.ERP608.DB6.HA
 
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
       sap_swpm_inifile_sections_list:
         - swpm_installation_media
         - credentials
@@ -287,22 +275,16 @@ sap_software_install_dictionary:
         - nw_config_ers
         - sap_os_linux_user
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM10*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I
-        - 'SAPEXEDB_*' # Kernel Part II
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['ascs_ers'] }}"
 
     nwas_pas:
 
+      # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_ABAP_CI:BS2016.ERP608.DB6.PD
 
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
       sap_swpm_inifile_sections_list:
         - swpm_installation_media
         - swpm_installation_media_swpm1_exportfiles
@@ -320,11 +302,12 @@ sap_software_install_dictionary:
         - nw_config_host_agent
         - sap_os_linux_user
 
-
     nwas_aas:
 
+      # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_DI:BS2016.ERP608.DB6.PD
 
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
       sap_swpm_inifile_sections_list:
         - swpm_installation_media
         - swpm_installation_media_swpm1_ibmdb2
@@ -340,7 +323,8 @@ sap_software_install_dictionary:
         - nw_config_host_agent
         - sap_os_linux_user
 
-      software_files_wildcard_list:
+      # List of file name patterns relevant to host type.
+      sap_software_files_wildcard_list:
         - 'SAPCAR*'
         - 'IMDB_CLIENT*'
         - 'SWPM10*'
@@ -353,3 +337,35 @@ sap_software_install_dictionary:
         - '51056*' # IBM DB2 FOR LUW files
         - '51057*' # IBM DB2 FOR LUW files
         - '51058*' # IBM DB2 FOR LUW files
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  ibmdb2:
+    - swpm_installation_media
+    - swpm_installation_media_swpm1_exportfiles
+    - swpm_installation_media_swpm1_ibmdb2
+    - credentials
+    - credentials_anydb_ibmdb2
+    - db_config_anydb_all
+    - db_config_anydb_ibmdb2
+    - db_connection_nw_anydb_ibmdb2
+    - nw_config_other
+    - sap_os_linux_user
+
+# Dictionary of lists for software filename wildcard patterns that is used during rsync operations.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_software_wildcards:
+  ascs_ers:
+    - 'SAPCAR*'
+    - 'IMDB_CLIENT*'
+    - 'SWPM10*'
+    - 'igsexe_*'
+    - 'igshelper_*'
+    - 'SAPEXE_*' # Kernel Part I
+    - 'SAPEXEDB_*' # Kernel Part II
+    - 'SUM*'
+    - 'SAPHOSTAGENT*'

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_playbook.yml
@@ -272,8 +272,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
@@ -281,7 +282,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_ascs_ha']['software_files_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_ascs_ha']['sap_software_files_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_nwas_ascs_install_media_files
 
@@ -289,7 +290,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_aas']['software_files_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_aas']['sap_software_files_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_nwas_aas_install_media_files
 
@@ -297,7 +298,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['anydb_ha_secondary_ibmdb2']['software_files_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['anydb_ha_secondary_ibmdb2']['sap_software_files_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_anydb_secondary_install_media_files
 

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/optional/ansible_extravars_interactive.yml
@@ -38,19 +38,17 @@ sap_software_install_dictionary:
 
   sap_ecc6_ehp8_ibmdb2_distributed:
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
-      # - '51056772' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
-      # - '51056774' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 Client, ZIP
-      - '51057972' # IBM DB2 FOR LUW 11.5 MP9 FP0 SAP4 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
-      - '51057974' # IBM DB2 FOR LUW 11.5 MP9 FP0 SAP4 Client, ZIP
-      - '73554900102000002424' # IBM DB2 FOR LUW 11.5 SAP OEM license (Note 816773), ZIP
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
+      - '73554900102000002424' # IBM DB2 LUW 11.5 SAP OEM license (Note 816773), ZIP
+      - '51056772' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
+      # Application Server
+      - '51056774' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 Client, ZIP
       - '51050708_1' # SAP ERP 6.0 EHP8 Installation Export 1/4, Self-extract RAR EXE
       - '51050708_2'
       - '51050708_3'
@@ -63,9 +61,18 @@ sap_software_install_dictionary:
       # - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
       # - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
       # - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
 
 
@@ -78,37 +85,22 @@ sap_software_install_dictionary:
       sap_swpm_product_catalog_id: NW_ABAP_DB:BS2016.ERP608.DB6.HA
 
       # List of INI file sections to generate using sap_install.sap_swpm role (List).
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm1_exportfiles
-        - swpm_installation_media_swpm1_ibmdb2
-        - credentials
-        - credentials_anydb_ibmdb2
-        - db_config_anydb_all
-        - db_config_anydb_ibmdb2
-        - db_connection_nw_anydb_ibmdb2
-        - nw_config_other
-        - sap_os_linux_user
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ibmdb2'] }}"
 
     # SAP Business Suite 7i 2016 > EHP8 for SAP ERP 6.0 ABAP > IBM Db2 for Linux, UNIX, and Windows
     # > System Copy > Target System > Distributed System > Based on AS ABAP > Database Instance
     anydb_ha_secondary_ibmdb2:
 
+      # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_ABAP_DB:BS2016.ERP608.DB6.HACP
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm1_exportfiles
-        - swpm_installation_media_swpm1_ibmdb2
-        - credentials
-        - credentials_anydb_ibmdb2
-        - db_config_anydb_all
-        - db_config_anydb_ibmdb2
-        - db_connection_nw_anydb_ibmdb2
-        - nw_config_other
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ibmdb2'] }}"
 
-      software_files_wildcard_list:
+      # List of file name patterns relevant to host type.
+      sap_software_files_wildcard_list:
         - 'SAPCAR*'
         - 'IMDB_CLIENT*'
         - 'SWPM10*'
@@ -123,13 +115,14 @@ sap_software_install_dictionary:
         - '51058*' # IBM DB2 FOR LUW files
         - '73554900102000002424*' # IBM DB2 LUW 11.5 SAP OEM license (Note 816773), ZIP
 
-
     # SAP Business Suite 7i 2016 > EHP8 for SAP ERP 6.0 ABAP > IBM Db2 for Linux, UNIX, and Windows
     # > System Copy > Target System > High-Availability System > Based on AS ABAP > Database Instance
     anydb_ha_syscopy_import_secondary:
 
+      # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_ABAP_DB:BS2016.ERP608.DB6.HACP
 
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
       sap_swpm_inifile_sections_list:
         - swpm_installation_media
         - swpm_installation_media_swpm1_ibmdb2
@@ -144,11 +137,12 @@ sap_software_install_dictionary:
         # AnyDB Instance Parameters
         sap_swpm_load_type: DB6BR
 
-
     nwas_ascs_ha:
 
+      # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:BS2016.ERP608.DB6.HA
 
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
       sap_swpm_inifile_sections_list:
         - swpm_installation_media
         - swpm_installation_media_swpm1_ibmdb2
@@ -165,22 +159,16 @@ sap_software_install_dictionary:
         - nw_config_host_agent
         - sap_os_linux_user
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM10*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I
-        - 'SAPEXEDB_*' # Kernel Part II
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['ascs_ers'] }}"
 
     nwas_ers_ha:
 
+      # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_ERS:BS2016.ERP608.DB6.HA
 
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
       sap_swpm_inifile_sections_list:
         - swpm_installation_media
         - credentials
@@ -189,22 +177,16 @@ sap_software_install_dictionary:
         - nw_config_ers
         - sap_os_linux_user
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM10*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I
-        - 'SAPEXEDB_*' # Kernel Part II
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['ascs_ers'] }}"
 
     nwas_pas:
 
+      # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_ABAP_CI:BS2016.ERP608.DB6.PD
 
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
       sap_swpm_inifile_sections_list:
         - swpm_installation_media
         - swpm_installation_media_swpm1_exportfiles
@@ -222,11 +204,12 @@ sap_software_install_dictionary:
         - nw_config_host_agent
         - sap_os_linux_user
 
-
     nwas_aas:
 
+      # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_DI:BS2016.ERP608.DB6.PD
 
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
       sap_swpm_inifile_sections_list:
         - swpm_installation_media
         - swpm_installation_media_swpm1_ibmdb2
@@ -242,7 +225,8 @@ sap_software_install_dictionary:
         - nw_config_host_agent
         - sap_os_linux_user
 
-      software_files_wildcard_list:
+      # List of file name patterns relevant to host type.
+      sap_software_files_wildcard_list:
         - 'SAPCAR*'
         - 'IMDB_CLIENT*'
         - 'SWPM10*'
@@ -255,6 +239,38 @@ sap_software_install_dictionary:
         - '51056*' # IBM DB2 FOR LUW files
         - '51057*' # IBM DB2 FOR LUW files
         - '51058*' # IBM DB2 FOR LUW files
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  ibmdb2:
+    - swpm_installation_media
+    - swpm_installation_media_swpm1_exportfiles
+    - swpm_installation_media_swpm1_ibmdb2
+    - credentials
+    - credentials_anydb_ibmdb2
+    - db_config_anydb_all
+    - db_config_anydb_ibmdb2
+    - db_connection_nw_anydb_ibmdb2
+    - nw_config_other
+    - sap_os_linux_user
+
+# Dictionary of lists for software filename wildcard patterns that is used during rsync operations.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_software_wildcards:
+  ascs_ers:
+    - 'SAPCAR*'
+    - 'IMDB_CLIENT*'
+    - 'SWPM10*'
+    - 'igsexe_*'
+    - 'igshelper_*'
+    - 'SAPEXE_*' # Kernel Part I
+    - 'SAPEXEDB_*' # Kernel Part II
+    - 'SUM*'
+    - 'SAPHOSTAGENT*'
 
 
 #### Interactive Prompt Control Variables ####

--- a/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_extravars.yml
@@ -29,7 +29,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -93,49 +93,44 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BS2016.ERP608.DB6.PD
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1_exportfiles
-      - swpm_installation_media_swpm1_ibmdb2
-      - credentials
-      - credentials_anydb_ibmdb2
-      - db_config_anydb_all
-      - db_config_anydb_ibmdb2
-      - db_connection_nw_anydb_ibmdb2
-      - nw_config_anydb
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
-      - '51056772' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - '73554900102000002424' # IBM DB2 LUW 11.5 SAP OEM license (Note 816773), ZIP
+      - '51056772' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
+      # Application Server
       - '51056774' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 Client, ZIP
       - '51050708_1' # SAP ERP 6.0 EHP8 Installation Export 1/4, Self-extract RAR EXE
       - '51050708_2'
       - '51050708_3'
       - '51050708_4'
-    #  - '51050610_1' # SAP ERP 6.0 EHP8 Language I 1/3, Self-extract RAR EXE
-    #  - '51050610_2'
-    #  - '51050610_3'
-    #  - '51050610_4' # SAP ERP 6.0 EHP8 Language II 1/2, Self-extract RAR EXE
-    #  - '51050610_5'
-    #  - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
-    #  - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
-    #  - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
+      # - '51050610_1' # SAP ERP 6.0 EHP8 Language I 1/3, Self-extract RAR EXE
+      # - '51050610_2'
+      # - '51050610_3'
+      # - '51050610_4' # SAP ERP 6.0 EHP8 Language II 1/2, Self-extract RAR EXE
+      # - '51050610_5'
+      # - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
+      # - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
+      # - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
 
 
@@ -143,48 +138,63 @@ sap_software_install_dictionary:
   # > Installation > Application Server ABAP > Standard System
   # uses SAP NetWeaver 7.5
   sap_ecc6_ehp7_ibmdb2_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BS2013SR2.ERP607SR2.DB6.PD
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1_exportfiles
-      - swpm_installation_media_swpm1_ibmdb2
-      - credentials
-      - credentials_anydb_ibmdb2
-      - db_config_anydb_all
-      - db_config_anydb_ibmdb2
-      - db_connection_nw_anydb_ibmdb2
-      - nw_config_anydb
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    sap_software_list_x86_64:
+      # Database Server
       - '51056772' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
       - '73554900102000002424' # IBM DB2 LUW 11.5 SAP OEM license (Note 816773), ZIP
+      # Application Server
       - '51056774' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 Client, ZIP
       - '51050882_1' # SAP ERP 6.0 EHP7 SR2 Installation Export I 1/2, Self-extract RAR EXE
       - '51050882_2'
       - '51050882_3' # SAP ERP 6.0 EHP7 SR2 Installation Export II, ZIP
-    #  - '51050882_4' # SAP ERP 6.0 EHP7 SR2 Language I 1/2
-    #  - '51050882_5'
-    #  - '51050882_6' # SAP ERP 6.0 EHP7 SR2 Language II 1/2
-    #  - '51050882_7'
-    #  - '51050882_8' # SAP ERP 6.0 EHP7 SR2 Language III
-    #  - '51050882_16' # SAP ERP 6.0 EHP7 SR2 SAP Components
-    #  - '51050882_15' # BS7i2013 SR2 Java Components - NW 7.4, ZIP
+      # - '51050882_4' # SAP ERP 6.0 EHP7 SR2 Language I 1/2
+      # - '51050882_5'
+      # - '51050882_6' # SAP ERP 6.0 EHP7 SR2 Language II 1/2
+      # - '51050882_7'
+      # - '51050882_8' # SAP ERP 6.0 EHP7 SR2 Language III
+      # - '51050882_16' # SAP ERP 6.0 EHP7 SR2 SAP Components
+      # - '51050882_15' # BS7i2013 SR2 Java Components - NW 7.4, ZIP
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  sandbox:
+    - swpm_installation_media
+    - swpm_installation_media_swpm1_exportfiles
+    - swpm_installation_media_swpm1_ibmdb2
+    - credentials
+    - credentials_anydb_ibmdb2
+    - db_config_anydb_all
+    - db_config_anydb_ibmdb2
+    - db_connection_nw_anydb_ibmdb2
+    - nw_config_anydb
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user

--- a/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_playbook.yml
@@ -255,8 +255,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 

--- a/deploy_scenarios/sap_ecc_ibmdb2_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_sandbox/optional/ansible_extravars_interactive.yml
@@ -37,49 +37,44 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BS2016.ERP608.DB6.PD
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1_exportfiles
-      - swpm_installation_media_swpm1_ibmdb2
-      - credentials
-      - credentials_anydb_ibmdb2
-      - db_config_anydb_all
-      - db_config_anydb_ibmdb2
-      - db_connection_nw_anydb_ibmdb2
-      - nw_config_anydb
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
-      - '51056772' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - '73554900102000002424' # IBM DB2 LUW 11.5 SAP OEM license (Note 816773), ZIP
+      - '51056772' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
+      # Application Server
       - '51056774' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 Client, ZIP
       - '51050708_1' # SAP ERP 6.0 EHP8 Installation Export 1/4, Self-extract RAR EXE
       - '51050708_2'
       - '51050708_3'
       - '51050708_4'
-    #  - '51050610_1' # SAP ERP 6.0 EHP8 Language I 1/3, Self-extract RAR EXE
-    #  - '51050610_2'
-    #  - '51050610_3'
-    #  - '51050610_4' # SAP ERP 6.0 EHP8 Language II 1/2, Self-extract RAR EXE
-    #  - '51050610_5'
-    #  - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
-    #  - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
-    #  - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
+      # - '51050610_1' # SAP ERP 6.0 EHP8 Language I 1/3, Self-extract RAR EXE
+      # - '51050610_2'
+      # - '51050610_3'
+      # - '51050610_4' # SAP ERP 6.0 EHP8 Language II 1/2, Self-extract RAR EXE
+      # - '51050610_5'
+      # - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
+      # - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
+      # - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
 
 
@@ -87,51 +82,66 @@ sap_software_install_dictionary:
   # > Installation > Application Server ABAP > Standard System
   # uses SAP NetWeaver 7.5
   sap_ecc6_ehp7_ibmdb2_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BS2013SR2.ERP607SR2.DB6.PD
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1_exportfiles
-      - swpm_installation_media_swpm1_ibmdb2
-      - credentials
-      - credentials_anydb_ibmdb2
-      - db_config_anydb_all
-      - db_config_anydb_ibmdb2
-      - db_connection_nw_anydb_ibmdb2
-      - nw_config_anydb
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    sap_software_list_x86_64:
+      # Database Server
       - '51056772' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
       - '73554900102000002424' # IBM DB2 LUW 11.5 SAP OEM license (Note 816773), ZIP
+      # Application Server
       - '51056774' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 Client, ZIP
       - '51050882_1' # SAP ERP 6.0 EHP7 SR2 Installation Export I 1/2, Self-extract RAR EXE
       - '51050882_2'
       - '51050882_3' # SAP ERP 6.0 EHP7 SR2 Installation Export II, ZIP
-    #  - '51050882_4' # SAP ERP 6.0 EHP7 SR2 Language I 1/2
-    #  - '51050882_5'
-    #  - '51050882_6' # SAP ERP 6.0 EHP7 SR2 Language II 1/2
-    #  - '51050882_7'
-    #  - '51050882_8' # SAP ERP 6.0 EHP7 SR2 Language III
-    #  - '51050882_16' # SAP ERP 6.0 EHP7 SR2 SAP Components
-    #  - '51050882_15' # BS7i2013 SR2 Java Components - NW 7.4, ZIP
+      # - '51050882_4' # SAP ERP 6.0 EHP7 SR2 Language I 1/2
+      # - '51050882_5'
+      # - '51050882_6' # SAP ERP 6.0 EHP7 SR2 Language II 1/2
+      # - '51050882_7'
+      # - '51050882_8' # SAP ERP 6.0 EHP7 SR2 Language III
+      # - '51050882_16' # SAP ERP 6.0 EHP7 SR2 SAP Components
+      # - '51050882_15' # BS7i2013 SR2 Java Components - NW 7.4, ZIP
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  sandbox:
+    - swpm_installation_media
+    - swpm_installation_media_swpm1_exportfiles
+    - swpm_installation_media_swpm1_ibmdb2
+    - credentials
+    - credentials_anydb_ibmdb2
+    - db_config_anydb_all
+    - db_config_anydb_ibmdb2
+    - db_connection_nw_anydb_ibmdb2
+    - nw_config_anydb
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
 
 
 #### Interactive Prompt Control Variables ####

--- a/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_extravars.yml
@@ -29,7 +29,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -124,37 +124,48 @@ sap_software_install_dictionary:
       - nw_config_host_agent
       - sap_os_linux_user
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002605.SAR' # Kernel Part II (753), Oracle DB
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
-      # DBATOOLS Package for Oracle 11g, 12c and higher, Support Package SAP KERNEL 7.53 64-BIT UNICODE Linux on x86_64 64bit ORACLE
-      - 'DBATL740O11_49-80002605.SAR'
-    #  - '51047708'   # Oracle 12.1 RDBMS Linux on x86_64 64bit (AKA. Oracle Database 12c Release 1), ZIP. Compatible with RHEL 7.x and SLES 12.x
-    #  - '51052773_1' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 1/3, RAR EXE (AKA. Oracle Database 12c Release 2). Compatible with RHEL 7.x and SLES 12.x
-    #  - '51052773_2' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 2/3, RAR. Compatible with RHEL 7.x and SLES 12.x
-    #  - '51052773_3' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 3/3, RAR. Compatible with RHEL 7.x and SLES 12.x
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
+      # - '51047708'   # Oracle 12.1 RDBMS Linux on x86_64 64bit (AKA. Oracle Database 12c Release 1), ZIP. Compatible with RHEL 7.x and SLES 12.x
+      # - '51052773_1' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 1/3, RAR EXE (AKA. Oracle Database 12c Release 2). Compatible with RHEL 7.x and SLES 12.x
+      # - '51052773_2' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 2/3, RAR. Compatible with RHEL 7.x and SLES 12.x
+      # - '51052773_3' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 3/3, RAR. Compatible with RHEL 7.x and SLES 12.x
       - '51053828'   # Oracle 19.0.0.0 RDBMS Linux on x86_64 64bit, ZIP. Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
-    #  - '51054219'   # Oracle Client 12.1.0.2. Compatible with RHEL 7.x and SLES 12.x
-    #  - '51054433'   # Oracle 12.2.0.1 Client V2 64bit (All), ZIP. Compatible with RHEL 7.x and SLES 12.x
+      # - '51054219'   # Oracle Client 12.1.0.2. Compatible with RHEL 7.x and SLES 12.x
+      # - '51054433'   # Oracle 12.2.0.1 Client V2 64bit (All), ZIP. Compatible with RHEL 7.x and SLES 12.x
       - '51057419'   # Oracle 19.0.0.0 RDBMS Client 64bit (All), ZIP (AKA. Oracle Database 19c Base Release). Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
+
+      # Application Server
       - '51050708_1' # SAP ERP 6.0 EHP8 Installation Export 1/4, Self-extract RAR EXE
       - '51050708_2'
       - '51050708_3'
       - '51050708_4'
-    #  - '51050610_1' # SAP ERP 6.0 EHP8 Language I 1/3, Self-extract RAR EXE
-    #  - '51050610_2'
-    #  - '51050610_3'
-    #  - '51050610_4' # SAP ERP 6.0 EHP8 Language II 1/2, Self-extract RAR EXE
-    #  - '51050610_5'
-    #  - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
-    #  - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
-    #  - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
+      # - '51050610_1' # SAP ERP 6.0 EHP8 Language I 1/3, Self-extract RAR EXE
+      # - '51050610_2'
+      # - '51050610_3'
+      # - '51050610_4' # SAP ERP 6.0 EHP8 Language II 1/2, Self-extract RAR EXE
+      # - '51050610_5'
+      # - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
+      # - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
+      # - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
+      # DBATOOLS Package for Oracle 11g, 12c and higher, Support Package SAP KERNEL 7.53 64-BIT UNICODE Linux on x86_64 64bit ORACLE
+      - 'DBATL740O11_49-80002605.SAR'
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002605.SAR' # Kernel Part II (753), Oracle DB
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
 
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
+
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'

--- a/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_playbook.yml
@@ -255,8 +255,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 

--- a/deploy_scenarios/sap_ecc_oracledb_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_ecc_oracledb_sandbox/optional/ansible_extravars_interactive.yml
@@ -38,8 +38,10 @@ sap_software_install_dictionary:
   # uses SAP NetWeaver 7.5
   sap_ecc6_ehp8_oracledb_sandbox:
 
+    # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BS2016.ERP608.ORA.PD
 
+    # List of INI file sections to generate using sap_install.sap_swpm role (List).
     sap_swpm_inifile_sections_list:
       - swpm_installation_media
       - swpm_installation_media_swpm1_exportfiles
@@ -58,39 +60,50 @@ sap_software_install_dictionary:
       - nw_config_host_agent
       - sap_os_linux_user
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002605.SAR' # Kernel Part II (753), Oracle DB
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
-      # DBATOOLS Package for Oracle 11g, 12c and higher, Support Package SAP KERNEL 7.53 64-BIT UNICODE Linux on x86_64 64bit ORACLE
-      - 'DBATL740O11_49-80002605.SAR'
-    #  - '51047708'   # Oracle 12.1 RDBMS Linux on x86_64 64bit (AKA. Oracle Database 12c Release 1), ZIP. Compatible with RHEL 7.x and SLES 12.x
-    #  - '51052773_1' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 1/3, RAR EXE (AKA. Oracle Database 12c Release 2). Compatible with RHEL 7.x and SLES 12.x
-    #  - '51052773_2' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 2/3, RAR. Compatible with RHEL 7.x and SLES 12.x
-    #  - '51052773_3' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 3/3, RAR. Compatible with RHEL 7.x and SLES 12.x
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
+      # - '51047708'   # Oracle 12.1 RDBMS Linux on x86_64 64bit (AKA. Oracle Database 12c Release 1), ZIP. Compatible with RHEL 7.x and SLES 12.x
+      # - '51052773_1' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 1/3, RAR EXE (AKA. Oracle Database 12c Release 2). Compatible with RHEL 7.x and SLES 12.x
+      # - '51052773_2' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 2/3, RAR. Compatible with RHEL 7.x and SLES 12.x
+      # - '51052773_3' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 3/3, RAR. Compatible with RHEL 7.x and SLES 12.x
       - '51053828'   # Oracle 19.0.0.0 RDBMS Linux on x86_64 64bit, ZIP. Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
-    #  - '51054219'   # Oracle Client 12.1.0.2. Compatible with RHEL 7.x and SLES 12.x
-    #  - '51054433'   # Oracle 12.2.0.1 Client V2 64bit (All), ZIP. Compatible with RHEL 7.x and SLES 12.x
+      # - '51054219'   # Oracle Client 12.1.0.2. Compatible with RHEL 7.x and SLES 12.x
+      # - '51054433'   # Oracle 12.2.0.1 Client V2 64bit (All), ZIP. Compatible with RHEL 7.x and SLES 12.x
       - '51057419'   # Oracle 19.0.0.0 RDBMS Client 64bit (All), ZIP (AKA. Oracle Database 19c Base Release). Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
+
+      # Application Server
       - '51050708_1' # SAP ERP 6.0 EHP8 Installation Export 1/4, Self-extract RAR EXE
       - '51050708_2'
       - '51050708_3'
       - '51050708_4'
-    #  - '51050610_1' # SAP ERP 6.0 EHP8 Language I 1/3, Self-extract RAR EXE
-    #  - '51050610_2'
-    #  - '51050610_3'
-    #  - '51050610_4' # SAP ERP 6.0 EHP8 Language II 1/2, Self-extract RAR EXE
-    #  - '51050610_5'
-    #  - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
-    #  - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
-    #  - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
+      # - '51050610_1' # SAP ERP 6.0 EHP8 Language I 1/3, Self-extract RAR EXE
+      # - '51050610_2'
+      # - '51050610_3'
+      # - '51050610_4' # SAP ERP 6.0 EHP8 Language II 1/2, Self-extract RAR EXE
+      # - '51050610_5'
+      # - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
+      # - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
+      # - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
+      # DBATOOLS Package for Oracle 11g, 12c and higher, Support Package SAP KERNEL 7.53 64-BIT UNICODE Linux on x86_64 64bit ORACLE
+      - 'DBATL740O11_49-80002605.SAR'
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002605.SAR' # Kernel Part II (753), Oracle DB
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
 
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
+
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
 
 

--- a/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_extravars.yml
@@ -29,7 +29,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -108,31 +108,39 @@ sap_software_install_dictionary:
       - nw_config_host_agent
       - sap_os_linux_user
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002616.SAR' # Kernel Part II (753), SAP ASE 16.0 FOR BUS. SUITE
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
-      - 'SYBCTRL_1440-80002616.SAR'
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - '51057961_1' # SAP ASE 16.0.04.06 HF1 RDBMS Linux on x86_64 64bit
       - 'ASEBC16004P_5-20012477.SAR' # SAP ASE 16.0 SP04 (160-04) FOR BUS. SUITE DBCLIENT with Patch (P_*)
+      # Application Server
       - '51050708_1' # SAP ERP 6.0 EHP8 Installation Export 1/4, Self-extract RAR EXE
       - '51050708_2'
       - '51050708_3'
       - '51050708_4'
-    #  - '51050610_1' # SAP ERP 6.0 EHP8 Language I 1/3, Self-extract RAR EXE
-    #  - '51050610_2'
-    #  - '51050610_3'
-    #  - '51050610_4' # SAP ERP 6.0 EHP8 Language II 1/2, Self-extract RAR EXE
-    #  - '51050610_5'
-    #  - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
-    #  - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
-    #  - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
+      # - '51050610_1' # SAP ERP 6.0 EHP8 Language I 1/3, Self-extract RAR EXE
+      # - '51050610_2'
+      # - '51050610_3'
+      # - '51050610_4' # SAP ERP 6.0 EHP8 Language II 1/2, Self-extract RAR EXE
+      # - '51050610_5'
+      # - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
+      # - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
+      # - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002616.SAR' # Kernel Part II (753), SAP ASE 16.0 FOR BUS. SUITE
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'SYBCTRL_1440-80002616.SAR'
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
-    # Not available for IBM Power Little Endian (ppc64le),
-    # leave code to keep similarity of code structure across all Terraform Modules for SAP that wrap Ansible Playbooks
-    softwarecenter_search_list_ppc64le:
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'

--- a/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_playbook.yml
@@ -255,8 +255,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 

--- a/deploy_scenarios/sap_ecc_sapase_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_ecc_sapase_sandbox/optional/ansible_extravars_interactive.yml
@@ -32,8 +32,10 @@ sap_software_install_dictionary:
   # uses SAP NetWeaver 7.5
   sap_ecc6_ehp8_sapase_sandbox:
 
+    # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BS2016.ERP608.SYB.PD
 
+    # List of INI file sections to generate using sap_install.sap_swpm role (List).
     sap_swpm_inifile_sections_list:
       - swpm_installation_media
       - swpm_installation_media_swpm1_exportfiles
@@ -50,33 +52,41 @@ sap_software_install_dictionary:
       - nw_config_host_agent
       - sap_os_linux_user
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002616.SAR' # Kernel Part II (753), SAP ASE 16.0 FOR BUS. SUITE
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
-      - 'SYBCTRL_1440-80002616.SAR'
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - '51057961_1' # SAP ASE 16.0.04.06 HF1 RDBMS Linux on x86_64 64bit
       - 'ASEBC16004P_5-20012477.SAR' # SAP ASE 16.0 SP04 (160-04) FOR BUS. SUITE DBCLIENT with Patch (P_*)
+      # Application Server
       - '51050708_1' # SAP ERP 6.0 EHP8 Installation Export 1/4, Self-extract RAR EXE
       - '51050708_2'
       - '51050708_3'
       - '51050708_4'
-    #  - '51050610_1' # SAP ERP 6.0 EHP8 Language I 1/3, Self-extract RAR EXE
-    #  - '51050610_2'
-    #  - '51050610_3'
-    #  - '51050610_4' # SAP ERP 6.0 EHP8 Language II 1/2, Self-extract RAR EXE
-    #  - '51050610_5'
-    #  - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
-    #  - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
-    #  - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
+      # - '51050610_1' # SAP ERP 6.0 EHP8 Language I 1/3, Self-extract RAR EXE
+      # - '51050610_2'
+      # - '51050610_3'
+      # - '51050610_4' # SAP ERP 6.0 EHP8 Language II 1/2, Self-extract RAR EXE
+      # - '51050610_5'
+      # - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
+      # - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
+      # - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002616.SAR' # Kernel Part II (753), SAP ASE 16.0 FOR BUS. SUITE
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'SYBCTRL_1440-80002616.SAR'
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
-    # Not available for IBM Power Little Endian (ppc64le),
-    # leave code to keep similarity of code structure across all Terraform Modules for SAP that wrap Ansible Playbooks
-    softwarecenter_search_list_ppc64le:
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
 
 

--- a/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_extravars.yml
@@ -29,7 +29,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -92,6 +92,11 @@ sap_software_install_dictionary:
     # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BS2016.ERP608.ADA.PD
 
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
     sap_swpm_inifile_sections_list:
       - swpm_installation_media
@@ -109,31 +114,35 @@ sap_software_install_dictionary:
       - nw_config_host_agent
       - sap_os_linux_user
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002604.SAR' # Kernel Part II (753), SAP MaxDB 7.9
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       # - '51054410_2' # CD Media for MaxDB 7.9 - SP10 Build 04 Linux on x86_64 64bit
       - 'MAXDB7911_10-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
       - 'MAXDBART7911_10-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
+      # Application Server
       - '51050708_1' # SAP ERP 6.0 EHP8 Installation Export 1/4, Self-extract RAR EXE
       - '51050708_2'
       - '51050708_3'
       - '51050708_4'
-    #  - '51050610_1' # SAP ERP 6.0 EHP8 Language I 1/3, Self-extract RAR EXE
-    #  - '51050610_2'
-    #  - '51050610_3'
-    #  - '51050610_4' # SAP ERP 6.0 EHP8 Language II 1/2, Self-extract RAR EXE
-    #  - '51050610_5'
-    #  - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
-    #  - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
-    #  - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
+      # - '51050610_1' # SAP ERP 6.0 EHP8 Language I 1/3, Self-extract RAR EXE
+      # - '51050610_2'
+      # - '51050610_3'
+      # - '51050610_4' # SAP ERP 6.0 EHP8 Language II 1/2, Self-extract RAR EXE
+      # - '51050610_5'
+      # - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
+      # - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
+      # - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002604.SAR' # Kernel Part II (753), SAP MaxDB 7.9
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
-    # Not available for IBM Power Little Endian (ppc64le),
-    # leave code to keep similarity of code structure across all Terraform Modules for SAP that wrap Ansible Playbooks
-    softwarecenter_search_list_ppc64le:
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'

--- a/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_playbook.yml
@@ -255,8 +255,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 

--- a/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/optional/ansible_extravars_interactive.yml
@@ -35,6 +35,11 @@ sap_software_install_dictionary:
     # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BS2016.ERP608.ADA.PD
 
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
     sap_swpm_inifile_sections_list:
       - swpm_installation_media
@@ -52,33 +57,37 @@ sap_software_install_dictionary:
       - nw_config_host_agent
       - sap_os_linux_user
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002604.SAR' # Kernel Part II (753), SAP MaxDB 7.9
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       # - '51054410_2' # CD Media for MaxDB 7.9 - SP10 Build 04 Linux on x86_64 64bit
       - 'MAXDB7911_10-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
       - 'MAXDBART7911_10-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
+      # Application Server
       - '51050708_1' # SAP ERP 6.0 EHP8 Installation Export 1/4, Self-extract RAR EXE
       - '51050708_2'
       - '51050708_3'
       - '51050708_4'
-    #  - '51050610_1' # SAP ERP 6.0 EHP8 Language I 1/3, Self-extract RAR EXE
-    #  - '51050610_2'
-    #  - '51050610_3'
-    #  - '51050610_4' # SAP ERP 6.0 EHP8 Language II 1/2, Self-extract RAR EXE
-    #  - '51050610_5'
-    #  - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
-    #  - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
-    #  - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
+      # - '51050610_1' # SAP ERP 6.0 EHP8 Language I 1/3, Self-extract RAR EXE
+      # - '51050610_2'
+      # - '51050610_3'
+      # - '51050610_4' # SAP ERP 6.0 EHP8 Language II 1/2, Self-extract RAR EXE
+      # - '51050610_5'
+      # - '51050610_6' # SAP ERP 6.0 EHP8 Language III, ZIP
+      # - '51050610_16' # SAP ERP 6.0 EHP8 SAP Components, ZIP
+      # - '51050610_17' # BS7i2016 Java Components - NW 7.5, ZIP
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002604.SAR' # Kernel Part II (753), SAP MaxDB 7.9
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
-    # Not available for IBM Power Little Endian (ppc64le),
-    # leave code to keep similarity of code structure across all Terraform Modules for SAP that wrap Ansible Playbooks
-    softwarecenter_search_list_ppc64le:
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
 
 

--- a/deploy_scenarios/sap_hana/ansible_extravars.yml
+++ b/deploy_scenarios/sap_hana/ansible_extravars.yml
@@ -27,7 +27,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -85,50 +85,71 @@ sap_software_install_dictionary:
 
   sap_hana_2_sps08_install:
 
-    softwarecenter_search_list_x86_64:
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
       - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP Host Agent 7.22
+      # Tools
       - 'SAPCAR_1300-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
       - 'SAPHOSTAGENT67_67-80004831.SAR'  # SAP Host Agent 7.22
+      # Tools
       - 'SAPCAR_1300-70007726.EXE'
 
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
 
   sap_hana_2_sps07_install:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
+    sap_software_list_independent: []
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
       - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP Host Agent 7.22
+      # Tools
       - 'SAPCAR_1300-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
       - 'SAPHOSTAGENT67_67-80004831.SAR'  # SAP Host Agent 7.22
+      # Tools
       - 'SAPCAR_1300-70007726.EXE'
 
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
 
   sap_hana_2_sps06_install:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent: []
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
+      # Application Server
       - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
+      # Application Server
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'

--- a/deploy_scenarios/sap_hana/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana/ansible_playbook.yml
@@ -251,8 +251,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 

--- a/deploy_scenarios/sap_hana/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_hana/optional/ansible_extravars_interactive.yml
@@ -26,53 +26,74 @@ sap_software_install_dictionary:
 
   sap_hana_2_sps08_install:
 
-    softwarecenter_search_list_x86_64:
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
       - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP Host Agent 7.22
+      # Tools
       - 'SAPCAR_1300-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
       - 'SAPHOSTAGENT67_67-80004831.SAR'  # SAP Host Agent 7.22
+      # Tools
       - 'SAPCAR_1300-70007726.EXE'
 
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
 
   sap_hana_2_sps07_install:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
+    sap_software_list_independent: []
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
       - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP Host Agent 7.22
+      # Tools
       - 'SAPCAR_1300-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
       - 'SAPHOSTAGENT67_67-80004831.SAR'  # SAP Host Agent 7.22
+      # Tools
       - 'SAPCAR_1300-70007726.EXE'
 
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
 
   sap_hana_2_sps06_install:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent: []
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
+      # Application Server
       - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
+      # Application Server
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
 
 
 #### Interactive Prompt Control Variables ####

--- a/deploy_scenarios/sap_hana_ha/ansible_extravars.yml
+++ b/deploy_scenarios/sap_hana_ha/ansible_extravars.yml
@@ -27,7 +27,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -116,56 +116,89 @@ sap_software_install_dictionary:
 
   sap_hana_2_sps08_install:
 
-    softwarecenter_search_list_x86_64:
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
       - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP Host Agent 7.22
+      # Tools
       - 'SAPCAR_1300-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
       - 'SAPHOSTAGENT67_67-80004831.SAR'  # SAP Host Agent 7.22
+      # Tools
       - 'SAPCAR_1300-70007726.EXE'
 
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    # This list assigned from shared dictionary, because it is same with other products or host types.
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
+
 
   sap_hana_2_sps07_install:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
+    sap_software_list_independent: []
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
       - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP Host Agent 7.22
+      # Tools
       - 'SAPCAR_1300-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
       - 'SAPHOSTAGENT67_67-80004831.SAR'  # SAP Host Agent 7.22
+      # Tools
       - 'SAPCAR_1300-70007726.EXE'
 
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
 
   sap_hana_2_sps06_install:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent: []
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
+      # Application Server
       - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
+      # Application Server
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
 
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for software filename wildcard patterns that is used during rsync operations.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_software_wildcards:
+  hana:
+    - 'SAPCAR*'
+    - 'IMDB_*'
+    - 'SAPHOSTAGENT*'

--- a/deploy_scenarios/sap_hana_ha/ansible_extravars_ibmpowervm_vm_base.yml
+++ b/deploy_scenarios/sap_hana_ha/ansible_extravars_ibmpowervm_vm_base.yml
@@ -7,5 +7,5 @@
 sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host: "ENTER_STRING_VALUE_HERE"
 sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_port: "ENTER_STRING_VALUE_HERE" # Default, 22 for SSH
 sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_login: "ENTER_STRING_VALUE_HERE"
-sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_login_password: "ENTER_STRING_VALUE_HERE"
+sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_login_password: ''
 sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_version: "4"

--- a/deploy_scenarios/sap_hana_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana_ha/ansible_playbook.yml
@@ -269,8 +269,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
@@ -278,7 +279,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['software_files_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['sap_software_files_hana_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_hana_install_media_files
 

--- a/deploy_scenarios/sap_hana_ha/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_hana_ha/optional/ansible_extravars_interactive.yml
@@ -26,59 +26,92 @@ sap_software_install_dictionary:
 
   sap_hana_2_sps08_install:
 
-    softwarecenter_search_list_x86_64:
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
       - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP Host Agent 7.22
+      # Tools
       - 'SAPCAR_1300-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
       - 'SAPHOSTAGENT67_67-80004831.SAR'  # SAP Host Agent 7.22
+      # Tools
       - 'SAPCAR_1300-70007726.EXE'
 
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    # This list assigned from shared dictionary, because it is same with other products or host types.
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
+
 
   sap_hana_2_sps07_install:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
+    sap_software_list_independent: []
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
       - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP Host Agent 7.22
+      # Tools
       - 'SAPCAR_1300-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
       - 'SAPHOSTAGENT67_67-80004831.SAR'  # SAP Host Agent 7.22
+      # Tools
       - 'SAPCAR_1300-70007726.EXE'
 
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
 
   sap_hana_2_sps06_install:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent: []
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
+      # Application Server
       - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
+      # Application Server
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
 
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for software filename wildcard patterns that is used during rsync operations.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_software_wildcards:
+  hana:
+    - 'SAPCAR*'
+    - 'IMDB_*'
+    - 'SAPHOSTAGENT*'
 
 
 #### Interactive Prompt Control Variables ####

--- a/deploy_scenarios/sap_hana_scaleout/ansible_extravars.yml
+++ b/deploy_scenarios/sap_hana_scaleout/ansible_extravars.yml
@@ -32,7 +32,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -95,59 +95,73 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
 
-  # NOTE: SPS08 requires NFS mounted /lss/shared.
   sap_hana_2_sps08_install:
 
-    softwarecenter_search_list_x86_64:
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
       - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP Host Agent 7.22
+      # Tools
       - 'SAPCAR_1300-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
       - 'SAPHOSTAGENT67_67-80004831.SAR'  # SAP Host Agent 7.22
+      # Tools
       - 'SAPCAR_1300-70007726.EXE'
 
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
 
   sap_hana_2_sps07_install:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
+    sap_software_list_independent: []
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
       - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP Host Agent 7.22
+      # Tools
       - 'SAPCAR_1300-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
       - 'SAPHOSTAGENT67_67-80004831.SAR'  # SAP Host Agent 7.22
+      # Tools
       - 'SAPCAR_1300-70007726.EXE'
-
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
 
 
   sap_hana_2_sps06_install:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent: []
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
+      # Application Server
       - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
+      # Application Server
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
-
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'

--- a/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml
@@ -288,8 +288,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 

--- a/deploy_scenarios/sap_hana_scaleout/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_hana_scaleout/optional/ansible_extravars_interactive.yml
@@ -29,62 +29,76 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
 
-  # NOTE: SPS08 requires NFS mounted /lss/shared.
   sap_hana_2_sps08_install:
 
-    softwarecenter_search_list_x86_64:
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
       - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP Host Agent 7.22
+      # Tools
       - 'SAPCAR_1300-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
       - 'SAPHOSTAGENT67_67-80004831.SAR'  # SAP Host Agent 7.22
+      # Tools
       - 'SAPCAR_1300-70007726.EXE'
 
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
 
   sap_hana_2_sps07_install:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
+    sap_software_list_independent: []
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
       - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP Host Agent 7.22
+      # Tools
       - 'SAPCAR_1300-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
       - 'SAPHOSTAGENT67_67-80004831.SAR'  # SAP Host Agent 7.22
+      # Tools
       - 'SAPCAR_1300-70007726.EXE'
-
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
 
 
   sap_hana_2_sps06_install:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent: []
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
+      # Application Server
       - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
+      # Application Server
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
-
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
 
 
 #### Interactive Prompt Control Variables ####

--- a/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_extravars.yml
@@ -30,7 +30,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -147,34 +147,43 @@ sap_software_install_dictionary:
       - nw_config_host_agent
       - sap_os_linux_user
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Media
+      - '51057073_1' # IDES for SAP ERP 6.0 EHP8 on HANA (1/2)
+      - '51057073_2'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+      - 'SAPKD75090' # SPAM/SAINT Update - Version 750/0090
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # - 'VCH202300_2085_0-70007416.SAR'  # Not mandatory
-      - 'SWPM10SP43_3-20009701.SAR'
-      - 'igsexe_5-80007786.sar' # IGS 7.54
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_500-80007612.SAR'  # Kernel Part I (754)
       - 'SAPEXEDB_500-80007611.SAR'  # Kernel Part II (754)
       - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP HOST AGENT 7.22 SP67
+      - 'igsexe_5-80007786.sar' # IGS 7.54
+      # - 'VCH202300_2085_0-70007416.SAR'  # Not mandatory
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_3-20009701.SAR'
       - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
-      - 'SAPKD75090' # SPAM/SAINT Update - Version 750/0090
-      - '51057073_1' # IDES for SAP ERP 6.0 EHP8 on HANA (1/2)
-      - '51057073_2'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # - 'VCH202300_2085_0-70007417.SAR'  # Not mandatory
-      - 'SWPM10SP43_3-70002492.SAR'
-      - 'igsexe_5-80007795.sar' # IGS 7.54
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_500-80007669.SAR' # Kernel Part I (754)
       - 'SAPEXEDB_500-80007668.SAR' # Kernel Part II (754), SAP HANA
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP HOST AGENT 7.22 SP67
+      - 'igsexe_5-80007795.sar' # IGS 7.54
+      # - 'VCH202300_2085_0-70007417.SAR'  # Not mandatory
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM10SP43_3-70002492.SAR'
       - 'SUM20SP22_7-80002470.SAR' # SUM 2.0
-      - 'SAPKD75090' # SPAM/SAINT Update - Version 750/0090
-      - '51057073_1' # IDES for SAP ERP 6.0 EHP8 on HANA (1/2)
-      - '51057073_2'

--- a/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_playbook.yml
@@ -255,8 +255,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 

--- a/deploy_scenarios/sap_ides_ecc_hana_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_ides_ecc_hana_sandbox/optional/ansible_extravars_interactive.yml
@@ -55,37 +55,46 @@ sap_software_install_dictionary:
       - nw_config_host_agent
       - sap_os_linux_user
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Media
+      - '51057073_1' # IDES for SAP ERP 6.0 EHP8 on HANA (1/2)
+      - '51057073_2'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+      - 'SAPKD75090' # SPAM/SAINT Update - Version 750/0090
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # - 'VCH202300_2085_0-70007416.SAR'  # Not mandatory
-      - 'SWPM10SP43_3-20009701.SAR'
-      - 'igsexe_5-80007786.sar' # IGS 7.54
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_500-80007612.SAR'  # Kernel Part I (754)
       - 'SAPEXEDB_500-80007611.SAR'  # Kernel Part II (754)
       - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP HOST AGENT 7.22 SP67
+      - 'igsexe_5-80007786.sar' # IGS 7.54
+      # - 'VCH202300_2085_0-70007416.SAR'  # Not mandatory
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_3-20009701.SAR'
       - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
-      - 'SAPKD75090' # SPAM/SAINT Update - Version 750/0090
-      - '51057073_1' # IDES for SAP ERP 6.0 EHP8 on HANA (1/2)
-      - '51057073_2'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # - 'VCH202300_2085_0-70007417.SAR'  # Not mandatory
-      - 'SWPM10SP43_3-70002492.SAR'
-      - 'igsexe_5-80007795.sar' # IGS 7.54
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_500-80007669.SAR' # Kernel Part I (754)
       - 'SAPEXEDB_500-80007668.SAR' # Kernel Part II (754), SAP HANA
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP HOST AGENT 7.22 SP67
+      - 'igsexe_5-80007795.sar' # IGS 7.54
+      # - 'VCH202300_2085_0-70007417.SAR'  # Not mandatory
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM10SP43_3-70002492.SAR'
       - 'SUM20SP22_7-80002470.SAR' # SUM 2.0
-      - 'SAPKD75090' # SPAM/SAINT Update - Version 750/0090
-      - '51057073_1' # IDES for SAP ERP 6.0 EHP8 on HANA (1/2)
-      - '51057073_2'
 
 
 #### Interactive Prompt Control Variables ####

--- a/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_extravars.yml
@@ -29,7 +29,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -93,34 +93,20 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BS2016.ERP608.DB6.PD
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1_exportfiles
-      - swpm_installation_media_swpm1_ibmdb2
-      - credentials
-      - credentials_anydb_ibmdb2
-      - db_config_anydb_all
-      - db_config_anydb_ibmdb2
-      - db_connection_nw_anydb_ibmdb2
-      - nw_config_anydb
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - '51056772' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
       - '73554900102000002424' # IBM DB2 LUW 11.5 SAP OEM license (Note 816773), ZIP
       - '51056774' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 Client, ZIP
+      # Application Server
       - '51053216_1' # IDES SAP ERP 6.0 EHP8 - INSTALL. EXP. (1/2) 1/22
       - '51053216_2'
       - '51053216_3'
@@ -143,9 +129,18 @@ sap_software_install_dictionary:
       - '51053216_20'
       - '51053216_21'
       - '51053216_22'
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
 
 
@@ -153,37 +148,21 @@ sap_software_install_dictionary:
   # > Installation > Application Server ABAP > Standard System
   # uses SAP NetWeaver 7.5
   sap_ides_ecc6_ehp7_ibmdb2_onehost:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BS2013SR2.ERP607SR2.DB6.PD
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1_exportfiles
-      - swpm_installation_media_swpm1_ibmdb2
-      - credentials
-      - credentials_anydb_ibmdb2
-      - db_config_anydb_all
-      - db_config_anydb_ibmdb2
-      - db_connection_nw_anydb_ibmdb2
-      - nw_config_anydb
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    sap_software_list_x86_64:
+      # Database Server
       - '51056772' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
       - '73554900102000002424' # IBM DB2 LUW 11.5 SAP OEM license (Note 816773), ZIP
       - '51056774' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 Client, ZIP
+      # Application Server
       - '51052818_1' # IDES SAP ERP 6.0 EHP7 Installation Export 1/18
       - '51052818_2'
       - '51052818_3'
@@ -202,7 +181,38 @@ sap_software_install_dictionary:
       - '51052818_16'
       - '51052818_17'
       - '51052818_18'
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  sandbox:
+    - swpm_installation_media
+    - swpm_installation_media_swpm1_exportfiles
+    - swpm_installation_media_swpm1_ibmdb2
+    - credentials
+    - credentials_anydb_ibmdb2
+    - db_config_anydb_all
+    - db_config_anydb_ibmdb2
+    - db_connection_nw_anydb_ibmdb2
+    - nw_config_anydb
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user

--- a/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_playbook.yml
@@ -255,8 +255,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 

--- a/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/optional/ansible_extravars_interactive.yml
@@ -37,34 +37,20 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BS2016.ERP608.DB6.PD
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1_exportfiles
-      - swpm_installation_media_swpm1_ibmdb2
-      - credentials
-      - credentials_anydb_ibmdb2
-      - db_config_anydb_all
-      - db_config_anydb_ibmdb2
-      - db_connection_nw_anydb_ibmdb2
-      - nw_config_anydb
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - '51056772' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
       - '73554900102000002424' # IBM DB2 LUW 11.5 SAP OEM license (Note 816773), ZIP
       - '51056774' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 Client, ZIP
+      # Application Server
       - '51053216_1' # IDES SAP ERP 6.0 EHP8 - INSTALL. EXP. (1/2) 1/22
       - '51053216_2'
       - '51053216_3'
@@ -87,9 +73,18 @@ sap_software_install_dictionary:
       - '51053216_20'
       - '51053216_21'
       - '51053216_22'
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
 
 
@@ -97,37 +92,21 @@ sap_software_install_dictionary:
   # > Installation > Application Server ABAP > Standard System
   # uses SAP NetWeaver 7.5
   sap_ides_ecc6_ehp7_ibmdb2_onehost:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:BS2013SR2.ERP607SR2.DB6.PD
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1_exportfiles
-      - swpm_installation_media_swpm1_ibmdb2
-      - credentials
-      - credentials_anydb_ibmdb2
-      - db_config_anydb_all
-      - db_config_anydb_ibmdb2
-      - db_connection_nw_anydb_ibmdb2
-      - nw_config_anydb
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    sap_software_list_x86_64:
+      # Database Server
       - '51056772' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
       - '73554900102000002424' # IBM DB2 LUW 11.5 SAP OEM license (Note 816773), ZIP
       - '51056774' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 Client, ZIP
+      # Application Server
       - '51052818_1' # IDES SAP ERP 6.0 EHP7 Installation Export 1/18
       - '51052818_2'
       - '51052818_3'
@@ -146,10 +125,41 @@ sap_software_install_dictionary:
       - '51052818_16'
       - '51052818_17'
       - '51052818_18'
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  sandbox:
+    - swpm_installation_media
+    - swpm_installation_media_swpm1_exportfiles
+    - swpm_installation_media_swpm1_ibmdb2
+    - credentials
+    - credentials_anydb_ibmdb2
+    - db_config_anydb_all
+    - db_config_anydb_ibmdb2
+    - db_connection_nw_anydb_ibmdb2
+    - nw_config_anydb
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
 
 
 #### Interactive Prompt Control Variables ####

--- a/deploy_scenarios/sap_landscape_s4hana_standard/ansible_extravars.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard/ansible_extravars.yml
@@ -26,7 +26,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -119,225 +119,114 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.CORE.HDB.ABAP
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_CLIENT*'
-      - 'SWPM20*'
-      - 'igsexe_*'
-      - 'igshelper_*'
-      - 'SAPEXE_*'
-      - 'SAPEXEDB_*'
-      - 'SUM*'
-      - 'SAPHOSTAGENT*'
-      - 'S4CORE*'
-      - 'S4HANAOP*'
-      - 'HANAUMML*'
-      - 'K-*'
-      - 'KD*'
-      - 'KE*'
-      - 'KIT*'
-      - 'SAPPAAPL*'
-      - 'SAP_BASIS*'
+    # List of file name patterns relevant to host type.
+    # This list assigned from shared dictionary, because it is same with other products or host types.
+    sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    # This list assigned from shared dictionary, because it is same with other products or host types.
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
-    softwarecenter_search_list_x86_64:
-      # Database
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
       - 'SAPPAAPL4_2405_0-80004547.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
-      # Media
-      - 'S4HANAOP109_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_INST_EXPORT_2.zip'
-      - 'S4HANAOP109_INST_EXPORT_3.zip'
-      - 'S4HANAOP109_INST_EXPORT_4.zip'
-      - 'S4HANAOP109_INST_EXPORT_5.zip'
-      - 'S4HANAOP109_INST_EXPORT_6.zip'
-      - 'S4HANAOP109_INST_EXPORT_7.zip'
-      - 'S4HANAOP109_INST_EXPORT_8.zip'
-      - 'S4HANAOP109_INST_EXPORT_9.zip'
-      - 'S4HANAOP109_INST_EXPORT_10.zip'
-      - 'S4HANAOP109_INST_EXPORT_11.zip'
-      - 'S4HANAOP109_INST_EXPORT_12.zip'
-      - 'S4HANAOP109_INST_EXPORT_13.zip'
-      - 'S4HANAOP109_INST_EXPORT_14.zip'
-      - 'S4HANAOP109_INST_EXPORT_15.zip'
-      - 'S4HANAOP109_INST_EXPORT_16.zip'
-      - 'S4HANAOP109_INST_EXPORT_17.zip'
-      - 'S4HANAOP109_INST_EXPORT_18.zip'
-      - 'S4HANAOP109_INST_EXPORT_19.zip'
-      - 'S4HANAOP109_INST_EXPORT_20.zip'
-      - 'S4HANAOP109_INST_EXPORT_21.zip'
-      - 'S4HANAOP109_INST_EXPORT_22.zip'
-      - 'S4HANAOP109_INST_EXPORT_23.zip'
-      - 'S4HANAOP109_INST_EXPORT_24.zip'
-      - 'S4HANAOP109_INST_EXPORT_25.zip'
-      - 'S4HANAOP109_INST_EXPORT_26.zip'
-      - 'S4HANAOP109_INST_EXPORT_27.zip'
-      - 'S4HANAOP109_INST_EXPORT_28.zip'
-      - 'S4HANAOP109_INST_EXPORT_29.zip'
-      - 'S4HANAOP109_INST_EXPORT_30.zip'
-      - 'S4HANAOP109_INST_EXPORT_31.zip'
-      - 'S4HANAOP109_INST_EXPORT_32.zip'
-      - 'S4HANAOP109_INST_EXPORT_33.zip'
-      - 'S4HANAOP109_INST_EXPORT_34.zip'
-      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_ERP_LANG_EN.SAR'
       - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007716.EXE'
       - 'SWPM20SP23_2-80003424.SAR'
       # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
-      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
-      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
       - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
-      # Media
-      - 'S4HANAOP109_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_INST_EXPORT_2.zip'
-      - 'S4HANAOP109_INST_EXPORT_3.zip'
-      - 'S4HANAOP109_INST_EXPORT_4.zip'
-      - 'S4HANAOP109_INST_EXPORT_5.zip'
-      - 'S4HANAOP109_INST_EXPORT_6.zip'
-      - 'S4HANAOP109_INST_EXPORT_7.zip'
-      - 'S4HANAOP109_INST_EXPORT_8.zip'
-      - 'S4HANAOP109_INST_EXPORT_9.zip'
-      - 'S4HANAOP109_INST_EXPORT_10.zip'
-      - 'S4HANAOP109_INST_EXPORT_11.zip'
-      - 'S4HANAOP109_INST_EXPORT_12.zip'
-      - 'S4HANAOP109_INST_EXPORT_13.zip'
-      - 'S4HANAOP109_INST_EXPORT_14.zip'
-      - 'S4HANAOP109_INST_EXPORT_15.zip'
-      - 'S4HANAOP109_INST_EXPORT_16.zip'
-      - 'S4HANAOP109_INST_EXPORT_17.zip'
-      - 'S4HANAOP109_INST_EXPORT_18.zip'
-      - 'S4HANAOP109_INST_EXPORT_19.zip'
-      - 'S4HANAOP109_INST_EXPORT_20.zip'
-      - 'S4HANAOP109_INST_EXPORT_21.zip'
-      - 'S4HANAOP109_INST_EXPORT_22.zip'
-      - 'S4HANAOP109_INST_EXPORT_23.zip'
-      - 'S4HANAOP109_INST_EXPORT_24.zip'
-      - 'S4HANAOP109_INST_EXPORT_25.zip'
-      - 'S4HANAOP109_INST_EXPORT_26.zip'
-      - 'S4HANAOP109_INST_EXPORT_27.zip'
-      - 'S4HANAOP109_INST_EXPORT_28.zip'
-      - 'S4HANAOP109_INST_EXPORT_29.zip'
-      - 'S4HANAOP109_INST_EXPORT_30.zip'
-      - 'S4HANAOP109_INST_EXPORT_31.zip'
-      - 'S4HANAOP109_INST_EXPORT_32.zip'
-      - 'S4HANAOP109_INST_EXPORT_33.zip'
-      - 'S4HANAOP109_INST_EXPORT_34.zip'
-      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_ERP_LANG_EN.SAR'
       - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007726.EXE'
       - 'SWPM20SP23_2-80003426.SAR'
-      # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
-      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
-      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
 
 
   sap_s4hana_2023_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2023.CORE.HDB.ABAP
 
-    # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_CLIENT*'
-      - 'SWPM20*'
-      - 'igsexe_*'
-      - 'igshelper_*'
-      - 'SAPEXE_*' # Kernel Part I (785)
-      - 'SAPEXEDB_*' # Kernel Part I (785)
-      - 'SUM*'
-      - 'SAPHOSTAGENT*'
-      - 'S4CORE*'
-      - 'S4HANAOP*'
-      - 'HANAUMML*'
-      - 'K-*'
-      - 'KD*'
-      - 'KE*'
-      - 'KIT*'
-      - 'SAPPAAPL*'
-      - 'SAP_BASIS*'
+    sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
-    softwarecenter_search_list_x86_64:
-      # Database
-      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
-      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
-      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
-      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
-      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
-      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
-      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+    sap_software_list_independent:
+      # Application Media
       - 'S4CORE108_INST_EXPORT_1.zip'
       - 'S4CORE108_INST_EXPORT_2.zip'
       - 'S4CORE108_INST_EXPORT_3.zip'
@@ -370,57 +259,36 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
-      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Application Server
       - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
+      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
+      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
+      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+      - 'igsexe_4-70005417.sar' # IGS 7.81
       # Tools
       - 'SAPCAR_1300-70007716.EXE'
       - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
       - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
-      - 'S4CORE108_INST_EXPORT_1.zip'
-      - 'S4CORE108_INST_EXPORT_2.zip'
-      - 'S4CORE108_INST_EXPORT_3.zip'
-      - 'S4CORE108_INST_EXPORT_4.zip'
-      - 'S4CORE108_INST_EXPORT_5.zip'
-      - 'S4CORE108_INST_EXPORT_6.zip'
-      - 'S4CORE108_INST_EXPORT_7.zip'
-      - 'S4CORE108_INST_EXPORT_8.zip'
-      - 'S4CORE108_INST_EXPORT_9.zip'
-      - 'S4CORE108_INST_EXPORT_10.zip'
-      - 'S4CORE108_INST_EXPORT_11.zip'
-      - 'S4CORE108_INST_EXPORT_12.zip'
-      - 'S4CORE108_INST_EXPORT_13.zip'
-      - 'S4CORE108_INST_EXPORT_14.zip'
-      - 'S4CORE108_INST_EXPORT_15.zip'
-      - 'S4CORE108_INST_EXPORT_16.zip'
-      - 'S4CORE108_INST_EXPORT_17.zip'
-      - 'S4CORE108_INST_EXPORT_18.zip'
-      - 'S4CORE108_INST_EXPORT_19.zip'
-      - 'S4CORE108_INST_EXPORT_20.zip'
-      - 'S4CORE108_INST_EXPORT_21.zip'
-      - 'S4CORE108_INST_EXPORT_22.zip'
-      - 'S4CORE108_INST_EXPORT_23.zip'
-      - 'S4CORE108_INST_EXPORT_24.zip'
-      - 'S4CORE108_INST_EXPORT_25.zip'
-      - 'S4CORE108_INST_EXPORT_26.zip'
-      - 'S4CORE108_INST_EXPORT_27.zip'
-      - 'S4CORE108_INST_EXPORT_28.zip'
-      - 'S4CORE108_INST_EXPORT_29.zip'
-      - 'S4CORE108_INST_EXPORT_30.zip'
-      - 'S4HANAOP108_ERP_LANG_EN.SAR'
-      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
       - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
       # Tools
       - 'SAPCAR_1300-70007726.EXE'
       - 'SWPM20SP20_1-80003426.SAR'
@@ -428,391 +296,280 @@ sap_software_install_dictionary:
 
 
   sap_s4hana_2022_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2022.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_CLIENT*'
-      - 'SWPM20*'
-      - 'igsexe_*'
-      - 'igshelper_*'
-      - 'SAPEXE_*' # Kernel Part I (785)
-      - 'SAPEXEDB_*' # Kernel Part I (785)
-      - 'SUM*'
-      - 'SAPHOSTAGENT*'
-      - 'S4CORE*'
-      - 'S4HANAOP*'
-      - 'HANAUMML*'
-      - 'K-*'
-      - 'KD*'
-      - 'KE*'
-      - 'KIT*'
-      - 'SAPPAAPL*'
-      - 'SAP_BASIS*'
+    sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE107_INST_EXPORT_1.zip'
+      - 'S4CORE107_INST_EXPORT_2.zip'
+      - 'S4CORE107_INST_EXPORT_3.zip'
+      - 'S4CORE107_INST_EXPORT_4.zip'
+      - 'S4CORE107_INST_EXPORT_5.zip'
+      - 'S4CORE107_INST_EXPORT_6.zip'
+      - 'S4CORE107_INST_EXPORT_7.zip'
+      - 'S4CORE107_INST_EXPORT_8.zip'
+      - 'S4CORE107_INST_EXPORT_9.zip'
+      - 'S4CORE107_INST_EXPORT_10.zip'
+      - 'S4CORE107_INST_EXPORT_11.zip'
+      - 'S4CORE107_INST_EXPORT_12.zip'
+      - 'S4CORE107_INST_EXPORT_13.zip'
+      - 'S4CORE107_INST_EXPORT_14.zip'
+      - 'S4CORE107_INST_EXPORT_15.zip'
+      - 'S4CORE107_INST_EXPORT_16.zip'
+      - 'S4CORE107_INST_EXPORT_17.zip'
+      - 'S4CORE107_INST_EXPORT_18.zip'
+      - 'S4CORE107_INST_EXPORT_19.zip'
+      - 'S4CORE107_INST_EXPORT_20.zip'
+      - 'S4CORE107_INST_EXPORT_21.zip'
+      - 'S4CORE107_INST_EXPORT_22.zip'
+      - 'S4CORE107_INST_EXPORT_23.zip'
+      - 'S4CORE107_INST_EXPORT_24.zip'
+      - 'S4CORE107_INST_EXPORT_25.zip'
+      - 'S4CORE107_INST_EXPORT_26.zip'
+      - 'S4CORE107_INST_EXPORT_27.zip'
+      - 'S4CORE107_INST_EXPORT_28.zip'
+      - 'S4CORE107_INST_EXPORT_29.zip'
+      - 'S4CORE107_INST_EXPORT_30.zip'
+      - 'S4HANAOP107_ERP_LANG_EN.SAR'
+      # - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
+      # - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_51-70006642.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006641.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
-      - 'S4CORE107_INST_EXPORT_1.zip'
-      - 'S4CORE107_INST_EXPORT_2.zip'
-      - 'S4CORE107_INST_EXPORT_3.zip'
-      - 'S4CORE107_INST_EXPORT_4.zip'
-      - 'S4CORE107_INST_EXPORT_5.zip'
-      - 'S4CORE107_INST_EXPORT_6.zip'
-      - 'S4CORE107_INST_EXPORT_7.zip'
-      - 'S4CORE107_INST_EXPORT_8.zip'
-      - 'S4CORE107_INST_EXPORT_9.zip'
-      - 'S4CORE107_INST_EXPORT_10.zip'
-      - 'S4CORE107_INST_EXPORT_11.zip'
-      - 'S4CORE107_INST_EXPORT_12.zip'
-      - 'S4CORE107_INST_EXPORT_13.zip'
-      - 'S4CORE107_INST_EXPORT_14.zip'
-      - 'S4CORE107_INST_EXPORT_15.zip'
-      - 'S4CORE107_INST_EXPORT_16.zip'
-      - 'S4CORE107_INST_EXPORT_17.zip'
-      - 'S4CORE107_INST_EXPORT_18.zip'
-      - 'S4CORE107_INST_EXPORT_19.zip'
-      - 'S4CORE107_INST_EXPORT_20.zip'
-      - 'S4CORE107_INST_EXPORT_21.zip'
-      - 'S4CORE107_INST_EXPORT_22.zip'
-      - 'S4CORE107_INST_EXPORT_23.zip'
-      - 'S4CORE107_INST_EXPORT_24.zip'
-      - 'S4CORE107_INST_EXPORT_25.zip'
-      - 'S4CORE107_INST_EXPORT_26.zip'
-      - 'S4CORE107_INST_EXPORT_27.zip'
-      - 'S4CORE107_INST_EXPORT_28.zip'
-      - 'S4CORE107_INST_EXPORT_29.zip'
-      - 'S4CORE107_INST_EXPORT_30.zip'
-      - 'S4HANAOP107_ERP_LANG_EN.SAR'
-#      - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
-#      - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
-#      - 'SAPPAAPL4_2203_2-80004547.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
-#      - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # - 'SAPPAAPL4_2203_2-80004547.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
+      # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_51-70006667.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006666.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
-      - 'S4CORE107_INST_EXPORT_1.zip'
-      - 'S4CORE107_INST_EXPORT_2.zip'
-      - 'S4CORE107_INST_EXPORT_3.zip'
-      - 'S4CORE107_INST_EXPORT_4.zip'
-      - 'S4CORE107_INST_EXPORT_5.zip'
-      - 'S4CORE107_INST_EXPORT_6.zip'
-      - 'S4CORE107_INST_EXPORT_7.zip'
-      - 'S4CORE107_INST_EXPORT_8.zip'
-      - 'S4CORE107_INST_EXPORT_9.zip'
-      - 'S4CORE107_INST_EXPORT_10.zip'
-      - 'S4CORE107_INST_EXPORT_11.zip'
-      - 'S4CORE107_INST_EXPORT_12.zip'
-      - 'S4CORE107_INST_EXPORT_13.zip'
-      - 'S4CORE107_INST_EXPORT_14.zip'
-      - 'S4CORE107_INST_EXPORT_15.zip'
-      - 'S4CORE107_INST_EXPORT_16.zip'
-      - 'S4CORE107_INST_EXPORT_17.zip'
-      - 'S4CORE107_INST_EXPORT_18.zip'
-      - 'S4CORE107_INST_EXPORT_19.zip'
-      - 'S4CORE107_INST_EXPORT_20.zip'
-      - 'S4CORE107_INST_EXPORT_21.zip'
-      - 'S4CORE107_INST_EXPORT_22.zip'
-      - 'S4CORE107_INST_EXPORT_23.zip'
-      - 'S4CORE107_INST_EXPORT_24.zip'
-      - 'S4CORE107_INST_EXPORT_25.zip'
-      - 'S4CORE107_INST_EXPORT_26.zip'
-      - 'S4CORE107_INST_EXPORT_27.zip'
-      - 'S4CORE107_INST_EXPORT_28.zip'
-      - 'S4CORE107_INST_EXPORT_29.zip'
-      - 'S4CORE107_INST_EXPORT_30.zip'
-      - 'S4HANAOP107_ERP_LANG_EN.SAR'
-#      - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
-#      - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
-#      - 'SAPPAAPL4_2203_2-80004546.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
-#      - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # - 'SAPPAAPL4_2203_2-80004546.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
+      # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
 
   sap_s4hana_2021_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2021.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_CLIENT*'
-      - 'SWPM20*'
-      - 'igsexe_*'
-      - 'igshelper_*'
-      - 'SAPEXE_*' # Kernel Part I (785)
-      - 'SAPEXEDB_*' # Kernel Part I (785)
-      - 'SUM*'
-      - 'SAPHOSTAGENT*'
-      - 'S4CORE*'
-      - 'S4HANAOP*'
-      - 'HANAUMML*'
-      - 'K-*'
-      - 'KD*'
-      - 'KE*'
-      - 'KIT*'
-      - 'SAPPAAPL*'
-      - 'SAP_BASIS*'
+    sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE106_INST_EXPORT_1.zip'
+      - 'S4CORE106_INST_EXPORT_2.zip'
+      - 'S4CORE106_INST_EXPORT_3.zip'
+      - 'S4CORE106_INST_EXPORT_4.zip'
+      - 'S4CORE106_INST_EXPORT_5.zip'
+      - 'S4CORE106_INST_EXPORT_6.zip'
+      - 'S4CORE106_INST_EXPORT_7.zip'
+      - 'S4CORE106_INST_EXPORT_8.zip'
+      - 'S4CORE106_INST_EXPORT_9.zip'
+      - 'S4CORE106_INST_EXPORT_10.zip'
+      - 'S4CORE106_INST_EXPORT_11.zip'
+      - 'S4CORE106_INST_EXPORT_12.zip'
+      - 'S4CORE106_INST_EXPORT_13.zip'
+      - 'S4CORE106_INST_EXPORT_14.zip'
+      - 'S4CORE106_INST_EXPORT_15.zip'
+      - 'S4CORE106_INST_EXPORT_16.zip'
+      - 'S4CORE106_INST_EXPORT_17.zip'
+      - 'S4CORE106_INST_EXPORT_18.zip'
+      - 'S4CORE106_INST_EXPORT_19.zip'
+      - 'S4CORE106_INST_EXPORT_20.zip'
+      - 'S4CORE106_INST_EXPORT_21.zip'
+      - 'S4CORE106_INST_EXPORT_22.zip'
+      - 'S4CORE106_INST_EXPORT_23.zip'
+      - 'S4CORE106_INST_EXPORT_24.zip'
+      - 'S4CORE106_INST_EXPORT_25.zip'
+      - 'S4CORE106_INST_EXPORT_26.zip'
+      - 'S4CORE106_INST_EXPORT_27.zip'
+      - 'S4CORE106_INST_EXPORT_28.zip'
+      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004822.SAR'
-      - 'S4CORE106_INST_EXPORT_1.zip'
-      - 'S4CORE106_INST_EXPORT_2.zip'
-      - 'S4CORE106_INST_EXPORT_3.zip'
-      - 'S4CORE106_INST_EXPORT_4.zip'
-      - 'S4CORE106_INST_EXPORT_5.zip'
-      - 'S4CORE106_INST_EXPORT_6.zip'
-      - 'S4CORE106_INST_EXPORT_7.zip'
-      - 'S4CORE106_INST_EXPORT_8.zip'
-      - 'S4CORE106_INST_EXPORT_9.zip'
-      - 'S4CORE106_INST_EXPORT_10.zip'
-      - 'S4CORE106_INST_EXPORT_11.zip'
-      - 'S4CORE106_INST_EXPORT_12.zip'
-      - 'S4CORE106_INST_EXPORT_13.zip'
-      - 'S4CORE106_INST_EXPORT_14.zip'
-      - 'S4CORE106_INST_EXPORT_15.zip'
-      - 'S4CORE106_INST_EXPORT_16.zip'
-      - 'S4CORE106_INST_EXPORT_17.zip'
-      - 'S4CORE106_INST_EXPORT_18.zip'
-      - 'S4CORE106_INST_EXPORT_19.zip'
-      - 'S4CORE106_INST_EXPORT_20.zip'
-      - 'S4CORE106_INST_EXPORT_21.zip'
-      - 'S4CORE106_INST_EXPORT_22.zip'
-      - 'S4CORE106_INST_EXPORT_23.zip'
-      - 'S4CORE106_INST_EXPORT_24.zip'
-      - 'S4CORE106_INST_EXPORT_25.zip'
-      - 'S4CORE106_INST_EXPORT_26.zip'
-      - 'S4CORE106_INST_EXPORT_27.zip'
-      - 'S4CORE106_INST_EXPORT_28.zip'
-      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004831.SAR'
-      - 'S4CORE106_INST_EXPORT_1.zip'
-      - 'S4CORE106_INST_EXPORT_2.zip'
-      - 'S4CORE106_INST_EXPORT_3.zip'
-      - 'S4CORE106_INST_EXPORT_4.zip'
-      - 'S4CORE106_INST_EXPORT_5.zip'
-      - 'S4CORE106_INST_EXPORT_6.zip'
-      - 'S4CORE106_INST_EXPORT_7.zip'
-      - 'S4CORE106_INST_EXPORT_8.zip'
-      - 'S4CORE106_INST_EXPORT_9.zip'
-      - 'S4CORE106_INST_EXPORT_10.zip'
-      - 'S4CORE106_INST_EXPORT_11.zip'
-      - 'S4CORE106_INST_EXPORT_12.zip'
-      - 'S4CORE106_INST_EXPORT_13.zip'
-      - 'S4CORE106_INST_EXPORT_14.zip'
-      - 'S4CORE106_INST_EXPORT_15.zip'
-      - 'S4CORE106_INST_EXPORT_16.zip'
-      - 'S4CORE106_INST_EXPORT_17.zip'
-      - 'S4CORE106_INST_EXPORT_18.zip'
-      - 'S4CORE106_INST_EXPORT_19.zip'
-      - 'S4CORE106_INST_EXPORT_20.zip'
-      - 'S4CORE106_INST_EXPORT_21.zip'
-      - 'S4CORE106_INST_EXPORT_22.zip'
-      - 'S4CORE106_INST_EXPORT_23.zip'
-      - 'S4CORE106_INST_EXPORT_24.zip'
-      - 'S4CORE106_INST_EXPORT_25.zip'
-      - 'S4CORE106_INST_EXPORT_26.zip'
-      - 'S4CORE106_INST_EXPORT_27.zip'
-      - 'S4CORE106_INST_EXPORT_28.zip'
-      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
 
   sap_s4hana_2020_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2020.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_CLIENT*'
-      - 'SWPM20*'
-      - 'igsexe_*'
-      - 'igshelper_*'
-      - 'SAPEXE_*' # Kernel Part I (785)
-      - 'SAPEXEDB_*' # Kernel Part I (785)
-      - 'SUM*'
-      - 'SAPHOSTAGENT*'
-      - 'S4CORE*'
-      - 'S4HANAOP*'
-      - 'HANAUMML*'
-      - 'K-*'
-      - 'KD*'
-      - 'KE*'
-      - 'KIT*'
-      - 'SAPPAAPL*'
-      - 'SAP_BASIS*'
+    sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE105_INST_EXPORT_1.zip'
+      - 'S4CORE105_INST_EXPORT_2.zip'
+      - 'S4CORE105_INST_EXPORT_3.zip'
+      - 'S4CORE105_INST_EXPORT_4.zip'
+      - 'S4CORE105_INST_EXPORT_5.zip'
+      - 'S4CORE105_INST_EXPORT_6.zip'
+      - 'S4CORE105_INST_EXPORT_7.zip'
+      - 'S4CORE105_INST_EXPORT_8.zip'
+      - 'S4CORE105_INST_EXPORT_9.zip'
+      - 'S4CORE105_INST_EXPORT_10.zip'
+      - 'S4CORE105_INST_EXPORT_11.zip'
+      - 'S4CORE105_INST_EXPORT_12.zip'
+      - 'S4CORE105_INST_EXPORT_13.zip'
+      - 'S4CORE105_INST_EXPORT_14.zip'
+      - 'S4CORE105_INST_EXPORT_15.zip'
+      - 'S4CORE105_INST_EXPORT_16.zip'
+      - 'S4CORE105_INST_EXPORT_17.zip'
+      - 'S4CORE105_INST_EXPORT_18.zip'
+      - 'S4CORE105_INST_EXPORT_19.zip'
+      - 'S4CORE105_INST_EXPORT_20.zip'
+      - 'S4CORE105_INST_EXPORT_21.zip'
+      - 'S4CORE105_INST_EXPORT_22.zip'
+      - 'S4CORE105_INST_EXPORT_23.zip'
+      - 'S4CORE105_INST_EXPORT_24.zip'
+      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004822.SAR'
-      - 'S4CORE105_INST_EXPORT_1.zip'
-      - 'S4CORE105_INST_EXPORT_2.zip'
-      - 'S4CORE105_INST_EXPORT_3.zip'
-      - 'S4CORE105_INST_EXPORT_4.zip'
-      - 'S4CORE105_INST_EXPORT_5.zip'
-      - 'S4CORE105_INST_EXPORT_6.zip'
-      - 'S4CORE105_INST_EXPORT_7.zip'
-      - 'S4CORE105_INST_EXPORT_8.zip'
-      - 'S4CORE105_INST_EXPORT_9.zip'
-      - 'S4CORE105_INST_EXPORT_10.zip'
-      - 'S4CORE105_INST_EXPORT_11.zip'
-      - 'S4CORE105_INST_EXPORT_12.zip'
-      - 'S4CORE105_INST_EXPORT_13.zip'
-      - 'S4CORE105_INST_EXPORT_14.zip'
-      - 'S4CORE105_INST_EXPORT_15.zip'
-      - 'S4CORE105_INST_EXPORT_16.zip'
-      - 'S4CORE105_INST_EXPORT_17.zip'
-      - 'S4CORE105_INST_EXPORT_18.zip'
-      - 'S4CORE105_INST_EXPORT_19.zip'
-      - 'S4CORE105_INST_EXPORT_20.zip'
-      - 'S4CORE105_INST_EXPORT_21.zip'
-      - 'S4CORE105_INST_EXPORT_22.zip'
-      - 'S4CORE105_INST_EXPORT_23.zip'
-      - 'S4CORE105_INST_EXPORT_24.zip'
-      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004831.SAR'
-      - 'S4CORE105_INST_EXPORT_1.zip'
-      - 'S4CORE105_INST_EXPORT_2.zip'
-      - 'S4CORE105_INST_EXPORT_3.zip'
-      - 'S4CORE105_INST_EXPORT_4.zip'
-      - 'S4CORE105_INST_EXPORT_5.zip'
-      - 'S4CORE105_INST_EXPORT_6.zip'
-      - 'S4CORE105_INST_EXPORT_7.zip'
-      - 'S4CORE105_INST_EXPORT_8.zip'
-      - 'S4CORE105_INST_EXPORT_9.zip'
-      - 'S4CORE105_INST_EXPORT_10.zip'
-      - 'S4CORE105_INST_EXPORT_11.zip'
-      - 'S4CORE105_INST_EXPORT_12.zip'
-      - 'S4CORE105_INST_EXPORT_13.zip'
-      - 'S4CORE105_INST_EXPORT_14.zip'
-      - 'S4CORE105_INST_EXPORT_15.zip'
-      - 'S4CORE105_INST_EXPORT_16.zip'
-      - 'S4CORE105_INST_EXPORT_17.zip'
-      - 'S4CORE105_INST_EXPORT_18.zip'
-      - 'S4CORE105_INST_EXPORT_19.zip'
-      - 'S4CORE105_INST_EXPORT_20.zip'
-      - 'S4CORE105_INST_EXPORT_21.zip'
-      - 'S4CORE105_INST_EXPORT_22.zip'
-      - 'S4CORE105_INST_EXPORT_23.zip'
-      - 'S4CORE105_INST_EXPORT_24.zip'
-      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  standard:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
+
+# Dictionary of lists for software filename wildcard patterns that is used during rsync operations.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_software_wildcards:
+  hana:
+    - 'SAPCAR*'
+    - 'IMDB_*'
+    - 'SAPHOSTAGENT*'
+
+  netweaver:
+    - 'SAPCAR*'
+    - 'IMDB_CLIENT*'
+    - 'SWPM20*'
+    - 'igsexe_*'
+    - 'igshelper_*'
+    - 'SAPEXE_*'
+    - 'SAPEXEDB_*'
+    - 'SUM*'
+    - 'SAPHOSTAGENT*'
+    - 'S4CORE*'
+    - 'S4HANAOP*'
+    - 'HANAUMML*'
+    - 'K-*'
+    - 'KD*'
+    - 'KE*'
+    - 'KIT*'
+    - 'SAPPAAPL*'
+    - 'SAP_BASIS*'

--- a/deploy_scenarios/sap_landscape_s4hana_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard/ansible_playbook.yml
@@ -209,15 +209,16 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
     - name: Find SAP HANA installation media
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['software_files_hana_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['sap_software_files_hana_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_hana_install_media_files
 
@@ -225,7 +226,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['software_files_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['sap_software_files_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_nwas_install_media_files
 
@@ -308,7 +309,8 @@
         verify_host: false
         private_key: "/tmp/hosts_rsa"
         # set_remote_user: false
-      loop: "{{ hostvars[sap_inventory_project_dev_nwas_pas_hostname].__sap_playbook_register_sap_hana_install_media_files.files | map(attribute='path') | list }}"
+      loop: "{{ hostvars[sap_inventory_project_dev_nwas_pas_hostname].__sap_playbook_register_sap_hana_install_media_files.files
+        | map(attribute='path') | list }}"
       loop_control:
         loop_var: file_item
       # In some operating systems (e.g. SLES 16), the particular combination of RSYNC version and SSH configuration can cause issues.
@@ -335,7 +337,8 @@
         verify_host: false
         private_key: "/tmp/hosts_rsa"
         # set_remote_user: false
-      loop: "{{ hostvars[sap_inventory_project_dev_nwas_pas_hostname].__sap_playbook_register_sap_nwas_install_media_files.files | map(attribute='path') | list }}"
+      loop: "{{ hostvars[sap_inventory_project_dev_nwas_pas_hostname].__sap_playbook_register_sap_nwas_install_media_files.files
+        | map(attribute='path') | list }}"
       loop_control:
         loop_var: file_item
       # In some operating systems (e.g. SLES 16), the particular combination of RSYNC version and SSH configuration can cause issues.

--- a/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_extravars.yml
@@ -26,7 +26,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -118,41 +118,34 @@ sap_software_install_dictionary:
 
   sap_s4hana_2025_standard:
 
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
+    sap_software_list_x86_64:
       - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
       - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    # List of file name patterns relevant to host type.
+    # This list assigned from shared dictionary, because it is same with other products or host types.
+    sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
+
+    # This list assigned from shared dictionary, because it is same with other products or host types.
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.CORE.HDB.ABAP
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
-      - maintenance_plan_stack_tms_config
-      - maintenance_plan_stack_spam_config
-      - maintenance_plan_stack_sum_config
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
     sap_swpm_inifile_dictionary:
-
       # SAP SWPM using SAP Maintenance Planner Stack XML
       # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
       sap_swpm_configure_tms: true
@@ -160,65 +153,30 @@ sap_software_install_dictionary:
       sap_swpm_spam_update: false
       sap_swpm_sum_prepare: true
       sap_swpm_sum_start: true
-
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_CLIENT*'
-      - 'SWPM20*'
-      - 'igsexe_*'
-      - 'igshelper_*'
-      - 'SAPEXE_*'
-      - 'SAPEXEDB_*'
-      - 'SUM*'
-      - 'SAPHOSTAGENT*'
-      - 'S4CORE*'
-      - 'S4HANAOP*'
-      - 'HANAUMML*'
-      - 'K-*'
-      - 'KD*'
-      - 'KE*'
-      - 'KIT*'
-      - 'SAPPAAPL*'
-      - 'SAP_BASIS*'
 
 
   sap_s4hana_2023_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
+
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
-    # SWPM product catalog ID for the installation (String).
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
+
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2023.CORE.HDB.ABAP
 
-    # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
-      - maintenance_plan_stack_tms_config
-      - maintenance_plan_stack_spam_config
-      - maintenance_plan_stack_sum_config
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
     sap_swpm_inifile_dictionary:
-
       # SAP SWPM using SAP Maintenance Planner Stack XML
       # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
       sap_swpm_configure_tms: true
@@ -226,64 +184,30 @@ sap_software_install_dictionary:
       sap_swpm_spam_update: false
       sap_swpm_sum_prepare: true
       sap_swpm_sum_start: true
-
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_CLIENT*'
-      - 'SWPM20*'
-      - 'igsexe_*'
-      - 'igshelper_*'
-      - 'SAPEXE_*' # Kernel Part I (785)
-      - 'SAPEXEDB_*' # Kernel Part I (785)
-      - 'SUM*'
-      - 'SAPHOSTAGENT*'
-      - 'S4CORE*'
-      - 'S4HANAOP*'
-      - 'HANAUMML*'
-      - 'K-*'
-      - 'KD*'
-      - 'KE*'
-      - 'KIT*'
-      - 'SAPPAAPL*'
-      - 'SAP_BASIS*'
 
 
   sap_s4hana_2022_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
+
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
-    # Product ID for New Installation
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
+
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2022.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
-      - maintenance_plan_stack_tms_config
-      - maintenance_plan_stack_spam_config
-      - maintenance_plan_stack_sum_config
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
     sap_swpm_inifile_dictionary:
-
       # SAP SWPM using SAP Maintenance Planner Stack XML
       # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
       sap_swpm_configure_tms: true
@@ -291,64 +215,30 @@ sap_software_install_dictionary:
       sap_swpm_spam_update: false
       sap_swpm_sum_prepare: true
       sap_swpm_sum_start: true
-
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_CLIENT*'
-      - 'SWPM20*'
-      - 'igsexe_*'
-      - 'igshelper_*'
-      - 'SAPEXE_*' # Kernel Part I (785)
-      - 'SAPEXEDB_*' # Kernel Part I (785)
-      - 'SUM*'
-      - 'SAPHOSTAGENT*'
-      - 'S4CORE*'
-      - 'S4HANAOP*'
-      - 'HANAUMML*'
-      - 'K-*'
-      - 'KD*'
-      - 'KE*'
-      - 'KIT*'
-      - 'SAPPAAPL*'
-      - 'SAP_BASIS*'
 
 
   sap_s4hana_2021_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
+
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
-    # Product ID for New Installation
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
+
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2021.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
-      - maintenance_plan_stack_tms_config
-      - maintenance_plan_stack_spam_config
-      - maintenance_plan_stack_sum_config
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
     sap_swpm_inifile_dictionary:
-
       # SAP SWPM using SAP Maintenance Planner Stack XML
       # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
       sap_swpm_configure_tms: true
@@ -357,22 +247,53 @@ sap_software_install_dictionary:
       sap_swpm_sum_prepare: true
       sap_swpm_sum_start: true
 
-    software_files_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_CLIENT*'
-      - 'SWPM20*'
-      - 'igsexe_*'
-      - 'igshelper_*'
-      - 'SAPEXE_*' # Kernel Part I (785)
-      - 'SAPEXEDB_*' # Kernel Part I (785)
-      - 'SUM*'
-      - 'SAPHOSTAGENT*'
-      - 'S4CORE*'
-      - 'S4HANAOP*'
-      - 'HANAUMML*'
-      - 'K-*'
-      - 'KD*'
-      - 'KE*'
-      - 'KIT*'
-      - 'SAPPAAPL*'
-      - 'SAP_BASIS*'
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  standard:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
+    - maintenance_plan_stack_tms_config
+    - maintenance_plan_stack_spam_config
+    - maintenance_plan_stack_sum_config
+
+# Dictionary of lists for software filename wildcard patterns that is used during rsync operations.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_software_wildcards:
+  hana:
+    - 'SAPCAR*'
+    - 'IMDB_*'
+    - 'SAPHOSTAGENT*'
+
+  netweaver:
+    - 'SAPCAR*'
+    - 'IMDB_CLIENT*'
+    - 'SWPM20*'
+    - 'igsexe_*'
+    - 'igshelper_*'
+    - 'SAPEXE_*'
+    - 'SAPEXEDB_*'
+    - 'SUM*'
+    - 'SAPHOSTAGENT*'
+    - 'S4CORE*'
+    - 'S4HANAOP*'
+    - 'HANAUMML*'
+    - 'K-*'
+    - 'KD*'
+    - 'KE*'
+    - 'KIT*'
+    - 'SAPPAAPL*'
+    - 'SAP_BASIS*'

--- a/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_playbook.yml
@@ -209,8 +209,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
         sap_software_download_mp_transaction: "{{ sap_maintenance_planner_transaction_name }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
@@ -218,7 +219,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['software_files_hana_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['sap_software_files_hana_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_hana_install_media_files
 
@@ -226,7 +227,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['software_files_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['sap_software_files_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_nwas_install_media_files
 
@@ -309,7 +310,8 @@
         verify_host: false
         private_key: "/tmp/hosts_rsa"
         # set_remote_user: false
-      loop: "{{ hostvars[sap_inventory_project_dev_nwas_pas_hostname].__sap_playbook_register_sap_hana_install_media_files.files | map(attribute='path') | list }}"
+      loop: "{{ hostvars[sap_inventory_project_dev_nwas_pas_hostname].__sap_playbook_register_sap_hana_install_media_files.files
+        | map(attribute='path') | list }}"
       loop_control:
         loop_var: file_item
       # In some operating systems (e.g. SLES 16), the particular combination of RSYNC version and SSH configuration can cause issues.
@@ -336,7 +338,8 @@
         verify_host: false
         private_key: "/tmp/hosts_rsa"
         # set_remote_user: false
-      loop: "{{ hostvars[sap_inventory_project_dev_nwas_pas_hostname].__sap_playbook_register_sap_nwas_install_media_files.files | map(attribute='path') | list }}"
+      loop: "{{ hostvars[sap_inventory_project_dev_nwas_pas_hostname].__sap_playbook_register_sap_nwas_install_media_files.files
+        | map(attribute='path') | list }}"
       loop_control:
         loop_var: file_item
       # In some operating systems (e.g. SLES 16), the particular combination of RSYNC version and SSH configuration can cause issues.

--- a/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_extravars.yml
@@ -30,7 +30,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -131,104 +131,113 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:NW752.HDB.PD
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1
-      - swpm_installation_media_swpm1_exportfiles
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Media
+      - '51051806_1' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 1/2, RAR
+      - '51051806_2' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 2/2, RAR
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # - 'VCH202300_2085_0-70007416.SAR'  # Not mandatory
-      - 'SWPM10SP43_3-20009701.SAR'
-      - 'igsexe_5-80007786.sar' # IGS 7.54
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_500-80007612.SAR'  # Kernel Part I (754)
       - 'SAPEXEDB_500-80007611.SAR'  # Kernel Part II (754)
       - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP HOST AGENT 7.22 SP67
-      - '51051806_1' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 1/2, RAR
-      - '51051806_2' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 2/2, RAR
+      - 'igsexe_5-80007786.sar' # IGS 7.54
+      # - 'VCH202300_2085_0-70007416.SAR'  # Not mandatory
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_3-20009701.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # - 'VCH202300_2085_0-70007417.SAR'  # Not mandatory
-      - 'SWPM10SP43_3-70002492.SAR'
-      - 'igsexe_5-80007795.sar' # IGS 7.54
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_500-80007669.SAR' # Kernel Part I (754)
       - 'SAPEXEDB_500-80007668.SAR' # Kernel Part II (754), SAP HANA
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP HOST AGENT 7.22 SP67
-      - '51051806_1' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 1/2, RAR
-      - '51051806_2' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 2/2, RAR
+      - 'igsexe_5-80007795.sar' # IGS 7.54
+      # - 'VCH202300_2085_0-70007417.SAR'  # Not mandatory
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM10SP43_3-70002492.SAR'
 
 
   # SAP NetWeaver 7.5 > SAP HANA > Installation > Application Server ABAP > Standard System
   sap_nwas_750_sp00_abap_hana_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:NW750.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1
-      - swpm_installation_media_swpm1_exportfiles
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_067_4-80002031.SAR'
-    #  - 'VCH202000_2059_0-80005463.SAR'
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
+    sap_software_list_independent:
+      # Application Media
+      - '51050829_3' # SAP Netweaver 7.5 Installation Export, ZIP
+    #  - '51050829_4' # NW 7.5 Language 1/2
+    #  - '51050829_5' # NW 7.5 Language 2/2
+    #  - '51050829_6' # NW 7.5 Upgrade Export Part I 1/2
+    #  - '51050829_7' # NW 7.5 Upgrade Export Part I 2/2
+    #  - '51050829_8' # NW 7.5 Upgrade Export Part II 1/2
+    #  - '51050829_9' # NW 7.5 Upgrade Export Part II 2/2
+      # Application Server
       - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
+      - 'IMDB_SERVER20_067_4-80002031.SAR'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
+      # Application Server
       - 'SAPEXE_800-80002573.SAR' # Kernel Part I (753)
       - 'SAPEXEDB_800-80002572.SAR' # Kernel Part II (753)
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
       - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - '51050829_3' # SAP Netweaver 7.5 Installation Export, ZIP
-    #  - '51050829_4' # NW 7.5 Language 1/2
-    #  - '51050829_5' # NW 7.5 Language 2/2
-    #  - '51050829_6' # NW 7.5 Upgrade Export Part I 1/2
-    #  - '51050829_7' # NW 7.5 Upgrade Export Part I 2/2
-    #  - '51050829_8' # NW 7.5 Upgrade Export Part II 1/2
-    #  - '51050829_9' # NW 7.5 Upgrade Export Part II 2/2
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+    #  - 'VCH202000_2059_0-80005463.SAR'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
-    #  - 'VCH202000_2059_0-80005464.SAR'
-      - 'SWPM10SP43_2-70002492.SAR'
-      - 'igsexe_13-80003246.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
+      # Application Server
       - 'SAPEXE_800-80002630.SAR' # Kernel Part I (753)
       - 'SAPEXEDB_800-80002629.SAR' # Kernel Part II (753)
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
       - 'SAPHOSTAGENT51_51-70002261.SAR' # SAP Host Agent 7.21
-      - '51050829_3' # SAP Netweaver 7.5 Installation Export, ZIP
-    #  - '51050829_4' # NW 7.5 Language 1/2
-    #  - '51050829_5' # NW 7.5 Language 2/2
-    #  - '51050829_6' # NW 7.5 Upgrade Export Part I 1/2
-    #  - '51050829_7' # NW 7.5 Upgrade Export Part I 2/2
-    #  - '51050829_8' # NW 7.5 Upgrade Export Part II 1/2
-    #  - '51050829_9' # NW 7.5 Upgrade Export Part II 2/2
+      - 'igsexe_13-80003246.sar' # IGS 7.53
+    #  - 'VCH202000_2059_0-80005464.SAR'
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM10SP43_2-70002492.SAR'
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  sandbox:
+    - swpm_installation_media
+    - swpm_installation_media_swpm1
+    - swpm_installation_media_swpm1_exportfiles
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user

--- a/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_playbook.yml
@@ -255,8 +255,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 

--- a/deploy_scenarios/sap_nwas_abap_hana_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_nwas_abap_hana_sandbox/optional/ansible_extravars_interactive.yml
@@ -39,107 +39,116 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:NW752.HDB.PD
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1
-      - swpm_installation_media_swpm1_exportfiles
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Media
+      - '51051806_1' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 1/2, RAR
+      - '51051806_2' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 2/2, RAR
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # - 'VCH202300_2085_0-70007416.SAR'  # Not mandatory
-      - 'SWPM10SP43_3-20009701.SAR'
-      - 'igsexe_5-80007786.sar' # IGS 7.54
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_500-80007612.SAR'  # Kernel Part I (754)
       - 'SAPEXEDB_500-80007611.SAR'  # Kernel Part II (754)
       - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP HOST AGENT 7.22 SP67
-      - '51051806_1' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 1/2, RAR
-      - '51051806_2' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 2/2, RAR
+      - 'igsexe_5-80007786.sar' # IGS 7.54
+      # - 'VCH202300_2085_0-70007416.SAR'  # Not mandatory
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_3-20009701.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # - 'VCH202300_2085_0-70007417.SAR'  # Not mandatory
-      - 'SWPM10SP43_3-70002492.SAR'
-      - 'igsexe_5-80007795.sar' # IGS 7.54
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_500-80007669.SAR' # Kernel Part I (754)
       - 'SAPEXEDB_500-80007668.SAR' # Kernel Part II (754), SAP HANA
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP HOST AGENT 7.22 SP67
-      - '51051806_1' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 1/2, RAR
-      - '51051806_2' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 2/2, RAR
+      - 'igsexe_5-80007795.sar' # IGS 7.54
+      # - 'VCH202300_2085_0-70007417.SAR'  # Not mandatory
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM10SP43_3-70002492.SAR'
 
 
   # SAP NetWeaver 7.5 > SAP HANA > Installation > Application Server ABAP > Standard System
   sap_nwas_750_sp00_abap_hana_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:NW750.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1
-      - swpm_installation_media_swpm1_exportfiles
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'IMDB_SERVER20_067_4-80002031.SAR'
-    #  - 'VCH202000_2059_0-80005463.SAR'
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
+    sap_software_list_independent:
+      # Application Media
+      - '51050829_3' # SAP Netweaver 7.5 Installation Export, ZIP
+    #  - '51050829_4' # NW 7.5 Language 1/2
+    #  - '51050829_5' # NW 7.5 Language 2/2
+    #  - '51050829_6' # NW 7.5 Upgrade Export Part I 1/2
+    #  - '51050829_7' # NW 7.5 Upgrade Export Part I 2/2
+    #  - '51050829_8' # NW 7.5 Upgrade Export Part II 1/2
+    #  - '51050829_9' # NW 7.5 Upgrade Export Part II 2/2
+      # Application Server
       - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
+      - 'IMDB_SERVER20_067_4-80002031.SAR'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
+      # Application Server
       - 'SAPEXE_800-80002573.SAR' # Kernel Part I (753)
       - 'SAPEXEDB_800-80002572.SAR' # Kernel Part II (753)
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
       - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - '51050829_3' # SAP Netweaver 7.5 Installation Export, ZIP
-    #  - '51050829_4' # NW 7.5 Language 1/2
-    #  - '51050829_5' # NW 7.5 Language 2/2
-    #  - '51050829_6' # NW 7.5 Upgrade Export Part I 1/2
-    #  - '51050829_7' # NW 7.5 Upgrade Export Part I 2/2
-    #  - '51050829_8' # NW 7.5 Upgrade Export Part II 1/2
-    #  - '51050829_9' # NW 7.5 Upgrade Export Part II 2/2
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+    #  - 'VCH202000_2059_0-80005463.SAR'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
-    #  - 'VCH202000_2059_0-80005464.SAR'
-      - 'SWPM10SP43_2-70002492.SAR'
-      - 'igsexe_13-80003246.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
+      # Application Server
       - 'SAPEXE_800-80002630.SAR' # Kernel Part I (753)
       - 'SAPEXEDB_800-80002629.SAR' # Kernel Part II (753)
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
       - 'SAPHOSTAGENT51_51-70002261.SAR' # SAP Host Agent 7.21
-      - '51050829_3' # SAP Netweaver 7.5 Installation Export, ZIP
-    #  - '51050829_4' # NW 7.5 Language 1/2
-    #  - '51050829_5' # NW 7.5 Language 2/2
-    #  - '51050829_6' # NW 7.5 Upgrade Export Part I 1/2
-    #  - '51050829_7' # NW 7.5 Upgrade Export Part I 2/2
-    #  - '51050829_8' # NW 7.5 Upgrade Export Part II 1/2
-    #  - '51050829_9' # NW 7.5 Upgrade Export Part II 2/2
+      - 'igsexe_13-80003246.sar' # IGS 7.53
+    #  - 'VCH202000_2059_0-80005464.SAR'
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM10SP43_2-70002492.SAR'
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  sandbox:
+    - swpm_installation_media
+    - swpm_installation_media_swpm1
+    - swpm_installation_media_swpm1_exportfiles
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
 
 
 #### Interactive Prompt Control Variables ####

--- a/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_extravars.yml
@@ -29,7 +29,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -91,75 +91,54 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:NW752.DB6.PD
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1_exportfiles
-      - swpm_installation_media_swpm1_ibmdb2
-      - credentials
-      - credentials_anydb_ibmdb2
-      - db_config_anydb_all
-      - db_config_anydb_ibmdb2
-      - db_connection_nw_anydb_ibmdb2
-      - nw_config_anydb
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - '51056772' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
       - '73554900102000002424' # IBM DB2 LUW 11.5 SAP OEM license (Note 816773), ZIP
       - '51056774' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 Client, ZIP
+      # Application Server
       - '51051806_1' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 1/2, RAR
       - '51051806_2' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 2/2, RAR
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
 
 
   # SAP NetWeaver 7.5 > IBM Db2 for Linux, UNIX, and Windows > Installation > Application Server ABAP > Standard System
   sap_nwas_750_sp00_abap_ibmdb2_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:NW750.DB6.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1_exportfiles
-      - swpm_installation_media_swpm1_ibmdb2
-      - credentials
-      - credentials_anydb_ibmdb2
-      - db_config_anydb_all
-      - db_config_anydb_ibmdb2
-      - db_connection_nw_anydb_ibmdb2
-      - nw_config_anydb
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    sap_software_list_x86_64:
+      # Database Server
       - '51056772' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
       - '73554900102000002424' # IBM DB2 LUW 11.5 SAP OEM license (Note 816773), ZIP
       - '51056774' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 Client, ZIP
+      # Application Server
       - '51050829_3' # SAP Netweaver 7.5 Installation Export, ZIP
     #  - '51050829_4' # NW 7.5 Language 1/2
     #  - '51050829_5' # NW 7.5 Language 2/2
@@ -167,7 +146,38 @@ sap_software_install_dictionary:
     #  - '51050829_7' # NW 7.5 Upgrade Export Part I 2/2
     #  - '51050829_8' # NW 7.5 Upgrade Export Part II 1/2
     #  - '51050829_9' # NW 7.5 Upgrade Export Part II 2/2
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  sandbox:
+    - swpm_installation_media
+    - swpm_installation_media_swpm1_exportfiles
+    - swpm_installation_media_swpm1_ibmdb2
+    - credentials
+    - credentials_anydb_ibmdb2
+    - db_config_anydb_all
+    - db_config_anydb_ibmdb2
+    - db_connection_nw_anydb_ibmdb2
+    - nw_config_anydb
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user

--- a/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_playbook.yml
@@ -255,8 +255,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 

--- a/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/optional/ansible_extravars_interactive.yml
@@ -35,75 +35,54 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:NW752.DB6.PD
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1_exportfiles
-      - swpm_installation_media_swpm1_ibmdb2
-      - credentials
-      - credentials_anydb_ibmdb2
-      - db_config_anydb_all
-      - db_config_anydb_ibmdb2
-      - db_connection_nw_anydb_ibmdb2
-      - nw_config_anydb
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - '51056772' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
       - '73554900102000002424' # IBM DB2 LUW 11.5 SAP OEM license (Note 816773), ZIP
       - '51056774' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 Client, ZIP
+      # Application Server
       - '51051806_1' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 1/2, RAR
       - '51051806_2' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 2/2, RAR
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
 
 
   # SAP NetWeaver 7.5 > IBM Db2 for Linux, UNIX, and Windows > Installation > Application Server ABAP > Standard System
   sap_nwas_750_sp00_abap_ibmdb2_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:NW750.DB6.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1_exportfiles
-      - swpm_installation_media_swpm1_ibmdb2
-      - credentials
-      - credentials_anydb_ibmdb2
-      - db_config_anydb_all
-      - db_config_anydb_ibmdb2
-      - db_connection_nw_anydb_ibmdb2
-      - nw_config_anydb
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    sap_software_list_x86_64:
+      # Database Server
       - '51056772' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
       - '73554900102000002424' # IBM DB2 LUW 11.5 SAP OEM license (Note 816773), ZIP
       - '51056774' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 Client, ZIP
+      # Application Server
       - '51050829_3' # SAP Netweaver 7.5 Installation Export, ZIP
     #  - '51050829_4' # NW 7.5 Language 1/2
     #  - '51050829_5' # NW 7.5 Language 2/2
@@ -111,10 +90,41 @@ sap_software_install_dictionary:
     #  - '51050829_7' # NW 7.5 Upgrade Export Part I 2/2
     #  - '51050829_8' # NW 7.5 Upgrade Export Part II 1/2
     #  - '51050829_9' # NW 7.5 Upgrade Export Part II 2/2
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  sandbox:
+    - swpm_installation_media
+    - swpm_installation_media_swpm1_exportfiles
+    - swpm_installation_media_swpm1_ibmdb2
+    - credentials
+    - credentials_anydb_ibmdb2
+    - db_config_anydb_all
+    - db_config_anydb_ibmdb2
+    - db_connection_nw_anydb_ibmdb2
+    - nw_config_anydb
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
 
 
 #### Interactive Prompt Control Variables ####

--- a/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_extravars.yml
@@ -29,7 +29,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -105,91 +105,69 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:NW752.ORA.PD
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1_exportfiles
-      - swpm_installation_media_swpm1_oracledb_19
-      - credentials
-      - credentials_anydb_oracledb
-      - db_config_anydb_all
-      - db_config_anydb_oracledb
-      - db_config_anydb_oracledb_19
-      - db_connection_nw_anydb_oracledb
-      - nw_config_anydb
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
+      # - '51047708'  # Oracle 12.1 RDBMS Linux on x86_64 64bit (AKA. Oracle Database 12c Release 1), ZIP. Compatible with RHEL 7.x and SLES 12.x
+      # - '51052773_1' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 1/3, RAR EXE (AKA. Oracle Database 12c Release 2). Compatible with RHEL 7.x and SLES 12.x
+      # - '51052773_2' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 2/3, RAR. Compatible with RHEL 7.x and SLES 12.x
+      # - '51052773_3' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 3/3, RAR. Compatible with RHEL 7.x and SLES 12.x
+      - '51053828'  # Oracle 19.0.0.0 RDBMS Linux on x86_64 64bit, ZIP. Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
+      # - '51054219'  # Oracle Client 12.1.0.2. Compatible with RHEL 7.x and SLES 12.x
+      # - '51054433'  # Oracle 12.2.0.1 Client V2 64bit (All), ZIP. Compatible with RHEL 7.x and SLES 12.x
+      - '51057419'  # Oracle 19.0.0.0 RDBMS Client 64bit (All), ZIP (AKA. Oracle Database 19c Base Release). Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
+
+      # Application Server
+      - '51051806_1' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 1/2, RAR
+      - '51051806_2' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 2/2, RAR
       - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
       - 'SAPEXEDB_1000-80002605.SAR' # Kernel Part II (753), Oracle DB
       - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
       - 'igsexe_13-80003187.sar' # IGS 7.53
       - 'igshelper_17-10010245.sar'
       # DBATOOLS Package for Oracle 11g, 12c and higher, Support Package SAP KERNEL 7.53 64-BIT UNICODE Linux on x86_64 64bit ORACLE
       - 'DBATL740O11_49-80002605.SAR'
-    #  - '51047708'   # Oracle 12.1 RDBMS Linux on x86_64 64bit (AKA. Oracle Database 12c Release 1), ZIP. Compatible with RHEL 7.x and SLES 12.x
-    #  - '51052773_1' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 1/3, RAR EXE (AKA. Oracle Database 12c Release 2). Compatible with RHEL 7.x and SLES 12.x
-    #  - '51052773_2' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 2/3, RAR. Compatible with RHEL 7.x and SLES 12.x
-    #  - '51052773_3' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 3/3, RAR. Compatible with RHEL 7.x and SLES 12.x
-      - '51053828'   # Oracle 19.0.0.0 RDBMS Linux on x86_64 64bit, ZIP. Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
-    #  - '51054219'   # Oracle Client 12.1.0.2. Compatible with RHEL 7.x and SLES 12.x
-    #  - '51054433'   # Oracle 12.2.0.1 Client V2 64bit (All), ZIP. Compatible with RHEL 7.x and SLES 12.x
-      - '51057419'   # Oracle 19.0.0.0 RDBMS Client 64bit (All), ZIP (AKA. Oracle Database 19c Base Release). Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
-      - '51051806_1' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 1/2, RAR
-      - '51051806_2' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 2/2, RAR
 
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
+
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
 
 
   # SAP NetWeaver 7.5 > Oracle > Installation > Application Server ABAP > Standard System
   sap_nwas_750_sp00_abap_oracledb_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:NW750.ORA.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1_exportfiles
-      - swpm_installation_media_swpm1_oracledb_19
-      - credentials
-      - credentials_anydb_oracledb
-      - db_config_anydb_all
-      - db_config_anydb_oracledb
-      - db_config_anydb_oracledb_19
-      - db_connection_nw_anydb_oracledb
-      - nw_config_anydb
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002605.SAR' # Kernel Part II (753), Oracle DB
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
-      # DBATOOLS Package for Oracle 11g, 12c and higher, Support Package SAP KERNEL 7.53 64-BIT UNICODE Linux on x86_64 64bit ORACLE
-      - 'DBATL740O11_49-80002605.SAR'
-    #  - '51047708'   # Oracle 12.1 RDBMS Linux on x86_64 64bit (AKA. Oracle Database 12c Release 1), ZIP. Compatible with RHEL 7.x and SLES 12.x
-    #  - '51052773_1' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 1/3, RAR EXE (AKA. Oracle Database 12c Release 2). Compatible with RHEL 7.x and SLES 12.x
-    #  - '51052773_2' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 2/3, RAR. Compatible with RHEL 7.x and SLES 12.x
-    #  - '51052773_3' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 3/3, RAR. Compatible with RHEL 7.x and SLES 12.x
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    sap_software_list_x86_64:
+      # Database Server
+      # - '51047708'   # Oracle 12.1 RDBMS Linux on x86_64 64bit (AKA. Oracle Database 12c Release 1), ZIP. Compatible with RHEL 7.x and SLES 12.x
+      # - '51052773_1' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 1/3, RAR EXE (AKA. Oracle Database 12c Release 2). Compatible with RHEL 7.x and SLES 12.x
+      # - '51052773_2' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 2/3, RAR. Compatible with RHEL 7.x and SLES 12.x
+      # - '51052773_3' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 3/3, RAR. Compatible with RHEL 7.x and SLES 12.x
       - '51053828'   # Oracle 19.0.0.0 RDBMS Linux on x86_64 64bit, ZIP. Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
-    #  - '51054219'   # Oracle Client 12.1.0.2. Compatible with RHEL 7.x and SLES 12.x
-    #  - '51054433'   # Oracle 12.2.0.1 Client V2 64bit (All), ZIP. Compatible with RHEL 7.x and SLES 12.x
+      # - '51054219'   # Oracle Client 12.1.0.2. Compatible with RHEL 7.x and SLES 12.x
+      # - '51054433'   # Oracle 12.2.0.1 Client V2 64bit (All), ZIP. Compatible with RHEL 7.x and SLES 12.x
       - '51057419'   # Oracle 19.0.0.0 RDBMS Client 64bit (All), ZIP (AKA. Oracle Database 19c Base Release). Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
+
+      # Application Server
       - '51050829_3' # SAP Netweaver 7.5 Installation Export, ZIP
     #  - '51050829_4' # NW 7.5 Language 1/2
     #  - '51050829_5' # NW 7.5 Language 2/2
@@ -197,7 +175,41 @@ sap_software_install_dictionary:
     #  - '51050829_7' # NW 7.5 Upgrade Export Part I 2/2
     #  - '51050829_8' # NW 7.5 Upgrade Export Part II 1/2
     #  - '51050829_9' # NW 7.5 Upgrade Export Part II 2/2
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002605.SAR' # Kernel Part II (753), Oracle DB
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # DBATOOLS Package for Oracle 11g, 12c and higher, Support Package SAP KERNEL 7.53 64-BIT UNICODE Linux on x86_64 64bit ORACLE
+      - 'DBATL740O11_49-80002605.SAR'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  sandbox:
+    - swpm_installation_media
+    - swpm_installation_media_swpm1_exportfiles
+    - swpm_installation_media_swpm1_oracledb_19
+    - credentials
+    - credentials_anydb_oracledb
+    - db_config_anydb_all
+    - db_config_anydb_oracledb
+    - db_config_anydb_oracledb_19
+    - db_connection_nw_anydb_oracledb
+    - nw_config_anydb
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user

--- a/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_playbook.yml
@@ -257,8 +257,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 

--- a/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/optional/ansible_extravars_interactive.yml
@@ -41,91 +41,69 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:NW752.ORA.PD
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1_exportfiles
-      - swpm_installation_media_swpm1_oracledb_19
-      - credentials
-      - credentials_anydb_oracledb
-      - db_config_anydb_all
-      - db_config_anydb_oracledb
-      - db_config_anydb_oracledb_19
-      - db_connection_nw_anydb_oracledb
-      - nw_config_anydb
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
+      # - '51047708'  # Oracle 12.1 RDBMS Linux on x86_64 64bit (AKA. Oracle Database 12c Release 1), ZIP. Compatible with RHEL 7.x and SLES 12.x
+      # - '51052773_1' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 1/3, RAR EXE (AKA. Oracle Database 12c Release 2). Compatible with RHEL 7.x and SLES 12.x
+      # - '51052773_2' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 2/3, RAR. Compatible with RHEL 7.x and SLES 12.x
+      # - '51052773_3' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 3/3, RAR. Compatible with RHEL 7.x and SLES 12.x
+      - '51053828'  # Oracle 19.0.0.0 RDBMS Linux on x86_64 64bit, ZIP. Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
+      # - '51054219'  # Oracle Client 12.1.0.2. Compatible with RHEL 7.x and SLES 12.x
+      # - '51054433'  # Oracle 12.2.0.1 Client V2 64bit (All), ZIP. Compatible with RHEL 7.x and SLES 12.x
+      - '51057419'  # Oracle 19.0.0.0 RDBMS Client 64bit (All), ZIP (AKA. Oracle Database 19c Base Release). Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
+
+      # Application Server
+      - '51051806_1' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 1/2, RAR
+      - '51051806_2' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 2/2, RAR
       - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
       - 'SAPEXEDB_1000-80002605.SAR' # Kernel Part II (753), Oracle DB
       - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
       - 'igsexe_13-80003187.sar' # IGS 7.53
       - 'igshelper_17-10010245.sar'
       # DBATOOLS Package for Oracle 11g, 12c and higher, Support Package SAP KERNEL 7.53 64-BIT UNICODE Linux on x86_64 64bit ORACLE
       - 'DBATL740O11_49-80002605.SAR'
-    #  - '51047708'   # Oracle 12.1 RDBMS Linux on x86_64 64bit (AKA. Oracle Database 12c Release 1), ZIP. Compatible with RHEL 7.x and SLES 12.x
-    #  - '51052773_1' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 1/3, RAR EXE (AKA. Oracle Database 12c Release 2). Compatible with RHEL 7.x and SLES 12.x
-    #  - '51052773_2' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 2/3, RAR. Compatible with RHEL 7.x and SLES 12.x
-    #  - '51052773_3' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 3/3, RAR. Compatible with RHEL 7.x and SLES 12.x
-      - '51053828'   # Oracle 19.0.0.0 RDBMS Linux on x86_64 64bit, ZIP. Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
-    #  - '51054219'   # Oracle Client 12.1.0.2. Compatible with RHEL 7.x and SLES 12.x
-    #  - '51054433'   # Oracle 12.2.0.1 Client V2 64bit (All), ZIP. Compatible with RHEL 7.x and SLES 12.x
-      - '51057419'   # Oracle 19.0.0.0 RDBMS Client 64bit (All), ZIP (AKA. Oracle Database 19c Base Release). Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
-      - '51051806_1' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 1/2, RAR
-      - '51051806_2' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 2/2, RAR
 
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
+
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
 
 
   # SAP NetWeaver 7.5 > Oracle > Installation > Application Server ABAP > Standard System
   sap_nwas_750_sp00_abap_oracledb_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:NW750.ORA.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1_exportfiles
-      - swpm_installation_media_swpm1_oracledb_19
-      - credentials
-      - credentials_anydb_oracledb
-      - db_config_anydb_all
-      - db_config_anydb_oracledb
-      - db_config_anydb_oracledb_19
-      - db_connection_nw_anydb_oracledb
-      - nw_config_anydb
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002605.SAR' # Kernel Part II (753), Oracle DB
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
-      # DBATOOLS Package for Oracle 11g, 12c and higher, Support Package SAP KERNEL 7.53 64-BIT UNICODE Linux on x86_64 64bit ORACLE
-      - 'DBATL740O11_49-80002605.SAR'
-    #  - '51047708'   # Oracle 12.1 RDBMS Linux on x86_64 64bit (AKA. Oracle Database 12c Release 1), ZIP. Compatible with RHEL 7.x and SLES 12.x
-    #  - '51052773_1' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 1/3, RAR EXE (AKA. Oracle Database 12c Release 2). Compatible with RHEL 7.x and SLES 12.x
-    #  - '51052773_2' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 2/3, RAR. Compatible with RHEL 7.x and SLES 12.x
-    #  - '51052773_3' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 3/3, RAR. Compatible with RHEL 7.x and SLES 12.x
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    sap_software_list_x86_64:
+      # Database Server
+      # - '51047708'   # Oracle 12.1 RDBMS Linux on x86_64 64bit (AKA. Oracle Database 12c Release 1), ZIP. Compatible with RHEL 7.x and SLES 12.x
+      # - '51052773_1' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 1/3, RAR EXE (AKA. Oracle Database 12c Release 2). Compatible with RHEL 7.x and SLES 12.x
+      # - '51052773_2' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 2/3, RAR. Compatible with RHEL 7.x and SLES 12.x
+      # - '51052773_3' # Oracle 12.2.0.1 RDBMS Linux on x86_64 64bit 3/3, RAR. Compatible with RHEL 7.x and SLES 12.x
       - '51053828'   # Oracle 19.0.0.0 RDBMS Linux on x86_64 64bit, ZIP. Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
-    #  - '51054219'   # Oracle Client 12.1.0.2. Compatible with RHEL 7.x and SLES 12.x
-    #  - '51054433'   # Oracle 12.2.0.1 Client V2 64bit (All), ZIP. Compatible with RHEL 7.x and SLES 12.x
+      # - '51054219'   # Oracle Client 12.1.0.2. Compatible with RHEL 7.x and SLES 12.x
+      # - '51054433'   # Oracle 12.2.0.1 Client V2 64bit (All), ZIP. Compatible with RHEL 7.x and SLES 12.x
       - '51057419'   # Oracle 19.0.0.0 RDBMS Client 64bit (All), ZIP (AKA. Oracle Database 19c Base Release). Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
+
+      # Application Server
       - '51050829_3' # SAP Netweaver 7.5 Installation Export, ZIP
     #  - '51050829_4' # NW 7.5 Language 1/2
     #  - '51050829_5' # NW 7.5 Language 2/2
@@ -133,10 +111,44 @@ sap_software_install_dictionary:
     #  - '51050829_7' # NW 7.5 Upgrade Export Part I 2/2
     #  - '51050829_8' # NW 7.5 Upgrade Export Part II 1/2
     #  - '51050829_9' # NW 7.5 Upgrade Export Part II 2/2
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002605.SAR' # Kernel Part II (753), Oracle DB
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # DBATOOLS Package for Oracle 11g, 12c and higher, Support Package SAP KERNEL 7.53 64-BIT UNICODE Linux on x86_64 64bit ORACLE
+      - 'DBATL740O11_49-80002605.SAR'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  sandbox:
+    - swpm_installation_media
+    - swpm_installation_media_swpm1_exportfiles
+    - swpm_installation_media_swpm1_oracledb_19
+    - credentials
+    - credentials_anydb_oracledb
+    - db_config_anydb_all
+    - db_config_anydb_oracledb
+    - db_config_anydb_oracledb_19
+    - db_connection_nw_anydb_oracledb
+    - nw_config_anydb
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
 
 
 #### Interactive Prompt Control Variables ####

--- a/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_extravars.yml
@@ -29,7 +29,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -91,81 +91,92 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:NW752.SYB.PD
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1_exportfiles
-      - swpm_installation_media_swpm1_sapase
-      - credentials
-      - credentials_anydb_sapase
-      - db_config_anydb_all
-      - db_config_anydb_sapase
-      - nw_config_anydb
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
+      - '51057961_1' # SAP ASE 16.0.04.06 HF1 RDBMS Linux on x86_64 64bit
+      - 'ASEBC16004P_5-20012477.SAR' # SAP ASE 16.0 SP04 (160-04) FOR BUS. SUITE DBCLIENT with Patch (P_*)
+      # Application Server
+      - '51051806_1' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 1/2, RAR
+      - '51051806_2' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 2/2, RAR
       - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
       - 'SAPEXEDB_1000-80002616.SAR' # Kernel Part II (753), SAP ASE 16.0 FOR BUS. SUITE
       - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
       - 'igsexe_13-80003187.sar' # IGS 7.53
       - 'igshelper_17-10010245.sar'
       - 'SYBCTRL_1440-80002616.SAR'
-      - '51057961_1' # SAP ASE 16.0.04.06 HF1 RDBMS Linux on x86_64 64bit
-      - 'ASEBC16004P_5-20012477.SAR' # SAP ASE 16.0 SP04 (160-04) FOR BUS. SUITE DBCLIENT with Patch (P_*)
-      - '51051806_1' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 1/2, RAR
-      - '51051806_2' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 2/2, RAR
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
 
 
   # SAP NetWeaver 7.5 > SAP ASE > Installation > Application Server ABAP > Standard System
   sap_nwas_750_sp00_abap_sapase_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:NW750.SYB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1_exportfiles
-      - swpm_installation_media_swpm1_sapase
-      - credentials
-      - credentials_anydb_sapase
-      - db_config_anydb_all
-      - db_config_anydb_sapase
-      - nw_config_anydb
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    sap_software_list_x86_64:
+      # Database Server
+      - '51057961_1' # SAP ASE 16.0.04.06 HF1 RDBMS Linux on x86_64 64bit
+      - 'ASEBC16004P_5-20012477.SAR' # SAP ASE 16.0 SP04 (160-04) FOR BUS. SUITE DBCLIENT with Patch (P_*)
+      # Application Server
+      - '51050829_3' # SAP Netweaver 7.5 Installation Export, ZIP
+      # - '51050829_4' # NW 7.5 Language 1/2
+      # - '51050829_5' # NW 7.5 Language 2/2
+      # - '51050829_6' # NW 7.5 Upgrade Export Part I 1/2
+      # - '51050829_7' # NW 7.5 Upgrade Export Part I 2/2
+      # - '51050829_8' # NW 7.5 Upgrade Export Part II 1/2
+      # - '51050829_9' # NW 7.5 Upgrade Export Part II 2/2
       - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
       - 'SAPEXEDB_1000-80002616.SAR' # Kernel Part II (753), SAP ASE 16.0 FOR BUS. SUITE
       - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
       - 'igsexe_13-80003187.sar' # IGS 7.53
       - 'igshelper_17-10010245.sar'
       - 'SYBCTRL_1440-80002616.SAR'
-      - '51057961_1' # SAP ASE 16.0.04.06 HF1 RDBMS Linux on x86_64 64bit
-      - 'ASEBC16004P_5-20012477.SAR' # SAP ASE 16.0 SP04 (160-04) FOR BUS. SUITE DBCLIENT with Patch (P_*)
-      - '51050829_3' # SAP Netweaver 7.5 Installation Export, ZIP
-    #  - '51050829_4' # NW 7.5 Language 1/2
-    #  - '51050829_5' # NW 7.5 Language 2/2
-    #  - '51050829_6' # NW 7.5 Upgrade Export Part I 1/2
-    #  - '51050829_7' # NW 7.5 Upgrade Export Part I 2/2
-    #  - '51050829_8' # NW 7.5 Upgrade Export Part II 1/2
-    #  - '51050829_9' # NW 7.5 Upgrade Export Part II 2/2
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  sandbox:
+    - swpm_installation_media
+    - swpm_installation_media_swpm1_exportfiles
+    - swpm_installation_media_swpm1_sapase
+    - credentials
+    - credentials_anydb_sapase
+    - db_config_anydb_all
+    - db_config_anydb_sapase
+    - nw_config_anydb
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user

--- a/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_playbook.yml
@@ -257,8 +257,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 

--- a/deploy_scenarios/sap_nwas_abap_sapase_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapase_sandbox/optional/ansible_extravars_interactive.yml
@@ -35,84 +35,95 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:NW752.SYB.PD
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1_exportfiles
-      - swpm_installation_media_swpm1_sapase
-      - credentials
-      - credentials_anydb_sapase
-      - db_config_anydb_all
-      - db_config_anydb_sapase
-      - nw_config_anydb
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
+      - '51057961_1' # SAP ASE 16.0.04.06 HF1 RDBMS Linux on x86_64 64bit
+      - 'ASEBC16004P_5-20012477.SAR' # SAP ASE 16.0 SP04 (160-04) FOR BUS. SUITE DBCLIENT with Patch (P_*)
+      # Application Server
+      - '51051806_1' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 1/2, RAR
+      - '51051806_2' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 2/2, RAR
       - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
       - 'SAPEXEDB_1000-80002616.SAR' # Kernel Part II (753), SAP ASE 16.0 FOR BUS. SUITE
       - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
       - 'igsexe_13-80003187.sar' # IGS 7.53
       - 'igshelper_17-10010245.sar'
       - 'SYBCTRL_1440-80002616.SAR'
-      - '51057961_1' # SAP ASE 16.0.04.06 HF1 RDBMS Linux on x86_64 64bit
-      - 'ASEBC16004P_5-20012477.SAR' # SAP ASE 16.0 SP04 (160-04) FOR BUS. SUITE DBCLIENT with Patch (P_*)
-      - '51051806_1' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 1/2, RAR
-      - '51051806_2' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 2/2, RAR
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
 
 
   # SAP NetWeaver 7.5 > SAP ASE > Installation > Application Server ABAP > Standard System
   sap_nwas_750_sp00_abap_sapase_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:NW750.SYB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1_exportfiles
-      - swpm_installation_media_swpm1_sapase
-      - credentials
-      - credentials_anydb_sapase
-      - db_config_anydb_all
-      - db_config_anydb_sapase
-      - nw_config_anydb
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    sap_software_list_x86_64:
+      # Database Server
+      - '51057961_1' # SAP ASE 16.0.04.06 HF1 RDBMS Linux on x86_64 64bit
+      - 'ASEBC16004P_5-20012477.SAR' # SAP ASE 16.0 SP04 (160-04) FOR BUS. SUITE DBCLIENT with Patch (P_*)
+      # Application Server
+      - '51050829_3' # SAP Netweaver 7.5 Installation Export, ZIP
+      # - '51050829_4' # NW 7.5 Language 1/2
+      # - '51050829_5' # NW 7.5 Language 2/2
+      # - '51050829_6' # NW 7.5 Upgrade Export Part I 1/2
+      # - '51050829_7' # NW 7.5 Upgrade Export Part I 2/2
+      # - '51050829_8' # NW 7.5 Upgrade Export Part II 1/2
+      # - '51050829_9' # NW 7.5 Upgrade Export Part II 2/2
       - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
       - 'SAPEXEDB_1000-80002616.SAR' # Kernel Part II (753), SAP ASE 16.0 FOR BUS. SUITE
       - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
       - 'igsexe_13-80003187.sar' # IGS 7.53
       - 'igshelper_17-10010245.sar'
       - 'SYBCTRL_1440-80002616.SAR'
-      - '51057961_1' # SAP ASE 16.0.04.06 HF1 RDBMS Linux on x86_64 64bit
-      - 'ASEBC16004P_5-20012477.SAR' # SAP ASE 16.0 SP04 (160-04) FOR BUS. SUITE DBCLIENT with Patch (P_*)
-      - '51050829_3' # SAP Netweaver 7.5 Installation Export, ZIP
-    #  - '51050829_4' # NW 7.5 Language 1/2
-    #  - '51050829_5' # NW 7.5 Language 2/2
-    #  - '51050829_6' # NW 7.5 Upgrade Export Part I 1/2
-    #  - '51050829_7' # NW 7.5 Upgrade Export Part I 2/2
-    #  - '51050829_8' # NW 7.5 Upgrade Export Part II 1/2
-    #  - '51050829_9' # NW 7.5 Upgrade Export Part II 2/2
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  sandbox:
+    - swpm_installation_media
+    - swpm_installation_media_swpm1_exportfiles
+    - swpm_installation_media_swpm1_sapase
+    - credentials
+    - credentials_anydb_sapase
+    - db_config_anydb_all
+    - db_config_anydb_sapase
+    - nw_config_anydb
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
 
 
 #### Interactive Prompt Control Variables ####

--- a/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_extravars.yml
@@ -29,7 +29,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -92,81 +92,92 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:NW752.ADA.PD
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1_exportfiles
-      # - swpm_installation_media_swpm1_sapmaxdb  # Required when using CD Media, not SAR file.
-      - credentials
-      - credentials_anydb_sapmaxdb
-      - db_config_anydb_all
-      - db_config_anydb_sapmaxdb
-      - nw_config_anydb
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002604.SAR' # Kernel Part II (753), SAP MaxDB 7.9
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       # - '51054410_2' # CD Media for MaxDB 7.9 - SP10 Build 04 Linux on x86_64 64bit
       - 'MAXDB7911_10-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
       - 'MAXDBART7911_10-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
+      # Application Server
       - '51051806_1' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 1/2, RAR
       - '51051806_2' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 2/2, RAR
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002604.SAR' # Kernel Part II (753), SAP MaxDB 7.9
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
 
 
   # SAP NetWeaver 7.5 > MaxDB > Installation > Application Server ABAP > Standard System
   sap_nwas_750_sp00_abap_sapmaxdb_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:NW750.ADA.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1_exportfiles
-      # - swpm_installation_media_swpm1_sapmaxdb  # Required when using CD Media, not SAR file.
-      - credentials
-      - credentials_anydb_sapmaxdb
-      - db_config_anydb_all
-      - db_config_anydb_sapmaxdb
-      - nw_config_anydb
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002604.SAR' # Kernel Part II (753), SAP MaxDB 7.9
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    sap_software_list_x86_64:
+      # Database Server
       # - '51054410_2' # CD Media for MaxDB 7.9 - SP10 Build 04 Linux on x86_64 64bit
       - 'MAXDB7911_10-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
       - 'MAXDBART7911_10-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
+      # Application Server
       - '51050829_3' # SAP Netweaver 7.5 Installation Export, ZIP
-    #  - '51050829_4' # NW 7.5 Language 1/2
-    #  - '51050829_5' # NW 7.5 Language 2/2
-    #  - '51050829_6' # NW 7.5 Upgrade Export Part I 1/2
-    #  - '51050829_7' # NW 7.5 Upgrade Export Part I 2/2
-    #  - '51050829_8' # NW 7.5 Upgrade Export Part II 1/2
-    #  - '51050829_9' # NW 7.5 Upgrade Export Part II 2/2
+      # - '51050829_4' # NW 7.5 Language 1/2
+      # - '51050829_5' # NW 7.5 Language 2/2
+      # - '51050829_6' # NW 7.5 Upgrade Export Part I 1/2
+      # - '51050829_7' # NW 7.5 Upgrade Export Part I 2/2
+      # - '51050829_8' # NW 7.5 Upgrade Export Part II 1/2
+      # - '51050829_9' # NW 7.5 Upgrade Export Part II 2/2
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002604.SAR' # Kernel Part II (753), SAP MaxDB 7.9
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  sandbox:
+    - swpm_installation_media
+    - swpm_installation_media_swpm1_exportfiles
+    # - swpm_installation_media_swpm1_sapmaxdb  # Required when using CD Media, not SAR file.
+    - credentials
+    - credentials_anydb_sapmaxdb
+    - db_config_anydb_all
+    - db_config_anydb_sapmaxdb
+    - nw_config_anydb
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user

--- a/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_playbook.yml
@@ -257,8 +257,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 

--- a/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/optional/ansible_extravars_interactive.yml
@@ -35,84 +35,95 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:NW752.ADA.PD
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1_exportfiles
-      # - swpm_installation_media_swpm1_sapmaxdb  # Required when using CD Media, not SAR file.
-      - credentials
-      - credentials_anydb_sapmaxdb
-      - db_config_anydb_all
-      - db_config_anydb_sapmaxdb
-      - nw_config_anydb
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002604.SAR' # Kernel Part II (753), SAP MaxDB 7.9
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       # - '51054410_2' # CD Media for MaxDB 7.9 - SP10 Build 04 Linux on x86_64 64bit
       - 'MAXDB7911_10-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
       - 'MAXDBART7911_10-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
+      # Application Server
       - '51051806_1' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 1/2, RAR
       - '51051806_2' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 2/2, RAR
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002604.SAR' # Kernel Part II (753), SAP MaxDB 7.9
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
 
 
   # SAP NetWeaver 7.5 > MaxDB > Installation > Application Server ABAP > Standard System
   sap_nwas_750_sp00_abap_sapmaxdb_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:NW750.ADA.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm1_exportfiles
-      # - swpm_installation_media_swpm1_sapmaxdb  # Required when using CD Media, not SAR file.
-      - credentials
-      - credentials_anydb_sapmaxdb
-      - db_config_anydb_all
-      - db_config_anydb_sapmaxdb
-      - nw_config_anydb
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002604.SAR' # Kernel Part II (753), SAP MaxDB 7.9
-      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    sap_software_list_x86_64:
+      # Database Server
       # - '51054410_2' # CD Media for MaxDB 7.9 - SP10 Build 04 Linux on x86_64 64bit
       - 'MAXDB7911_10-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
       - 'MAXDBART7911_10-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
+      # Application Server
       - '51050829_3' # SAP Netweaver 7.5 Installation Export, ZIP
-    #  - '51050829_4' # NW 7.5 Language 1/2
-    #  - '51050829_5' # NW 7.5 Language 2/2
-    #  - '51050829_6' # NW 7.5 Upgrade Export Part I 1/2
-    #  - '51050829_7' # NW 7.5 Upgrade Export Part I 2/2
-    #  - '51050829_8' # NW 7.5 Upgrade Export Part II 1/2
-    #  - '51050829_9' # NW 7.5 Upgrade Export Part II 2/2
+      # - '51050829_4' # NW 7.5 Language 1/2
+      # - '51050829_5' # NW 7.5 Language 2/2
+      # - '51050829_6' # NW 7.5 Upgrade Export Part I 1/2
+      # - '51050829_7' # NW 7.5 Upgrade Export Part I 2/2
+      # - '51050829_8' # NW 7.5 Upgrade Export Part II 1/2
+      # - '51050829_9' # NW 7.5 Upgrade Export Part II 2/2
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002604.SAR' # Kernel Part II (753), SAP MaxDB 7.9
+      - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
     # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
-    softwarecenter_search_list_ppc64le:
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  sandbox:
+    - swpm_installation_media
+    - swpm_installation_media_swpm1_exportfiles
+    # - swpm_installation_media_swpm1_sapmaxdb  # Required when using CD Media, not SAR file.
+    - credentials
+    - credentials_anydb_sapmaxdb
+    - db_config_anydb_all
+    - db_config_anydb_sapmaxdb
+    - nw_config_anydb
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
 
 
 #### Interactive Prompt Control Variables ####

--- a/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_extravars.yml
@@ -31,7 +31,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -123,22 +123,32 @@ sap_software_install_dictionary:
     sap_swpm_java_template_id_selected_list:
       - java_adobe_document_services
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
-      - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
-      - 'SAPJVM8_90-80000202.SAR' # SAP JVM 8.1
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
+      - '51056772' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
+      - '73554900102000002424' # IBM DB2 LUW 11.5 SAP OEM license (Note 816773), ZIP
+      - '51056774' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 Client, ZIP
+      # Application Server
       # Contains JAVA_EXPORT (SAP:JEXPORT:750:SP22:*:*), JAVA_EXPORT_JDMP (SAP:JDMP:750:SP22:*:SW-LABEL),
       # JAVA_J2EE_OSINDEP (SAP:J2EE-CD:750:J2EE-CD:j2ee-cd:*), JAVA_J2EE_OSINDEP_J2EE_INST (SAP:J2EE-INST:750:SP22:*:*),
       # JAVA_J2EE_OSINDEP_UT (SAP:UT:750:SP22:*:*)
       - '51055106' # SAP Netweaver 7.5 SP22 Java, ZIP.
-      - '51056772' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
-      - '73554900102000002424' # IBM DB2 LUW 11.5 SAP OEM license (Note 816773), ZIP
-      - '51056774' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 Client, ZIP
       - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
       - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
+      - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
+      - 'SAPJVM8_90-80000202.SAR' # SAP JVM 8.1
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
-    softwarecenter_search_list_ppc64le:
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'

--- a/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_playbook.yml
@@ -255,8 +255,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 

--- a/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/optional/ansible_extravars_interactive.yml
@@ -70,24 +70,34 @@ sap_software_install_dictionary:
     sap_swpm_java_template_id_selected_list:
       - java_adobe_document_services
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
-      - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
-      - 'SAPJVM8_90-80000202.SAR' # SAP JVM 8.1
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
+      - '51056772' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
+      - '73554900102000002424' # IBM DB2 LUW 11.5 SAP OEM license (Note 816773), ZIP
+      - '51056774' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 Client, ZIP
+      # Application Server
       # Contains JAVA_EXPORT (SAP:JEXPORT:750:SP22:*:*), JAVA_EXPORT_JDMP (SAP:JDMP:750:SP22:*:SW-LABEL),
       # JAVA_J2EE_OSINDEP (SAP:J2EE-CD:750:J2EE-CD:j2ee-cd:*), JAVA_J2EE_OSINDEP_J2EE_INST (SAP:J2EE-INST:750:SP22:*:*),
       # JAVA_J2EE_OSINDEP_UT (SAP:UT:750:SP22:*:*)
       - '51055106' # SAP Netweaver 7.5 SP22 Java, ZIP.
-      - '51056772' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 LINUX x86_64, ZIP. See SAP Note 101809 - DB6: Supported Db2 Versions and Fix Pack Levels
-      - '73554900102000002424' # IBM DB2 LUW 11.5 SAP OEM license (Note 816773), ZIP
-      - '51056774' # IBM DB2 FOR LUW 11.5 MP8 FP0 SAP2 Client, ZIP
       - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
       - 'SAPEXEDB_1000-80002603.SAR' # Kernel Part II (753), IBM DB2
+      - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
+      - 'SAPJVM8_90-80000202.SAR' # SAP JVM 8.1
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
-    softwarecenter_search_list_ppc64le:
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
 
 

--- a/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_extravars.yml
@@ -31,7 +31,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -97,8 +97,10 @@ sap_software_install_dictionary:
   # SAP NetWeaver 7.5 > SAP ASE > Installation > Application Server Java > Standard System > Standard System
   sap_nwas_750_sp22_java_sapase_sandbox_ads:
 
+    # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_Java_OneHost:NW750.SYB.PD
 
+    # List of INI file sections to generate using sap_install.sap_swpm role (List).
     sap_swpm_inifile_sections_list:
       - swpm_installation_media
       - swpm_installation_media_swpm1_exportfiles
@@ -120,21 +122,31 @@ sap_software_install_dictionary:
     sap_swpm_java_template_id_selected_list:
       - java_adobe_document_services
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002616.SAR' # Kernel Part II (753), SAP ASE 16.0 FOR BUS. SUITE
-      - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
-      - 'SAPJVM8_90-80000202.SAR' # SAP JVM 8.1
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
+      - '51057961_1' # SAP ASE 16.0.04.06 HF1 RDBMS Linux on x86_64 64bit
+      - 'ASEBC16004P_5-20012477.SAR' # SAP ASE 16.0 SP04 (160-04) FOR BUS. SUITE DBCLIENT with Patch (P_*)
+      # Application Server
       # Contains JAVA_EXPORT (SAP:JEXPORT:750:SP22:*:*), JAVA_EXPORT_JDMP (SAP:JDMP:750:SP22:*:SW-LABEL),
       # JAVA_J2EE_OSINDEP (SAP:J2EE-CD:750:J2EE-CD:j2ee-cd:*), JAVA_J2EE_OSINDEP_J2EE_INST (SAP:J2EE-INST:750:SP22:*:*),
       # JAVA_J2EE_OSINDEP_UT (SAP:UT:750:SP22:*:*)
       - '51055106' # SAP Netweaver 7.5 SP22 Java, ZIP.
-      - '51057961_1' # SAP ASE 16.0.04.06 HF1 RDBMS Linux on x86_64 64bit
-      - 'ASEBC16004P_5-20012477.SAR' # SAP ASE 16.0 SP04 (160-04) FOR BUS. SUITE DBCLIENT with Patch (P_*)
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002616.SAR' # Kernel Part II (753), SAP ASE 16.0 FOR BUS. SUITE
+      - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
+      - 'SAPJVM8_90-80000202.SAR' # SAP JVM 8.1
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
-    softwarecenter_search_list_ppc64le:
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'

--- a/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_playbook.yml
@@ -255,8 +255,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 

--- a/deploy_scenarios/sap_nwas_java_sapase_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_nwas_java_sapase_sandbox/optional/ansible_extravars_interactive.yml
@@ -37,8 +37,10 @@ sap_software_install_dictionary:
   # SAP NetWeaver 7.5 > SAP ASE > Installation > Application Server Java > Standard System > Standard System
   sap_nwas_750_sp22_java_sapase_sandbox_ads:
 
+    # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_Java_OneHost:NW750.SYB.PD
 
+    # List of INI file sections to generate using sap_install.sap_swpm role (List).
     sap_swpm_inifile_sections_list:
       - swpm_installation_media
       - swpm_installation_media_swpm1_exportfiles
@@ -60,23 +62,33 @@ sap_software_install_dictionary:
     sap_swpm_java_template_id_selected_list:
       - java_adobe_document_services
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002616.SAR' # Kernel Part II (753), SAP ASE 16.0 FOR BUS. SUITE
-      - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
-      - 'SAPJVM8_90-80000202.SAR' # SAP JVM 8.1
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
+      - '51057961_1' # SAP ASE 16.0.04.06 HF1 RDBMS Linux on x86_64 64bit
+      - 'ASEBC16004P_5-20012477.SAR' # SAP ASE 16.0 SP04 (160-04) FOR BUS. SUITE DBCLIENT with Patch (P_*)
+      # Application Server
       # Contains JAVA_EXPORT (SAP:JEXPORT:750:SP22:*:*), JAVA_EXPORT_JDMP (SAP:JDMP:750:SP22:*:SW-LABEL),
       # JAVA_J2EE_OSINDEP (SAP:J2EE-CD:750:J2EE-CD:j2ee-cd:*), JAVA_J2EE_OSINDEP_J2EE_INST (SAP:J2EE-INST:750:SP22:*:*),
       # JAVA_J2EE_OSINDEP_UT (SAP:UT:750:SP22:*:*)
       - '51055106' # SAP Netweaver 7.5 SP22 Java, ZIP.
-      - '51057961_1' # SAP ASE 16.0.04.06 HF1 RDBMS Linux on x86_64 64bit
-      - 'ASEBC16004P_5-20012477.SAR' # SAP ASE 16.0 SP04 (160-04) FOR BUS. SUITE DBCLIENT with Patch (P_*)
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002616.SAR' # Kernel Part II (753), SAP ASE 16.0 FOR BUS. SUITE
+      - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
+      - 'SAPJVM8_90-80000202.SAR' # SAP JVM 8.1
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
-    softwarecenter_search_list_ppc64le:
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
 
 

--- a/deploy_scenarios/sap_s4hana_distributed/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_distributed/ansible_extravars.yml
@@ -31,7 +31,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -134,134 +134,92 @@ sap_software_install_dictionary:
 
   sap_s4hana_2025_distributed:
 
-    softwarecenter_search_list_x86_64:
-      # Database
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
       - 'SAPPAAPL4_2405_0-80004547.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
-      # Media
-      - 'S4HANAOP109_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_INST_EXPORT_2.zip'
-      - 'S4HANAOP109_INST_EXPORT_3.zip'
-      - 'S4HANAOP109_INST_EXPORT_4.zip'
-      - 'S4HANAOP109_INST_EXPORT_5.zip'
-      - 'S4HANAOP109_INST_EXPORT_6.zip'
-      - 'S4HANAOP109_INST_EXPORT_7.zip'
-      - 'S4HANAOP109_INST_EXPORT_8.zip'
-      - 'S4HANAOP109_INST_EXPORT_9.zip'
-      - 'S4HANAOP109_INST_EXPORT_10.zip'
-      - 'S4HANAOP109_INST_EXPORT_11.zip'
-      - 'S4HANAOP109_INST_EXPORT_12.zip'
-      - 'S4HANAOP109_INST_EXPORT_13.zip'
-      - 'S4HANAOP109_INST_EXPORT_14.zip'
-      - 'S4HANAOP109_INST_EXPORT_15.zip'
-      - 'S4HANAOP109_INST_EXPORT_16.zip'
-      - 'S4HANAOP109_INST_EXPORT_17.zip'
-      - 'S4HANAOP109_INST_EXPORT_18.zip'
-      - 'S4HANAOP109_INST_EXPORT_19.zip'
-      - 'S4HANAOP109_INST_EXPORT_20.zip'
-      - 'S4HANAOP109_INST_EXPORT_21.zip'
-      - 'S4HANAOP109_INST_EXPORT_22.zip'
-      - 'S4HANAOP109_INST_EXPORT_23.zip'
-      - 'S4HANAOP109_INST_EXPORT_24.zip'
-      - 'S4HANAOP109_INST_EXPORT_25.zip'
-      - 'S4HANAOP109_INST_EXPORT_26.zip'
-      - 'S4HANAOP109_INST_EXPORT_27.zip'
-      - 'S4HANAOP109_INST_EXPORT_28.zip'
-      - 'S4HANAOP109_INST_EXPORT_29.zip'
-      - 'S4HANAOP109_INST_EXPORT_30.zip'
-      - 'S4HANAOP109_INST_EXPORT_31.zip'
-      - 'S4HANAOP109_INST_EXPORT_32.zip'
-      - 'S4HANAOP109_INST_EXPORT_33.zip'
-      - 'S4HANAOP109_INST_EXPORT_34.zip'
-      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_ERP_LANG_EN.SAR'
       - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007716.EXE'
       - 'SWPM20SP23_2-80003424.SAR'
       # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
-      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
-      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
       - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
-      # Media
-      - 'S4HANAOP109_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_INST_EXPORT_2.zip'
-      - 'S4HANAOP109_INST_EXPORT_3.zip'
-      - 'S4HANAOP109_INST_EXPORT_4.zip'
-      - 'S4HANAOP109_INST_EXPORT_5.zip'
-      - 'S4HANAOP109_INST_EXPORT_6.zip'
-      - 'S4HANAOP109_INST_EXPORT_7.zip'
-      - 'S4HANAOP109_INST_EXPORT_8.zip'
-      - 'S4HANAOP109_INST_EXPORT_9.zip'
-      - 'S4HANAOP109_INST_EXPORT_10.zip'
-      - 'S4HANAOP109_INST_EXPORT_11.zip'
-      - 'S4HANAOP109_INST_EXPORT_12.zip'
-      - 'S4HANAOP109_INST_EXPORT_13.zip'
-      - 'S4HANAOP109_INST_EXPORT_14.zip'
-      - 'S4HANAOP109_INST_EXPORT_15.zip'
-      - 'S4HANAOP109_INST_EXPORT_16.zip'
-      - 'S4HANAOP109_INST_EXPORT_17.zip'
-      - 'S4HANAOP109_INST_EXPORT_18.zip'
-      - 'S4HANAOP109_INST_EXPORT_19.zip'
-      - 'S4HANAOP109_INST_EXPORT_20.zip'
-      - 'S4HANAOP109_INST_EXPORT_21.zip'
-      - 'S4HANAOP109_INST_EXPORT_22.zip'
-      - 'S4HANAOP109_INST_EXPORT_23.zip'
-      - 'S4HANAOP109_INST_EXPORT_24.zip'
-      - 'S4HANAOP109_INST_EXPORT_25.zip'
-      - 'S4HANAOP109_INST_EXPORT_26.zip'
-      - 'S4HANAOP109_INST_EXPORT_27.zip'
-      - 'S4HANAOP109_INST_EXPORT_28.zip'
-      - 'S4HANAOP109_INST_EXPORT_29.zip'
-      - 'S4HANAOP109_INST_EXPORT_30.zip'
-      - 'S4HANAOP109_INST_EXPORT_31.zip'
-      - 'S4HANAOP109_INST_EXPORT_32.zip'
-      - 'S4HANAOP109_INST_EXPORT_33.zip'
-      - 'S4HANAOP109_INST_EXPORT_34.zip'
-      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_ERP_LANG_EN.SAR'
       - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007726.EXE'
       - 'SWPM20SP23_2-80003426.SAR'
-      # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
-      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
-      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    # This list assigned from shared dictionary, because it is same with other products or host types.
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs:
 
@@ -269,117 +227,47 @@ sap_software_install_dictionary:
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2025.CORE.HDB.ABAP
 
       # List of INI file sections to generate using sap_install.sap_swpm role (List).
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2025.CORE.HDB.ABAP
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2025.CORE.HDB.ABAP
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2025.CORE.HDB.PD
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
 
       sap_swpm_inifile_dictionary:
 
@@ -387,30 +275,19 @@ sap_software_install_dictionary:
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+        # SAP Host Agent
+        sap_swpm_install_saphostagent: true
+
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2023_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
-      # Database
-      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
-      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
-      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
-      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
-      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
-      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
-      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+    sap_software_list_independent:
+      # Application Media
       - 'S4CORE108_INST_EXPORT_1.zip'
       - 'S4CORE108_INST_EXPORT_2.zip'
       - 'S4CORE108_INST_EXPORT_3.zip'
@@ -443,889 +320,421 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
-      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Application Server
       - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
+      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
+      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
+      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+      - 'igsexe_4-70005417.sar' # IGS 7.81
       # Tools
       - 'SAPCAR_1300-70007716.EXE'
       - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
       - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
-      - 'S4CORE108_INST_EXPORT_1.zip'
-      - 'S4CORE108_INST_EXPORT_2.zip'
-      - 'S4CORE108_INST_EXPORT_3.zip'
-      - 'S4CORE108_INST_EXPORT_4.zip'
-      - 'S4CORE108_INST_EXPORT_5.zip'
-      - 'S4CORE108_INST_EXPORT_6.zip'
-      - 'S4CORE108_INST_EXPORT_7.zip'
-      - 'S4CORE108_INST_EXPORT_8.zip'
-      - 'S4CORE108_INST_EXPORT_9.zip'
-      - 'S4CORE108_INST_EXPORT_10.zip'
-      - 'S4CORE108_INST_EXPORT_11.zip'
-      - 'S4CORE108_INST_EXPORT_12.zip'
-      - 'S4CORE108_INST_EXPORT_13.zip'
-      - 'S4CORE108_INST_EXPORT_14.zip'
-      - 'S4CORE108_INST_EXPORT_15.zip'
-      - 'S4CORE108_INST_EXPORT_16.zip'
-      - 'S4CORE108_INST_EXPORT_17.zip'
-      - 'S4CORE108_INST_EXPORT_18.zip'
-      - 'S4CORE108_INST_EXPORT_19.zip'
-      - 'S4CORE108_INST_EXPORT_20.zip'
-      - 'S4CORE108_INST_EXPORT_21.zip'
-      - 'S4CORE108_INST_EXPORT_22.zip'
-      - 'S4CORE108_INST_EXPORT_23.zip'
-      - 'S4CORE108_INST_EXPORT_24.zip'
-      - 'S4CORE108_INST_EXPORT_25.zip'
-      - 'S4CORE108_INST_EXPORT_26.zip'
-      - 'S4CORE108_INST_EXPORT_27.zip'
-      - 'S4CORE108_INST_EXPORT_28.zip'
-      - 'S4CORE108_INST_EXPORT_29.zip'
-      - 'S4CORE108_INST_EXPORT_30.zip'
-      - 'S4HANAOP108_ERP_LANG_EN.SAR'
-      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
       - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
       # Tools
       - 'SAPCAR_1300-70007726.EXE'
       - 'SWPM20SP20_1-80003426.SAR'
       # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs:
-
-      # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2023.CORE.HDB.ABAP
-
-      # List of INI file sections to generate using sap_install.sap_swpm role (List).
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2023.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2023.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2023.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
-
-        # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+        sap_swpm_install_saphostagent: true
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2022_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE107_INST_EXPORT_1.zip'
+      - 'S4CORE107_INST_EXPORT_2.zip'
+      - 'S4CORE107_INST_EXPORT_3.zip'
+      - 'S4CORE107_INST_EXPORT_4.zip'
+      - 'S4CORE107_INST_EXPORT_5.zip'
+      - 'S4CORE107_INST_EXPORT_6.zip'
+      - 'S4CORE107_INST_EXPORT_7.zip'
+      - 'S4CORE107_INST_EXPORT_8.zip'
+      - 'S4CORE107_INST_EXPORT_9.zip'
+      - 'S4CORE107_INST_EXPORT_10.zip'
+      - 'S4CORE107_INST_EXPORT_11.zip'
+      - 'S4CORE107_INST_EXPORT_12.zip'
+      - 'S4CORE107_INST_EXPORT_13.zip'
+      - 'S4CORE107_INST_EXPORT_14.zip'
+      - 'S4CORE107_INST_EXPORT_15.zip'
+      - 'S4CORE107_INST_EXPORT_16.zip'
+      - 'S4CORE107_INST_EXPORT_17.zip'
+      - 'S4CORE107_INST_EXPORT_18.zip'
+      - 'S4CORE107_INST_EXPORT_19.zip'
+      - 'S4CORE107_INST_EXPORT_20.zip'
+      - 'S4CORE107_INST_EXPORT_21.zip'
+      - 'S4CORE107_INST_EXPORT_22.zip'
+      - 'S4CORE107_INST_EXPORT_23.zip'
+      - 'S4CORE107_INST_EXPORT_24.zip'
+      - 'S4CORE107_INST_EXPORT_25.zip'
+      - 'S4CORE107_INST_EXPORT_26.zip'
+      - 'S4CORE107_INST_EXPORT_27.zip'
+      - 'S4CORE107_INST_EXPORT_28.zip'
+      - 'S4CORE107_INST_EXPORT_29.zip'
+      - 'S4CORE107_INST_EXPORT_30.zip'
+      - 'S4HANAOP107_ERP_LANG_EN.SAR'
+      # - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
+      # - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_51-70006642.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006641.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
-      - 'S4CORE107_INST_EXPORT_1.zip'
-      - 'S4CORE107_INST_EXPORT_2.zip'
-      - 'S4CORE107_INST_EXPORT_3.zip'
-      - 'S4CORE107_INST_EXPORT_4.zip'
-      - 'S4CORE107_INST_EXPORT_5.zip'
-      - 'S4CORE107_INST_EXPORT_6.zip'
-      - 'S4CORE107_INST_EXPORT_7.zip'
-      - 'S4CORE107_INST_EXPORT_8.zip'
-      - 'S4CORE107_INST_EXPORT_9.zip'
-      - 'S4CORE107_INST_EXPORT_10.zip'
-      - 'S4CORE107_INST_EXPORT_11.zip'
-      - 'S4CORE107_INST_EXPORT_12.zip'
-      - 'S4CORE107_INST_EXPORT_13.zip'
-      - 'S4CORE107_INST_EXPORT_14.zip'
-      - 'S4CORE107_INST_EXPORT_15.zip'
-      - 'S4CORE107_INST_EXPORT_16.zip'
-      - 'S4CORE107_INST_EXPORT_17.zip'
-      - 'S4CORE107_INST_EXPORT_18.zip'
-      - 'S4CORE107_INST_EXPORT_19.zip'
-      - 'S4CORE107_INST_EXPORT_20.zip'
-      - 'S4CORE107_INST_EXPORT_21.zip'
-      - 'S4CORE107_INST_EXPORT_22.zip'
-      - 'S4CORE107_INST_EXPORT_23.zip'
-      - 'S4CORE107_INST_EXPORT_24.zip'
-      - 'S4CORE107_INST_EXPORT_25.zip'
-      - 'S4CORE107_INST_EXPORT_26.zip'
-      - 'S4CORE107_INST_EXPORT_27.zip'
-      - 'S4CORE107_INST_EXPORT_28.zip'
-      - 'S4CORE107_INST_EXPORT_29.zip'
-      - 'S4CORE107_INST_EXPORT_30.zip'
-      - 'S4HANAOP107_ERP_LANG_EN.SAR'
-    #  - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
-    #  - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
-    #  - 'SAPPAAPL4_2203_2-80004547.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
-    #  - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # - 'SAPPAAPL4_2203_2-80004547.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
+      # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_51-70006667.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006666.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
-      - 'S4CORE107_INST_EXPORT_1.zip'
-      - 'S4CORE107_INST_EXPORT_2.zip'
-      - 'S4CORE107_INST_EXPORT_3.zip'
-      - 'S4CORE107_INST_EXPORT_4.zip'
-      - 'S4CORE107_INST_EXPORT_5.zip'
-      - 'S4CORE107_INST_EXPORT_6.zip'
-      - 'S4CORE107_INST_EXPORT_7.zip'
-      - 'S4CORE107_INST_EXPORT_8.zip'
-      - 'S4CORE107_INST_EXPORT_9.zip'
-      - 'S4CORE107_INST_EXPORT_10.zip'
-      - 'S4CORE107_INST_EXPORT_11.zip'
-      - 'S4CORE107_INST_EXPORT_12.zip'
-      - 'S4CORE107_INST_EXPORT_13.zip'
-      - 'S4CORE107_INST_EXPORT_14.zip'
-      - 'S4CORE107_INST_EXPORT_15.zip'
-      - 'S4CORE107_INST_EXPORT_16.zip'
-      - 'S4CORE107_INST_EXPORT_17.zip'
-      - 'S4CORE107_INST_EXPORT_18.zip'
-      - 'S4CORE107_INST_EXPORT_19.zip'
-      - 'S4CORE107_INST_EXPORT_20.zip'
-      - 'S4CORE107_INST_EXPORT_21.zip'
-      - 'S4CORE107_INST_EXPORT_22.zip'
-      - 'S4CORE107_INST_EXPORT_23.zip'
-      - 'S4CORE107_INST_EXPORT_24.zip'
-      - 'S4CORE107_INST_EXPORT_25.zip'
-      - 'S4CORE107_INST_EXPORT_26.zip'
-      - 'S4CORE107_INST_EXPORT_27.zip'
-      - 'S4CORE107_INST_EXPORT_28.zip'
-      - 'S4CORE107_INST_EXPORT_29.zip'
-      - 'S4CORE107_INST_EXPORT_30.zip'
-      - 'S4HANAOP107_ERP_LANG_EN.SAR'
-    #  - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
-    #  - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
-    #  - 'SAPPAAPL4_2203_2-80004546.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
-    #  - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # - 'SAPPAAPL4_2203_2-80004546.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
+      # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2022.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2022.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2022.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2022.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
-
-        # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
-
-        # SAP Host Agent
         sap_swpm_install_saphostagent: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2021_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE106_INST_EXPORT_1.zip'
+      - 'S4CORE106_INST_EXPORT_2.zip'
+      - 'S4CORE106_INST_EXPORT_3.zip'
+      - 'S4CORE106_INST_EXPORT_4.zip'
+      - 'S4CORE106_INST_EXPORT_5.zip'
+      - 'S4CORE106_INST_EXPORT_6.zip'
+      - 'S4CORE106_INST_EXPORT_7.zip'
+      - 'S4CORE106_INST_EXPORT_8.zip'
+      - 'S4CORE106_INST_EXPORT_9.zip'
+      - 'S4CORE106_INST_EXPORT_10.zip'
+      - 'S4CORE106_INST_EXPORT_11.zip'
+      - 'S4CORE106_INST_EXPORT_12.zip'
+      - 'S4CORE106_INST_EXPORT_13.zip'
+      - 'S4CORE106_INST_EXPORT_14.zip'
+      - 'S4CORE106_INST_EXPORT_15.zip'
+      - 'S4CORE106_INST_EXPORT_16.zip'
+      - 'S4CORE106_INST_EXPORT_17.zip'
+      - 'S4CORE106_INST_EXPORT_18.zip'
+      - 'S4CORE106_INST_EXPORT_19.zip'
+      - 'S4CORE106_INST_EXPORT_20.zip'
+      - 'S4CORE106_INST_EXPORT_21.zip'
+      - 'S4CORE106_INST_EXPORT_22.zip'
+      - 'S4CORE106_INST_EXPORT_23.zip'
+      - 'S4CORE106_INST_EXPORT_24.zip'
+      - 'S4CORE106_INST_EXPORT_25.zip'
+      - 'S4CORE106_INST_EXPORT_26.zip'
+      - 'S4CORE106_INST_EXPORT_27.zip'
+      - 'S4CORE106_INST_EXPORT_28.zip'
+      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004822.SAR'
-      - 'S4CORE106_INST_EXPORT_1.zip'
-      - 'S4CORE106_INST_EXPORT_2.zip'
-      - 'S4CORE106_INST_EXPORT_3.zip'
-      - 'S4CORE106_INST_EXPORT_4.zip'
-      - 'S4CORE106_INST_EXPORT_5.zip'
-      - 'S4CORE106_INST_EXPORT_6.zip'
-      - 'S4CORE106_INST_EXPORT_7.zip'
-      - 'S4CORE106_INST_EXPORT_8.zip'
-      - 'S4CORE106_INST_EXPORT_9.zip'
-      - 'S4CORE106_INST_EXPORT_10.zip'
-      - 'S4CORE106_INST_EXPORT_11.zip'
-      - 'S4CORE106_INST_EXPORT_12.zip'
-      - 'S4CORE106_INST_EXPORT_13.zip'
-      - 'S4CORE106_INST_EXPORT_14.zip'
-      - 'S4CORE106_INST_EXPORT_15.zip'
-      - 'S4CORE106_INST_EXPORT_16.zip'
-      - 'S4CORE106_INST_EXPORT_17.zip'
-      - 'S4CORE106_INST_EXPORT_18.zip'
-      - 'S4CORE106_INST_EXPORT_19.zip'
-      - 'S4CORE106_INST_EXPORT_20.zip'
-      - 'S4CORE106_INST_EXPORT_21.zip'
-      - 'S4CORE106_INST_EXPORT_22.zip'
-      - 'S4CORE106_INST_EXPORT_23.zip'
-      - 'S4CORE106_INST_EXPORT_24.zip'
-      - 'S4CORE106_INST_EXPORT_25.zip'
-      - 'S4CORE106_INST_EXPORT_26.zip'
-      - 'S4CORE106_INST_EXPORT_27.zip'
-      - 'S4CORE106_INST_EXPORT_28.zip'
-      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004831.SAR'
-      - 'S4CORE106_INST_EXPORT_1.zip'
-      - 'S4CORE106_INST_EXPORT_2.zip'
-      - 'S4CORE106_INST_EXPORT_3.zip'
-      - 'S4CORE106_INST_EXPORT_4.zip'
-      - 'S4CORE106_INST_EXPORT_5.zip'
-      - 'S4CORE106_INST_EXPORT_6.zip'
-      - 'S4CORE106_INST_EXPORT_7.zip'
-      - 'S4CORE106_INST_EXPORT_8.zip'
-      - 'S4CORE106_INST_EXPORT_9.zip'
-      - 'S4CORE106_INST_EXPORT_10.zip'
-      - 'S4CORE106_INST_EXPORT_11.zip'
-      - 'S4CORE106_INST_EXPORT_12.zip'
-      - 'S4CORE106_INST_EXPORT_13.zip'
-      - 'S4CORE106_INST_EXPORT_14.zip'
-      - 'S4CORE106_INST_EXPORT_15.zip'
-      - 'S4CORE106_INST_EXPORT_16.zip'
-      - 'S4CORE106_INST_EXPORT_17.zip'
-      - 'S4CORE106_INST_EXPORT_18.zip'
-      - 'S4CORE106_INST_EXPORT_19.zip'
-      - 'S4CORE106_INST_EXPORT_20.zip'
-      - 'S4CORE106_INST_EXPORT_21.zip'
-      - 'S4CORE106_INST_EXPORT_22.zip'
-      - 'S4CORE106_INST_EXPORT_23.zip'
-      - 'S4CORE106_INST_EXPORT_24.zip'
-      - 'S4CORE106_INST_EXPORT_25.zip'
-      - 'S4CORE106_INST_EXPORT_26.zip'
-      - 'S4CORE106_INST_EXPORT_27.zip'
-      - 'S4CORE106_INST_EXPORT_28.zip'
-      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2021.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2021.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2021.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2021.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
-
-        # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
-
-        # SAP Host Agent
         sap_swpm_install_saphostagent: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2020_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE105_INST_EXPORT_1.zip'
+      - 'S4CORE105_INST_EXPORT_2.zip'
+      - 'S4CORE105_INST_EXPORT_3.zip'
+      - 'S4CORE105_INST_EXPORT_4.zip'
+      - 'S4CORE105_INST_EXPORT_5.zip'
+      - 'S4CORE105_INST_EXPORT_6.zip'
+      - 'S4CORE105_INST_EXPORT_7.zip'
+      - 'S4CORE105_INST_EXPORT_8.zip'
+      - 'S4CORE105_INST_EXPORT_9.zip'
+      - 'S4CORE105_INST_EXPORT_10.zip'
+      - 'S4CORE105_INST_EXPORT_11.zip'
+      - 'S4CORE105_INST_EXPORT_12.zip'
+      - 'S4CORE105_INST_EXPORT_13.zip'
+      - 'S4CORE105_INST_EXPORT_14.zip'
+      - 'S4CORE105_INST_EXPORT_15.zip'
+      - 'S4CORE105_INST_EXPORT_16.zip'
+      - 'S4CORE105_INST_EXPORT_17.zip'
+      - 'S4CORE105_INST_EXPORT_18.zip'
+      - 'S4CORE105_INST_EXPORT_19.zip'
+      - 'S4CORE105_INST_EXPORT_20.zip'
+      - 'S4CORE105_INST_EXPORT_21.zip'
+      - 'S4CORE105_INST_EXPORT_22.zip'
+      - 'S4CORE105_INST_EXPORT_23.zip'
+      - 'S4CORE105_INST_EXPORT_24.zip'
+      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004822.SAR'
-      - 'S4CORE105_INST_EXPORT_1.zip'
-      - 'S4CORE105_INST_EXPORT_2.zip'
-      - 'S4CORE105_INST_EXPORT_3.zip'
-      - 'S4CORE105_INST_EXPORT_4.zip'
-      - 'S4CORE105_INST_EXPORT_5.zip'
-      - 'S4CORE105_INST_EXPORT_6.zip'
-      - 'S4CORE105_INST_EXPORT_7.zip'
-      - 'S4CORE105_INST_EXPORT_8.zip'
-      - 'S4CORE105_INST_EXPORT_9.zip'
-      - 'S4CORE105_INST_EXPORT_10.zip'
-      - 'S4CORE105_INST_EXPORT_11.zip'
-      - 'S4CORE105_INST_EXPORT_12.zip'
-      - 'S4CORE105_INST_EXPORT_13.zip'
-      - 'S4CORE105_INST_EXPORT_14.zip'
-      - 'S4CORE105_INST_EXPORT_15.zip'
-      - 'S4CORE105_INST_EXPORT_16.zip'
-      - 'S4CORE105_INST_EXPORT_17.zip'
-      - 'S4CORE105_INST_EXPORT_18.zip'
-      - 'S4CORE105_INST_EXPORT_19.zip'
-      - 'S4CORE105_INST_EXPORT_20.zip'
-      - 'S4CORE105_INST_EXPORT_21.zip'
-      - 'S4CORE105_INST_EXPORT_22.zip'
-      - 'S4CORE105_INST_EXPORT_23.zip'
-      - 'S4CORE105_INST_EXPORT_24.zip'
-      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004831.SAR'
-      - 'S4CORE105_INST_EXPORT_1.zip'
-      - 'S4CORE105_INST_EXPORT_2.zip'
-      - 'S4CORE105_INST_EXPORT_3.zip'
-      - 'S4CORE105_INST_EXPORT_4.zip'
-      - 'S4CORE105_INST_EXPORT_5.zip'
-      - 'S4CORE105_INST_EXPORT_6.zip'
-      - 'S4CORE105_INST_EXPORT_7.zip'
-      - 'S4CORE105_INST_EXPORT_8.zip'
-      - 'S4CORE105_INST_EXPORT_9.zip'
-      - 'S4CORE105_INST_EXPORT_10.zip'
-      - 'S4CORE105_INST_EXPORT_11.zip'
-      - 'S4CORE105_INST_EXPORT_12.zip'
-      - 'S4CORE105_INST_EXPORT_13.zip'
-      - 'S4CORE105_INST_EXPORT_14.zip'
-      - 'S4CORE105_INST_EXPORT_15.zip'
-      - 'S4CORE105_INST_EXPORT_16.zip'
-      - 'S4CORE105_INST_EXPORT_17.zip'
-      - 'S4CORE105_INST_EXPORT_18.zip'
-      - 'S4CORE105_INST_EXPORT_19.zip'
-      - 'S4CORE105_INST_EXPORT_20.zip'
-      - 'S4CORE105_INST_EXPORT_21.zip'
-      - 'S4CORE105_INST_EXPORT_22.zip'
-      - 'S4CORE105_INST_EXPORT_23.zip'
-      - 'S4CORE105_INST_EXPORT_24.zip'
-      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2020.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2020.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2020.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2020.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
-
-        # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
-
-        # SAP Host Agent
         sap_swpm_install_saphostagent: true
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  ascs_pas:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
+
+  aas:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_ports
+    - nw_config_other
+    - nw_config_additional_application_server_instance
+    - nw_config_host_agent
+    - sap_os_linux_user
+
+# Dictionary of lists for software filename wildcard patterns that is used during rsync operations.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_software_wildcards:
+  hana:
+    - 'SAPCAR*'
+    - 'IMDB_*'
+    - 'SAPHOSTAGENT*'
+
+  netweaver:
+    - 'SAPCAR*'
+    - 'IMDB_CLIENT*'
+    - 'SWPM20*'
+    - 'igsexe_*'
+    - 'igshelper_*'
+    - 'SAPEXE_*'
+    - 'SAPEXEDB_*'
+    - 'SUM*'
+    - 'SAPHOSTAGENT*'
+
+  dbload:
+    - 'SAPCAR*'
+    - 'IMDB_CLIENT*'
+    - 'SWPM20*'
+    - 'igsexe_*'
+    - 'igshelper_*'
+    - 'SAPEXE_*'
+    - 'SAPEXEDB_*'
+    - 'SUM*'
+    - 'SAPHOSTAGENT*'
+    - 'S4CORE*'
+    - 'S4HANAOP*'
+    - 'HANAUMML*'
+    - 'K-*'
+    - 'KD*'
+    - 'KE*'
+    - 'KIT*'
+    - 'SAPPAAPL*'
+    - 'SAP_BASIS*'

--- a/deploy_scenarios/sap_s4hana_distributed/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed/ansible_playbook.yml
@@ -270,8 +270,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
@@ -279,7 +280,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['software_files_hana_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['sap_software_files_hana_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_hana_install_media_files
 
@@ -287,7 +288,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_ascs']['software_files_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_ascs']['sap_software_files_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_nwas_ascs_install_media_files
 
@@ -295,7 +296,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_aas']['software_files_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_aas']['sap_software_files_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_nwas_aas_install_media_files
 

--- a/deploy_scenarios/sap_s4hana_distributed/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_distributed/optional/ansible_extravars_interactive.yml
@@ -40,134 +40,92 @@ sap_software_install_dictionary:
 
   sap_s4hana_2025_distributed:
 
-    softwarecenter_search_list_x86_64:
-      # Database
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
       - 'SAPPAAPL4_2405_0-80004547.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
-      # Media
-      - 'S4HANAOP109_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_INST_EXPORT_2.zip'
-      - 'S4HANAOP109_INST_EXPORT_3.zip'
-      - 'S4HANAOP109_INST_EXPORT_4.zip'
-      - 'S4HANAOP109_INST_EXPORT_5.zip'
-      - 'S4HANAOP109_INST_EXPORT_6.zip'
-      - 'S4HANAOP109_INST_EXPORT_7.zip'
-      - 'S4HANAOP109_INST_EXPORT_8.zip'
-      - 'S4HANAOP109_INST_EXPORT_9.zip'
-      - 'S4HANAOP109_INST_EXPORT_10.zip'
-      - 'S4HANAOP109_INST_EXPORT_11.zip'
-      - 'S4HANAOP109_INST_EXPORT_12.zip'
-      - 'S4HANAOP109_INST_EXPORT_13.zip'
-      - 'S4HANAOP109_INST_EXPORT_14.zip'
-      - 'S4HANAOP109_INST_EXPORT_15.zip'
-      - 'S4HANAOP109_INST_EXPORT_16.zip'
-      - 'S4HANAOP109_INST_EXPORT_17.zip'
-      - 'S4HANAOP109_INST_EXPORT_18.zip'
-      - 'S4HANAOP109_INST_EXPORT_19.zip'
-      - 'S4HANAOP109_INST_EXPORT_20.zip'
-      - 'S4HANAOP109_INST_EXPORT_21.zip'
-      - 'S4HANAOP109_INST_EXPORT_22.zip'
-      - 'S4HANAOP109_INST_EXPORT_23.zip'
-      - 'S4HANAOP109_INST_EXPORT_24.zip'
-      - 'S4HANAOP109_INST_EXPORT_25.zip'
-      - 'S4HANAOP109_INST_EXPORT_26.zip'
-      - 'S4HANAOP109_INST_EXPORT_27.zip'
-      - 'S4HANAOP109_INST_EXPORT_28.zip'
-      - 'S4HANAOP109_INST_EXPORT_29.zip'
-      - 'S4HANAOP109_INST_EXPORT_30.zip'
-      - 'S4HANAOP109_INST_EXPORT_31.zip'
-      - 'S4HANAOP109_INST_EXPORT_32.zip'
-      - 'S4HANAOP109_INST_EXPORT_33.zip'
-      - 'S4HANAOP109_INST_EXPORT_34.zip'
-      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_ERP_LANG_EN.SAR'
       - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007716.EXE'
       - 'SWPM20SP23_2-80003424.SAR'
       # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
-      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
-      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
       - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
-      # Media
-      - 'S4HANAOP109_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_INST_EXPORT_2.zip'
-      - 'S4HANAOP109_INST_EXPORT_3.zip'
-      - 'S4HANAOP109_INST_EXPORT_4.zip'
-      - 'S4HANAOP109_INST_EXPORT_5.zip'
-      - 'S4HANAOP109_INST_EXPORT_6.zip'
-      - 'S4HANAOP109_INST_EXPORT_7.zip'
-      - 'S4HANAOP109_INST_EXPORT_8.zip'
-      - 'S4HANAOP109_INST_EXPORT_9.zip'
-      - 'S4HANAOP109_INST_EXPORT_10.zip'
-      - 'S4HANAOP109_INST_EXPORT_11.zip'
-      - 'S4HANAOP109_INST_EXPORT_12.zip'
-      - 'S4HANAOP109_INST_EXPORT_13.zip'
-      - 'S4HANAOP109_INST_EXPORT_14.zip'
-      - 'S4HANAOP109_INST_EXPORT_15.zip'
-      - 'S4HANAOP109_INST_EXPORT_16.zip'
-      - 'S4HANAOP109_INST_EXPORT_17.zip'
-      - 'S4HANAOP109_INST_EXPORT_18.zip'
-      - 'S4HANAOP109_INST_EXPORT_19.zip'
-      - 'S4HANAOP109_INST_EXPORT_20.zip'
-      - 'S4HANAOP109_INST_EXPORT_21.zip'
-      - 'S4HANAOP109_INST_EXPORT_22.zip'
-      - 'S4HANAOP109_INST_EXPORT_23.zip'
-      - 'S4HANAOP109_INST_EXPORT_24.zip'
-      - 'S4HANAOP109_INST_EXPORT_25.zip'
-      - 'S4HANAOP109_INST_EXPORT_26.zip'
-      - 'S4HANAOP109_INST_EXPORT_27.zip'
-      - 'S4HANAOP109_INST_EXPORT_28.zip'
-      - 'S4HANAOP109_INST_EXPORT_29.zip'
-      - 'S4HANAOP109_INST_EXPORT_30.zip'
-      - 'S4HANAOP109_INST_EXPORT_31.zip'
-      - 'S4HANAOP109_INST_EXPORT_32.zip'
-      - 'S4HANAOP109_INST_EXPORT_33.zip'
-      - 'S4HANAOP109_INST_EXPORT_34.zip'
-      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_ERP_LANG_EN.SAR'
       - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007726.EXE'
       - 'SWPM20SP23_2-80003426.SAR'
-      # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
-      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
-      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    # This list assigned from shared dictionary, because it is same with other products or host types.
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs:
 
@@ -175,117 +133,47 @@ sap_software_install_dictionary:
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2025.CORE.HDB.ABAP
 
       # List of INI file sections to generate using sap_install.sap_swpm role (List).
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2025.CORE.HDB.ABAP
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2025.CORE.HDB.ABAP
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2025.CORE.HDB.PD
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
 
       sap_swpm_inifile_dictionary:
 
@@ -293,30 +181,19 @@ sap_software_install_dictionary:
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+        # SAP Host Agent
+        sap_swpm_install_saphostagent: true
+
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2023_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
-      # Database
-      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
-      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
-      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
-      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
-      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
-      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
-      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+    sap_software_list_independent:
+      # Application Media
       - 'S4CORE108_INST_EXPORT_1.zip'
       - 'S4CORE108_INST_EXPORT_2.zip'
       - 'S4CORE108_INST_EXPORT_3.zip'
@@ -349,892 +226,424 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
-      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Application Server
       - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
+      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
+      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
+      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+      - 'igsexe_4-70005417.sar' # IGS 7.81
       # Tools
       - 'SAPCAR_1300-70007716.EXE'
       - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
       - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
-      - 'S4CORE108_INST_EXPORT_1.zip'
-      - 'S4CORE108_INST_EXPORT_2.zip'
-      - 'S4CORE108_INST_EXPORT_3.zip'
-      - 'S4CORE108_INST_EXPORT_4.zip'
-      - 'S4CORE108_INST_EXPORT_5.zip'
-      - 'S4CORE108_INST_EXPORT_6.zip'
-      - 'S4CORE108_INST_EXPORT_7.zip'
-      - 'S4CORE108_INST_EXPORT_8.zip'
-      - 'S4CORE108_INST_EXPORT_9.zip'
-      - 'S4CORE108_INST_EXPORT_10.zip'
-      - 'S4CORE108_INST_EXPORT_11.zip'
-      - 'S4CORE108_INST_EXPORT_12.zip'
-      - 'S4CORE108_INST_EXPORT_13.zip'
-      - 'S4CORE108_INST_EXPORT_14.zip'
-      - 'S4CORE108_INST_EXPORT_15.zip'
-      - 'S4CORE108_INST_EXPORT_16.zip'
-      - 'S4CORE108_INST_EXPORT_17.zip'
-      - 'S4CORE108_INST_EXPORT_18.zip'
-      - 'S4CORE108_INST_EXPORT_19.zip'
-      - 'S4CORE108_INST_EXPORT_20.zip'
-      - 'S4CORE108_INST_EXPORT_21.zip'
-      - 'S4CORE108_INST_EXPORT_22.zip'
-      - 'S4CORE108_INST_EXPORT_23.zip'
-      - 'S4CORE108_INST_EXPORT_24.zip'
-      - 'S4CORE108_INST_EXPORT_25.zip'
-      - 'S4CORE108_INST_EXPORT_26.zip'
-      - 'S4CORE108_INST_EXPORT_27.zip'
-      - 'S4CORE108_INST_EXPORT_28.zip'
-      - 'S4CORE108_INST_EXPORT_29.zip'
-      - 'S4CORE108_INST_EXPORT_30.zip'
-      - 'S4HANAOP108_ERP_LANG_EN.SAR'
-      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
       - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
       # Tools
       - 'SAPCAR_1300-70007726.EXE'
       - 'SWPM20SP20_1-80003426.SAR'
       # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs:
-
-      # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2023.CORE.HDB.ABAP
-
-      # List of INI file sections to generate using sap_install.sap_swpm role (List).
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2023.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2023.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2023.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
-
-        # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+        sap_swpm_install_saphostagent: true
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2022_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE107_INST_EXPORT_1.zip'
+      - 'S4CORE107_INST_EXPORT_2.zip'
+      - 'S4CORE107_INST_EXPORT_3.zip'
+      - 'S4CORE107_INST_EXPORT_4.zip'
+      - 'S4CORE107_INST_EXPORT_5.zip'
+      - 'S4CORE107_INST_EXPORT_6.zip'
+      - 'S4CORE107_INST_EXPORT_7.zip'
+      - 'S4CORE107_INST_EXPORT_8.zip'
+      - 'S4CORE107_INST_EXPORT_9.zip'
+      - 'S4CORE107_INST_EXPORT_10.zip'
+      - 'S4CORE107_INST_EXPORT_11.zip'
+      - 'S4CORE107_INST_EXPORT_12.zip'
+      - 'S4CORE107_INST_EXPORT_13.zip'
+      - 'S4CORE107_INST_EXPORT_14.zip'
+      - 'S4CORE107_INST_EXPORT_15.zip'
+      - 'S4CORE107_INST_EXPORT_16.zip'
+      - 'S4CORE107_INST_EXPORT_17.zip'
+      - 'S4CORE107_INST_EXPORT_18.zip'
+      - 'S4CORE107_INST_EXPORT_19.zip'
+      - 'S4CORE107_INST_EXPORT_20.zip'
+      - 'S4CORE107_INST_EXPORT_21.zip'
+      - 'S4CORE107_INST_EXPORT_22.zip'
+      - 'S4CORE107_INST_EXPORT_23.zip'
+      - 'S4CORE107_INST_EXPORT_24.zip'
+      - 'S4CORE107_INST_EXPORT_25.zip'
+      - 'S4CORE107_INST_EXPORT_26.zip'
+      - 'S4CORE107_INST_EXPORT_27.zip'
+      - 'S4CORE107_INST_EXPORT_28.zip'
+      - 'S4CORE107_INST_EXPORT_29.zip'
+      - 'S4CORE107_INST_EXPORT_30.zip'
+      - 'S4HANAOP107_ERP_LANG_EN.SAR'
+      # - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
+      # - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_51-70006642.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006641.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
-      - 'S4CORE107_INST_EXPORT_1.zip'
-      - 'S4CORE107_INST_EXPORT_2.zip'
-      - 'S4CORE107_INST_EXPORT_3.zip'
-      - 'S4CORE107_INST_EXPORT_4.zip'
-      - 'S4CORE107_INST_EXPORT_5.zip'
-      - 'S4CORE107_INST_EXPORT_6.zip'
-      - 'S4CORE107_INST_EXPORT_7.zip'
-      - 'S4CORE107_INST_EXPORT_8.zip'
-      - 'S4CORE107_INST_EXPORT_9.zip'
-      - 'S4CORE107_INST_EXPORT_10.zip'
-      - 'S4CORE107_INST_EXPORT_11.zip'
-      - 'S4CORE107_INST_EXPORT_12.zip'
-      - 'S4CORE107_INST_EXPORT_13.zip'
-      - 'S4CORE107_INST_EXPORT_14.zip'
-      - 'S4CORE107_INST_EXPORT_15.zip'
-      - 'S4CORE107_INST_EXPORT_16.zip'
-      - 'S4CORE107_INST_EXPORT_17.zip'
-      - 'S4CORE107_INST_EXPORT_18.zip'
-      - 'S4CORE107_INST_EXPORT_19.zip'
-      - 'S4CORE107_INST_EXPORT_20.zip'
-      - 'S4CORE107_INST_EXPORT_21.zip'
-      - 'S4CORE107_INST_EXPORT_22.zip'
-      - 'S4CORE107_INST_EXPORT_23.zip'
-      - 'S4CORE107_INST_EXPORT_24.zip'
-      - 'S4CORE107_INST_EXPORT_25.zip'
-      - 'S4CORE107_INST_EXPORT_26.zip'
-      - 'S4CORE107_INST_EXPORT_27.zip'
-      - 'S4CORE107_INST_EXPORT_28.zip'
-      - 'S4CORE107_INST_EXPORT_29.zip'
-      - 'S4CORE107_INST_EXPORT_30.zip'
-      - 'S4HANAOP107_ERP_LANG_EN.SAR'
-    #  - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
-    #  - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
-    #  - 'SAPPAAPL4_2203_2-80004547.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
-    #  - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # - 'SAPPAAPL4_2203_2-80004547.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
+      # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_51-70006667.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006666.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
-      - 'S4CORE107_INST_EXPORT_1.zip'
-      - 'S4CORE107_INST_EXPORT_2.zip'
-      - 'S4CORE107_INST_EXPORT_3.zip'
-      - 'S4CORE107_INST_EXPORT_4.zip'
-      - 'S4CORE107_INST_EXPORT_5.zip'
-      - 'S4CORE107_INST_EXPORT_6.zip'
-      - 'S4CORE107_INST_EXPORT_7.zip'
-      - 'S4CORE107_INST_EXPORT_8.zip'
-      - 'S4CORE107_INST_EXPORT_9.zip'
-      - 'S4CORE107_INST_EXPORT_10.zip'
-      - 'S4CORE107_INST_EXPORT_11.zip'
-      - 'S4CORE107_INST_EXPORT_12.zip'
-      - 'S4CORE107_INST_EXPORT_13.zip'
-      - 'S4CORE107_INST_EXPORT_14.zip'
-      - 'S4CORE107_INST_EXPORT_15.zip'
-      - 'S4CORE107_INST_EXPORT_16.zip'
-      - 'S4CORE107_INST_EXPORT_17.zip'
-      - 'S4CORE107_INST_EXPORT_18.zip'
-      - 'S4CORE107_INST_EXPORT_19.zip'
-      - 'S4CORE107_INST_EXPORT_20.zip'
-      - 'S4CORE107_INST_EXPORT_21.zip'
-      - 'S4CORE107_INST_EXPORT_22.zip'
-      - 'S4CORE107_INST_EXPORT_23.zip'
-      - 'S4CORE107_INST_EXPORT_24.zip'
-      - 'S4CORE107_INST_EXPORT_25.zip'
-      - 'S4CORE107_INST_EXPORT_26.zip'
-      - 'S4CORE107_INST_EXPORT_27.zip'
-      - 'S4CORE107_INST_EXPORT_28.zip'
-      - 'S4CORE107_INST_EXPORT_29.zip'
-      - 'S4CORE107_INST_EXPORT_30.zip'
-      - 'S4HANAOP107_ERP_LANG_EN.SAR'
-    #  - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
-    #  - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
-    #  - 'SAPPAAPL4_2203_2-80004546.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
-    #  - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # - 'SAPPAAPL4_2203_2-80004546.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
+      # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2022.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2022.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2022.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2022.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
-
-        # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
-
-        # SAP Host Agent
         sap_swpm_install_saphostagent: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2021_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE106_INST_EXPORT_1.zip'
+      - 'S4CORE106_INST_EXPORT_2.zip'
+      - 'S4CORE106_INST_EXPORT_3.zip'
+      - 'S4CORE106_INST_EXPORT_4.zip'
+      - 'S4CORE106_INST_EXPORT_5.zip'
+      - 'S4CORE106_INST_EXPORT_6.zip'
+      - 'S4CORE106_INST_EXPORT_7.zip'
+      - 'S4CORE106_INST_EXPORT_8.zip'
+      - 'S4CORE106_INST_EXPORT_9.zip'
+      - 'S4CORE106_INST_EXPORT_10.zip'
+      - 'S4CORE106_INST_EXPORT_11.zip'
+      - 'S4CORE106_INST_EXPORT_12.zip'
+      - 'S4CORE106_INST_EXPORT_13.zip'
+      - 'S4CORE106_INST_EXPORT_14.zip'
+      - 'S4CORE106_INST_EXPORT_15.zip'
+      - 'S4CORE106_INST_EXPORT_16.zip'
+      - 'S4CORE106_INST_EXPORT_17.zip'
+      - 'S4CORE106_INST_EXPORT_18.zip'
+      - 'S4CORE106_INST_EXPORT_19.zip'
+      - 'S4CORE106_INST_EXPORT_20.zip'
+      - 'S4CORE106_INST_EXPORT_21.zip'
+      - 'S4CORE106_INST_EXPORT_22.zip'
+      - 'S4CORE106_INST_EXPORT_23.zip'
+      - 'S4CORE106_INST_EXPORT_24.zip'
+      - 'S4CORE106_INST_EXPORT_25.zip'
+      - 'S4CORE106_INST_EXPORT_26.zip'
+      - 'S4CORE106_INST_EXPORT_27.zip'
+      - 'S4CORE106_INST_EXPORT_28.zip'
+      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004822.SAR'
-      - 'S4CORE106_INST_EXPORT_1.zip'
-      - 'S4CORE106_INST_EXPORT_2.zip'
-      - 'S4CORE106_INST_EXPORT_3.zip'
-      - 'S4CORE106_INST_EXPORT_4.zip'
-      - 'S4CORE106_INST_EXPORT_5.zip'
-      - 'S4CORE106_INST_EXPORT_6.zip'
-      - 'S4CORE106_INST_EXPORT_7.zip'
-      - 'S4CORE106_INST_EXPORT_8.zip'
-      - 'S4CORE106_INST_EXPORT_9.zip'
-      - 'S4CORE106_INST_EXPORT_10.zip'
-      - 'S4CORE106_INST_EXPORT_11.zip'
-      - 'S4CORE106_INST_EXPORT_12.zip'
-      - 'S4CORE106_INST_EXPORT_13.zip'
-      - 'S4CORE106_INST_EXPORT_14.zip'
-      - 'S4CORE106_INST_EXPORT_15.zip'
-      - 'S4CORE106_INST_EXPORT_16.zip'
-      - 'S4CORE106_INST_EXPORT_17.zip'
-      - 'S4CORE106_INST_EXPORT_18.zip'
-      - 'S4CORE106_INST_EXPORT_19.zip'
-      - 'S4CORE106_INST_EXPORT_20.zip'
-      - 'S4CORE106_INST_EXPORT_21.zip'
-      - 'S4CORE106_INST_EXPORT_22.zip'
-      - 'S4CORE106_INST_EXPORT_23.zip'
-      - 'S4CORE106_INST_EXPORT_24.zip'
-      - 'S4CORE106_INST_EXPORT_25.zip'
-      - 'S4CORE106_INST_EXPORT_26.zip'
-      - 'S4CORE106_INST_EXPORT_27.zip'
-      - 'S4CORE106_INST_EXPORT_28.zip'
-      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004831.SAR'
-      - 'S4CORE106_INST_EXPORT_1.zip'
-      - 'S4CORE106_INST_EXPORT_2.zip'
-      - 'S4CORE106_INST_EXPORT_3.zip'
-      - 'S4CORE106_INST_EXPORT_4.zip'
-      - 'S4CORE106_INST_EXPORT_5.zip'
-      - 'S4CORE106_INST_EXPORT_6.zip'
-      - 'S4CORE106_INST_EXPORT_7.zip'
-      - 'S4CORE106_INST_EXPORT_8.zip'
-      - 'S4CORE106_INST_EXPORT_9.zip'
-      - 'S4CORE106_INST_EXPORT_10.zip'
-      - 'S4CORE106_INST_EXPORT_11.zip'
-      - 'S4CORE106_INST_EXPORT_12.zip'
-      - 'S4CORE106_INST_EXPORT_13.zip'
-      - 'S4CORE106_INST_EXPORT_14.zip'
-      - 'S4CORE106_INST_EXPORT_15.zip'
-      - 'S4CORE106_INST_EXPORT_16.zip'
-      - 'S4CORE106_INST_EXPORT_17.zip'
-      - 'S4CORE106_INST_EXPORT_18.zip'
-      - 'S4CORE106_INST_EXPORT_19.zip'
-      - 'S4CORE106_INST_EXPORT_20.zip'
-      - 'S4CORE106_INST_EXPORT_21.zip'
-      - 'S4CORE106_INST_EXPORT_22.zip'
-      - 'S4CORE106_INST_EXPORT_23.zip'
-      - 'S4CORE106_INST_EXPORT_24.zip'
-      - 'S4CORE106_INST_EXPORT_25.zip'
-      - 'S4CORE106_INST_EXPORT_26.zip'
-      - 'S4CORE106_INST_EXPORT_27.zip'
-      - 'S4CORE106_INST_EXPORT_28.zip'
-      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2021.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2021.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2021.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2021.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
-
-        # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
-
-        # SAP Host Agent
         sap_swpm_install_saphostagent: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2020_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE105_INST_EXPORT_1.zip'
+      - 'S4CORE105_INST_EXPORT_2.zip'
+      - 'S4CORE105_INST_EXPORT_3.zip'
+      - 'S4CORE105_INST_EXPORT_4.zip'
+      - 'S4CORE105_INST_EXPORT_5.zip'
+      - 'S4CORE105_INST_EXPORT_6.zip'
+      - 'S4CORE105_INST_EXPORT_7.zip'
+      - 'S4CORE105_INST_EXPORT_8.zip'
+      - 'S4CORE105_INST_EXPORT_9.zip'
+      - 'S4CORE105_INST_EXPORT_10.zip'
+      - 'S4CORE105_INST_EXPORT_11.zip'
+      - 'S4CORE105_INST_EXPORT_12.zip'
+      - 'S4CORE105_INST_EXPORT_13.zip'
+      - 'S4CORE105_INST_EXPORT_14.zip'
+      - 'S4CORE105_INST_EXPORT_15.zip'
+      - 'S4CORE105_INST_EXPORT_16.zip'
+      - 'S4CORE105_INST_EXPORT_17.zip'
+      - 'S4CORE105_INST_EXPORT_18.zip'
+      - 'S4CORE105_INST_EXPORT_19.zip'
+      - 'S4CORE105_INST_EXPORT_20.zip'
+      - 'S4CORE105_INST_EXPORT_21.zip'
+      - 'S4CORE105_INST_EXPORT_22.zip'
+      - 'S4CORE105_INST_EXPORT_23.zip'
+      - 'S4CORE105_INST_EXPORT_24.zip'
+      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004822.SAR'
-      - 'S4CORE105_INST_EXPORT_1.zip'
-      - 'S4CORE105_INST_EXPORT_2.zip'
-      - 'S4CORE105_INST_EXPORT_3.zip'
-      - 'S4CORE105_INST_EXPORT_4.zip'
-      - 'S4CORE105_INST_EXPORT_5.zip'
-      - 'S4CORE105_INST_EXPORT_6.zip'
-      - 'S4CORE105_INST_EXPORT_7.zip'
-      - 'S4CORE105_INST_EXPORT_8.zip'
-      - 'S4CORE105_INST_EXPORT_9.zip'
-      - 'S4CORE105_INST_EXPORT_10.zip'
-      - 'S4CORE105_INST_EXPORT_11.zip'
-      - 'S4CORE105_INST_EXPORT_12.zip'
-      - 'S4CORE105_INST_EXPORT_13.zip'
-      - 'S4CORE105_INST_EXPORT_14.zip'
-      - 'S4CORE105_INST_EXPORT_15.zip'
-      - 'S4CORE105_INST_EXPORT_16.zip'
-      - 'S4CORE105_INST_EXPORT_17.zip'
-      - 'S4CORE105_INST_EXPORT_18.zip'
-      - 'S4CORE105_INST_EXPORT_19.zip'
-      - 'S4CORE105_INST_EXPORT_20.zip'
-      - 'S4CORE105_INST_EXPORT_21.zip'
-      - 'S4CORE105_INST_EXPORT_22.zip'
-      - 'S4CORE105_INST_EXPORT_23.zip'
-      - 'S4CORE105_INST_EXPORT_24.zip'
-      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004831.SAR'
-      - 'S4CORE105_INST_EXPORT_1.zip'
-      - 'S4CORE105_INST_EXPORT_2.zip'
-      - 'S4CORE105_INST_EXPORT_3.zip'
-      - 'S4CORE105_INST_EXPORT_4.zip'
-      - 'S4CORE105_INST_EXPORT_5.zip'
-      - 'S4CORE105_INST_EXPORT_6.zip'
-      - 'S4CORE105_INST_EXPORT_7.zip'
-      - 'S4CORE105_INST_EXPORT_8.zip'
-      - 'S4CORE105_INST_EXPORT_9.zip'
-      - 'S4CORE105_INST_EXPORT_10.zip'
-      - 'S4CORE105_INST_EXPORT_11.zip'
-      - 'S4CORE105_INST_EXPORT_12.zip'
-      - 'S4CORE105_INST_EXPORT_13.zip'
-      - 'S4CORE105_INST_EXPORT_14.zip'
-      - 'S4CORE105_INST_EXPORT_15.zip'
-      - 'S4CORE105_INST_EXPORT_16.zip'
-      - 'S4CORE105_INST_EXPORT_17.zip'
-      - 'S4CORE105_INST_EXPORT_18.zip'
-      - 'S4CORE105_INST_EXPORT_19.zip'
-      - 'S4CORE105_INST_EXPORT_20.zip'
-      - 'S4CORE105_INST_EXPORT_21.zip'
-      - 'S4CORE105_INST_EXPORT_22.zip'
-      - 'S4CORE105_INST_EXPORT_23.zip'
-      - 'S4CORE105_INST_EXPORT_24.zip'
-      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2020.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2020.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2020.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2020.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
-
-        # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
-
-        # SAP Host Agent
         sap_swpm_install_saphostagent: true
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  ascs_pas:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
+
+  aas:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_ports
+    - nw_config_other
+    - nw_config_additional_application_server_instance
+    - nw_config_host_agent
+    - sap_os_linux_user
+
+# Dictionary of lists for software filename wildcard patterns that is used during rsync operations.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_software_wildcards:
+  hana:
+    - 'SAPCAR*'
+    - 'IMDB_*'
+    - 'SAPHOSTAGENT*'
+
+  netweaver:
+    - 'SAPCAR*'
+    - 'IMDB_CLIENT*'
+    - 'SWPM20*'
+    - 'igsexe_*'
+    - 'igshelper_*'
+    - 'SAPEXE_*'
+    - 'SAPEXEDB_*'
+    - 'SUM*'
+    - 'SAPHOSTAGENT*'
+
+  dbload:
+    - 'SAPCAR*'
+    - 'IMDB_CLIENT*'
+    - 'SWPM20*'
+    - 'igsexe_*'
+    - 'igshelper_*'
+    - 'SAPEXE_*'
+    - 'SAPEXEDB_*'
+    - 'SUM*'
+    - 'SAPHOSTAGENT*'
+    - 'S4CORE*'
+    - 'S4HANAOP*'
+    - 'HANAUMML*'
+    - 'K-*'
+    - 'KD*'
+    - 'KE*'
+    - 'KIT*'
+    - 'SAPPAAPL*'
+    - 'SAP_BASIS*'
 
 
 #### Interactive Prompt Control Variables ####

--- a/deploy_scenarios/sap_s4hana_distributed_ha/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/ansible_extravars.yml
@@ -32,7 +32,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -179,134 +179,92 @@ sap_software_install_dictionary:
 
   sap_s4hana_2025_distributed:
 
-    softwarecenter_search_list_x86_64:
-      # Database
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
       - 'SAPPAAPL4_2405_0-80004547.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
-      # Media
-      - 'S4HANAOP109_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_INST_EXPORT_2.zip'
-      - 'S4HANAOP109_INST_EXPORT_3.zip'
-      - 'S4HANAOP109_INST_EXPORT_4.zip'
-      - 'S4HANAOP109_INST_EXPORT_5.zip'
-      - 'S4HANAOP109_INST_EXPORT_6.zip'
-      - 'S4HANAOP109_INST_EXPORT_7.zip'
-      - 'S4HANAOP109_INST_EXPORT_8.zip'
-      - 'S4HANAOP109_INST_EXPORT_9.zip'
-      - 'S4HANAOP109_INST_EXPORT_10.zip'
-      - 'S4HANAOP109_INST_EXPORT_11.zip'
-      - 'S4HANAOP109_INST_EXPORT_12.zip'
-      - 'S4HANAOP109_INST_EXPORT_13.zip'
-      - 'S4HANAOP109_INST_EXPORT_14.zip'
-      - 'S4HANAOP109_INST_EXPORT_15.zip'
-      - 'S4HANAOP109_INST_EXPORT_16.zip'
-      - 'S4HANAOP109_INST_EXPORT_17.zip'
-      - 'S4HANAOP109_INST_EXPORT_18.zip'
-      - 'S4HANAOP109_INST_EXPORT_19.zip'
-      - 'S4HANAOP109_INST_EXPORT_20.zip'
-      - 'S4HANAOP109_INST_EXPORT_21.zip'
-      - 'S4HANAOP109_INST_EXPORT_22.zip'
-      - 'S4HANAOP109_INST_EXPORT_23.zip'
-      - 'S4HANAOP109_INST_EXPORT_24.zip'
-      - 'S4HANAOP109_INST_EXPORT_25.zip'
-      - 'S4HANAOP109_INST_EXPORT_26.zip'
-      - 'S4HANAOP109_INST_EXPORT_27.zip'
-      - 'S4HANAOP109_INST_EXPORT_28.zip'
-      - 'S4HANAOP109_INST_EXPORT_29.zip'
-      - 'S4HANAOP109_INST_EXPORT_30.zip'
-      - 'S4HANAOP109_INST_EXPORT_31.zip'
-      - 'S4HANAOP109_INST_EXPORT_32.zip'
-      - 'S4HANAOP109_INST_EXPORT_33.zip'
-      - 'S4HANAOP109_INST_EXPORT_34.zip'
-      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_ERP_LANG_EN.SAR'
       - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007716.EXE'
       - 'SWPM20SP23_2-80003424.SAR'
       # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
-      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
-      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
       - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
-      # Media
-      - 'S4HANAOP109_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_INST_EXPORT_2.zip'
-      - 'S4HANAOP109_INST_EXPORT_3.zip'
-      - 'S4HANAOP109_INST_EXPORT_4.zip'
-      - 'S4HANAOP109_INST_EXPORT_5.zip'
-      - 'S4HANAOP109_INST_EXPORT_6.zip'
-      - 'S4HANAOP109_INST_EXPORT_7.zip'
-      - 'S4HANAOP109_INST_EXPORT_8.zip'
-      - 'S4HANAOP109_INST_EXPORT_9.zip'
-      - 'S4HANAOP109_INST_EXPORT_10.zip'
-      - 'S4HANAOP109_INST_EXPORT_11.zip'
-      - 'S4HANAOP109_INST_EXPORT_12.zip'
-      - 'S4HANAOP109_INST_EXPORT_13.zip'
-      - 'S4HANAOP109_INST_EXPORT_14.zip'
-      - 'S4HANAOP109_INST_EXPORT_15.zip'
-      - 'S4HANAOP109_INST_EXPORT_16.zip'
-      - 'S4HANAOP109_INST_EXPORT_17.zip'
-      - 'S4HANAOP109_INST_EXPORT_18.zip'
-      - 'S4HANAOP109_INST_EXPORT_19.zip'
-      - 'S4HANAOP109_INST_EXPORT_20.zip'
-      - 'S4HANAOP109_INST_EXPORT_21.zip'
-      - 'S4HANAOP109_INST_EXPORT_22.zip'
-      - 'S4HANAOP109_INST_EXPORT_23.zip'
-      - 'S4HANAOP109_INST_EXPORT_24.zip'
-      - 'S4HANAOP109_INST_EXPORT_25.zip'
-      - 'S4HANAOP109_INST_EXPORT_26.zip'
-      - 'S4HANAOP109_INST_EXPORT_27.zip'
-      - 'S4HANAOP109_INST_EXPORT_28.zip'
-      - 'S4HANAOP109_INST_EXPORT_29.zip'
-      - 'S4HANAOP109_INST_EXPORT_30.zip'
-      - 'S4HANAOP109_INST_EXPORT_31.zip'
-      - 'S4HANAOP109_INST_EXPORT_32.zip'
-      - 'S4HANAOP109_INST_EXPORT_33.zip'
-      - 'S4HANAOP109_INST_EXPORT_34.zip'
-      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_ERP_LANG_EN.SAR'
       - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007726.EXE'
       - 'SWPM20SP23_2-80003426.SAR'
-      # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
-      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
-      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    # This list assigned from shared dictionary, because it is same with other products or host types.
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs_ha:
 
@@ -314,140 +272,60 @@ sap_software_install_dictionary:
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2025.CORE.HDB.ABAPHA
 
       # List of INI file sections to generate using sap_install.sap_swpm role (List).
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_ers_ha:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ERS:S4HANA2025.CORE.HDB.ABAPHA
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - credentials
-        - nw_config_other
-        - nw_config_ers
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ers'] }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload_ha:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2025.CORE.HDB.ABAPHA
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2025.CORE.HDB.ABAP
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2025.CORE.HDB.PD
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
 
       sap_swpm_inifile_dictionary:
 
@@ -458,30 +336,16 @@ sap_software_install_dictionary:
         # SAP Host Agent
         sap_swpm_install_saphostagent: true
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2023_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
-      # Database
-      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
-      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
-      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
-      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
-      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
-      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
-      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+    sap_software_list_independent:
+      # Application Media
       - 'S4CORE108_INST_EXPORT_1.zip'
       - 'S4CORE108_INST_EXPORT_2.zip'
       - 'S4CORE108_INST_EXPORT_3.zip'
@@ -514,984 +378,448 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
-      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Application Server
       - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
+      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
+      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
+      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+      - 'igsexe_4-70005417.sar' # IGS 7.81
       # Tools
       - 'SAPCAR_1300-70007716.EXE'
       - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
       - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
-      - 'S4CORE108_INST_EXPORT_1.zip'
-      - 'S4CORE108_INST_EXPORT_2.zip'
-      - 'S4CORE108_INST_EXPORT_3.zip'
-      - 'S4CORE108_INST_EXPORT_4.zip'
-      - 'S4CORE108_INST_EXPORT_5.zip'
-      - 'S4CORE108_INST_EXPORT_6.zip'
-      - 'S4CORE108_INST_EXPORT_7.zip'
-      - 'S4CORE108_INST_EXPORT_8.zip'
-      - 'S4CORE108_INST_EXPORT_9.zip'
-      - 'S4CORE108_INST_EXPORT_10.zip'
-      - 'S4CORE108_INST_EXPORT_11.zip'
-      - 'S4CORE108_INST_EXPORT_12.zip'
-      - 'S4CORE108_INST_EXPORT_13.zip'
-      - 'S4CORE108_INST_EXPORT_14.zip'
-      - 'S4CORE108_INST_EXPORT_15.zip'
-      - 'S4CORE108_INST_EXPORT_16.zip'
-      - 'S4CORE108_INST_EXPORT_17.zip'
-      - 'S4CORE108_INST_EXPORT_18.zip'
-      - 'S4CORE108_INST_EXPORT_19.zip'
-      - 'S4CORE108_INST_EXPORT_20.zip'
-      - 'S4CORE108_INST_EXPORT_21.zip'
-      - 'S4CORE108_INST_EXPORT_22.zip'
-      - 'S4CORE108_INST_EXPORT_23.zip'
-      - 'S4CORE108_INST_EXPORT_24.zip'
-      - 'S4CORE108_INST_EXPORT_25.zip'
-      - 'S4CORE108_INST_EXPORT_26.zip'
-      - 'S4CORE108_INST_EXPORT_27.zip'
-      - 'S4CORE108_INST_EXPORT_28.zip'
-      - 'S4CORE108_INST_EXPORT_29.zip'
-      - 'S4CORE108_INST_EXPORT_30.zip'
-      - 'S4HANAOP108_ERP_LANG_EN.SAR'
-      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
       - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
       # Tools
       - 'SAPCAR_1300-70007726.EXE'
       - 'SWPM20SP20_1-80003426.SAR'
       # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs_ha:
-
-      # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2023.CORE.HDB.ABAPHA
-
-      # List of INI file sections to generate using sap_install.sap_swpm role (List).
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_ers_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ERS:S4HANA2023.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - credentials
-        - nw_config_other
-        - nw_config_ers
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ers'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2023.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2023.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2023.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
-
-        # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
-
-        # SAP Host Agent
         sap_swpm_install_saphostagent: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2022_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE107_INST_EXPORT_1.zip'
+      - 'S4CORE107_INST_EXPORT_2.zip'
+      - 'S4CORE107_INST_EXPORT_3.zip'
+      - 'S4CORE107_INST_EXPORT_4.zip'
+      - 'S4CORE107_INST_EXPORT_5.zip'
+      - 'S4CORE107_INST_EXPORT_6.zip'
+      - 'S4CORE107_INST_EXPORT_7.zip'
+      - 'S4CORE107_INST_EXPORT_8.zip'
+      - 'S4CORE107_INST_EXPORT_9.zip'
+      - 'S4CORE107_INST_EXPORT_10.zip'
+      - 'S4CORE107_INST_EXPORT_11.zip'
+      - 'S4CORE107_INST_EXPORT_12.zip'
+      - 'S4CORE107_INST_EXPORT_13.zip'
+      - 'S4CORE107_INST_EXPORT_14.zip'
+      - 'S4CORE107_INST_EXPORT_15.zip'
+      - 'S4CORE107_INST_EXPORT_16.zip'
+      - 'S4CORE107_INST_EXPORT_17.zip'
+      - 'S4CORE107_INST_EXPORT_18.zip'
+      - 'S4CORE107_INST_EXPORT_19.zip'
+      - 'S4CORE107_INST_EXPORT_20.zip'
+      - 'S4CORE107_INST_EXPORT_21.zip'
+      - 'S4CORE107_INST_EXPORT_22.zip'
+      - 'S4CORE107_INST_EXPORT_23.zip'
+      - 'S4CORE107_INST_EXPORT_24.zip'
+      - 'S4CORE107_INST_EXPORT_25.zip'
+      - 'S4CORE107_INST_EXPORT_26.zip'
+      - 'S4CORE107_INST_EXPORT_27.zip'
+      - 'S4CORE107_INST_EXPORT_28.zip'
+      - 'S4CORE107_INST_EXPORT_29.zip'
+      - 'S4CORE107_INST_EXPORT_30.zip'
+      - 'S4HANAOP107_ERP_LANG_EN.SAR'
+      # - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
+      # - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_51-70006642.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006641.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
-      - 'S4CORE107_INST_EXPORT_1.zip'
-      - 'S4CORE107_INST_EXPORT_2.zip'
-      - 'S4CORE107_INST_EXPORT_3.zip'
-      - 'S4CORE107_INST_EXPORT_4.zip'
-      - 'S4CORE107_INST_EXPORT_5.zip'
-      - 'S4CORE107_INST_EXPORT_6.zip'
-      - 'S4CORE107_INST_EXPORT_7.zip'
-      - 'S4CORE107_INST_EXPORT_8.zip'
-      - 'S4CORE107_INST_EXPORT_9.zip'
-      - 'S4CORE107_INST_EXPORT_10.zip'
-      - 'S4CORE107_INST_EXPORT_11.zip'
-      - 'S4CORE107_INST_EXPORT_12.zip'
-      - 'S4CORE107_INST_EXPORT_13.zip'
-      - 'S4CORE107_INST_EXPORT_14.zip'
-      - 'S4CORE107_INST_EXPORT_15.zip'
-      - 'S4CORE107_INST_EXPORT_16.zip'
-      - 'S4CORE107_INST_EXPORT_17.zip'
-      - 'S4CORE107_INST_EXPORT_18.zip'
-      - 'S4CORE107_INST_EXPORT_19.zip'
-      - 'S4CORE107_INST_EXPORT_20.zip'
-      - 'S4CORE107_INST_EXPORT_21.zip'
-      - 'S4CORE107_INST_EXPORT_22.zip'
-      - 'S4CORE107_INST_EXPORT_23.zip'
-      - 'S4CORE107_INST_EXPORT_24.zip'
-      - 'S4CORE107_INST_EXPORT_25.zip'
-      - 'S4CORE107_INST_EXPORT_26.zip'
-      - 'S4CORE107_INST_EXPORT_27.zip'
-      - 'S4CORE107_INST_EXPORT_28.zip'
-      - 'S4CORE107_INST_EXPORT_29.zip'
-      - 'S4CORE107_INST_EXPORT_30.zip'
-      - 'S4HANAOP107_ERP_LANG_EN.SAR'
-    #  - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
-    #  - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
-    #  - 'SAPPAAPL4_2203_2-80004547.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
-    #  - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # - 'SAPPAAPL4_2203_2-80004547.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
+      # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_51-70006667.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006666.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
-      - 'S4CORE107_INST_EXPORT_1.zip'
-      - 'S4CORE107_INST_EXPORT_2.zip'
-      - 'S4CORE107_INST_EXPORT_3.zip'
-      - 'S4CORE107_INST_EXPORT_4.zip'
-      - 'S4CORE107_INST_EXPORT_5.zip'
-      - 'S4CORE107_INST_EXPORT_6.zip'
-      - 'S4CORE107_INST_EXPORT_7.zip'
-      - 'S4CORE107_INST_EXPORT_8.zip'
-      - 'S4CORE107_INST_EXPORT_9.zip'
-      - 'S4CORE107_INST_EXPORT_10.zip'
-      - 'S4CORE107_INST_EXPORT_11.zip'
-      - 'S4CORE107_INST_EXPORT_12.zip'
-      - 'S4CORE107_INST_EXPORT_13.zip'
-      - 'S4CORE107_INST_EXPORT_14.zip'
-      - 'S4CORE107_INST_EXPORT_15.zip'
-      - 'S4CORE107_INST_EXPORT_16.zip'
-      - 'S4CORE107_INST_EXPORT_17.zip'
-      - 'S4CORE107_INST_EXPORT_18.zip'
-      - 'S4CORE107_INST_EXPORT_19.zip'
-      - 'S4CORE107_INST_EXPORT_20.zip'
-      - 'S4CORE107_INST_EXPORT_21.zip'
-      - 'S4CORE107_INST_EXPORT_22.zip'
-      - 'S4CORE107_INST_EXPORT_23.zip'
-      - 'S4CORE107_INST_EXPORT_24.zip'
-      - 'S4CORE107_INST_EXPORT_25.zip'
-      - 'S4CORE107_INST_EXPORT_26.zip'
-      - 'S4CORE107_INST_EXPORT_27.zip'
-      - 'S4CORE107_INST_EXPORT_28.zip'
-      - 'S4CORE107_INST_EXPORT_29.zip'
-      - 'S4CORE107_INST_EXPORT_30.zip'
-      - 'S4HANAOP107_ERP_LANG_EN.SAR'
-    #  - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
-    #  - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
-    #  - 'SAPPAAPL4_2203_2-80004546.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
-    #  - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # - 'SAPPAAPL4_2203_2-80004546.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
+      # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2022.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_ers_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ERS:S4HANA2022.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - credentials
-        - nw_config_other
-        - nw_config_ers
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ers'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2022.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2022.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2022.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
-
-        # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
-
-        # SAP Host Agent
         sap_swpm_install_saphostagent: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2021_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE106_INST_EXPORT_1.zip'
+      - 'S4CORE106_INST_EXPORT_2.zip'
+      - 'S4CORE106_INST_EXPORT_3.zip'
+      - 'S4CORE106_INST_EXPORT_4.zip'
+      - 'S4CORE106_INST_EXPORT_5.zip'
+      - 'S4CORE106_INST_EXPORT_6.zip'
+      - 'S4CORE106_INST_EXPORT_7.zip'
+      - 'S4CORE106_INST_EXPORT_8.zip'
+      - 'S4CORE106_INST_EXPORT_9.zip'
+      - 'S4CORE106_INST_EXPORT_10.zip'
+      - 'S4CORE106_INST_EXPORT_11.zip'
+      - 'S4CORE106_INST_EXPORT_12.zip'
+      - 'S4CORE106_INST_EXPORT_13.zip'
+      - 'S4CORE106_INST_EXPORT_14.zip'
+      - 'S4CORE106_INST_EXPORT_15.zip'
+      - 'S4CORE106_INST_EXPORT_16.zip'
+      - 'S4CORE106_INST_EXPORT_17.zip'
+      - 'S4CORE106_INST_EXPORT_18.zip'
+      - 'S4CORE106_INST_EXPORT_19.zip'
+      - 'S4CORE106_INST_EXPORT_20.zip'
+      - 'S4CORE106_INST_EXPORT_21.zip'
+      - 'S4CORE106_INST_EXPORT_22.zip'
+      - 'S4CORE106_INST_EXPORT_23.zip'
+      - 'S4CORE106_INST_EXPORT_24.zip'
+      - 'S4CORE106_INST_EXPORT_25.zip'
+      - 'S4CORE106_INST_EXPORT_26.zip'
+      - 'S4CORE106_INST_EXPORT_27.zip'
+      - 'S4CORE106_INST_EXPORT_28.zip'
+      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004822.SAR'
-      - 'S4CORE106_INST_EXPORT_1.zip'
-      - 'S4CORE106_INST_EXPORT_2.zip'
-      - 'S4CORE106_INST_EXPORT_3.zip'
-      - 'S4CORE106_INST_EXPORT_4.zip'
-      - 'S4CORE106_INST_EXPORT_5.zip'
-      - 'S4CORE106_INST_EXPORT_6.zip'
-      - 'S4CORE106_INST_EXPORT_7.zip'
-      - 'S4CORE106_INST_EXPORT_8.zip'
-      - 'S4CORE106_INST_EXPORT_9.zip'
-      - 'S4CORE106_INST_EXPORT_10.zip'
-      - 'S4CORE106_INST_EXPORT_11.zip'
-      - 'S4CORE106_INST_EXPORT_12.zip'
-      - 'S4CORE106_INST_EXPORT_13.zip'
-      - 'S4CORE106_INST_EXPORT_14.zip'
-      - 'S4CORE106_INST_EXPORT_15.zip'
-      - 'S4CORE106_INST_EXPORT_16.zip'
-      - 'S4CORE106_INST_EXPORT_17.zip'
-      - 'S4CORE106_INST_EXPORT_18.zip'
-      - 'S4CORE106_INST_EXPORT_19.zip'
-      - 'S4CORE106_INST_EXPORT_20.zip'
-      - 'S4CORE106_INST_EXPORT_21.zip'
-      - 'S4CORE106_INST_EXPORT_22.zip'
-      - 'S4CORE106_INST_EXPORT_23.zip'
-      - 'S4CORE106_INST_EXPORT_24.zip'
-      - 'S4CORE106_INST_EXPORT_25.zip'
-      - 'S4CORE106_INST_EXPORT_26.zip'
-      - 'S4CORE106_INST_EXPORT_27.zip'
-      - 'S4CORE106_INST_EXPORT_28.zip'
-      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004831.SAR'
-      - 'S4CORE106_INST_EXPORT_1.zip'
-      - 'S4CORE106_INST_EXPORT_2.zip'
-      - 'S4CORE106_INST_EXPORT_3.zip'
-      - 'S4CORE106_INST_EXPORT_4.zip'
-      - 'S4CORE106_INST_EXPORT_5.zip'
-      - 'S4CORE106_INST_EXPORT_6.zip'
-      - 'S4CORE106_INST_EXPORT_7.zip'
-      - 'S4CORE106_INST_EXPORT_8.zip'
-      - 'S4CORE106_INST_EXPORT_9.zip'
-      - 'S4CORE106_INST_EXPORT_10.zip'
-      - 'S4CORE106_INST_EXPORT_11.zip'
-      - 'S4CORE106_INST_EXPORT_12.zip'
-      - 'S4CORE106_INST_EXPORT_13.zip'
-      - 'S4CORE106_INST_EXPORT_14.zip'
-      - 'S4CORE106_INST_EXPORT_15.zip'
-      - 'S4CORE106_INST_EXPORT_16.zip'
-      - 'S4CORE106_INST_EXPORT_17.zip'
-      - 'S4CORE106_INST_EXPORT_18.zip'
-      - 'S4CORE106_INST_EXPORT_19.zip'
-      - 'S4CORE106_INST_EXPORT_20.zip'
-      - 'S4CORE106_INST_EXPORT_21.zip'
-      - 'S4CORE106_INST_EXPORT_22.zip'
-      - 'S4CORE106_INST_EXPORT_23.zip'
-      - 'S4CORE106_INST_EXPORT_24.zip'
-      - 'S4CORE106_INST_EXPORT_25.zip'
-      - 'S4CORE106_INST_EXPORT_26.zip'
-      - 'S4CORE106_INST_EXPORT_27.zip'
-      - 'S4CORE106_INST_EXPORT_28.zip'
-      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2021.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_ers_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ERS:S4HANA2021.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - credentials
-        - nw_config_other
-        - nw_config_ers
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ers'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2021.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2021.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2021.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
-
-        # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
-
-        # SAP Host Agent
         sap_swpm_install_saphostagent: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2020_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE105_INST_EXPORT_1.zip'
+      - 'S4CORE105_INST_EXPORT_2.zip'
+      - 'S4CORE105_INST_EXPORT_3.zip'
+      - 'S4CORE105_INST_EXPORT_4.zip'
+      - 'S4CORE105_INST_EXPORT_5.zip'
+      - 'S4CORE105_INST_EXPORT_6.zip'
+      - 'S4CORE105_INST_EXPORT_7.zip'
+      - 'S4CORE105_INST_EXPORT_8.zip'
+      - 'S4CORE105_INST_EXPORT_9.zip'
+      - 'S4CORE105_INST_EXPORT_10.zip'
+      - 'S4CORE105_INST_EXPORT_11.zip'
+      - 'S4CORE105_INST_EXPORT_12.zip'
+      - 'S4CORE105_INST_EXPORT_13.zip'
+      - 'S4CORE105_INST_EXPORT_14.zip'
+      - 'S4CORE105_INST_EXPORT_15.zip'
+      - 'S4CORE105_INST_EXPORT_16.zip'
+      - 'S4CORE105_INST_EXPORT_17.zip'
+      - 'S4CORE105_INST_EXPORT_18.zip'
+      - 'S4CORE105_INST_EXPORT_19.zip'
+      - 'S4CORE105_INST_EXPORT_20.zip'
+      - 'S4CORE105_INST_EXPORT_21.zip'
+      - 'S4CORE105_INST_EXPORT_22.zip'
+      - 'S4CORE105_INST_EXPORT_23.zip'
+      - 'S4CORE105_INST_EXPORT_24.zip'
+      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004822.SAR'
-      - 'S4CORE105_INST_EXPORT_1.zip'
-      - 'S4CORE105_INST_EXPORT_2.zip'
-      - 'S4CORE105_INST_EXPORT_3.zip'
-      - 'S4CORE105_INST_EXPORT_4.zip'
-      - 'S4CORE105_INST_EXPORT_5.zip'
-      - 'S4CORE105_INST_EXPORT_6.zip'
-      - 'S4CORE105_INST_EXPORT_7.zip'
-      - 'S4CORE105_INST_EXPORT_8.zip'
-      - 'S4CORE105_INST_EXPORT_9.zip'
-      - 'S4CORE105_INST_EXPORT_10.zip'
-      - 'S4CORE105_INST_EXPORT_11.zip'
-      - 'S4CORE105_INST_EXPORT_12.zip'
-      - 'S4CORE105_INST_EXPORT_13.zip'
-      - 'S4CORE105_INST_EXPORT_14.zip'
-      - 'S4CORE105_INST_EXPORT_15.zip'
-      - 'S4CORE105_INST_EXPORT_16.zip'
-      - 'S4CORE105_INST_EXPORT_17.zip'
-      - 'S4CORE105_INST_EXPORT_18.zip'
-      - 'S4CORE105_INST_EXPORT_19.zip'
-      - 'S4CORE105_INST_EXPORT_20.zip'
-      - 'S4CORE105_INST_EXPORT_21.zip'
-      - 'S4CORE105_INST_EXPORT_22.zip'
-      - 'S4CORE105_INST_EXPORT_23.zip'
-      - 'S4CORE105_INST_EXPORT_24.zip'
-      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004831.SAR'
-      - 'S4CORE105_INST_EXPORT_1.zip'
-      - 'S4CORE105_INST_EXPORT_2.zip'
-      - 'S4CORE105_INST_EXPORT_3.zip'
-      - 'S4CORE105_INST_EXPORT_4.zip'
-      - 'S4CORE105_INST_EXPORT_5.zip'
-      - 'S4CORE105_INST_EXPORT_6.zip'
-      - 'S4CORE105_INST_EXPORT_7.zip'
-      - 'S4CORE105_INST_EXPORT_8.zip'
-      - 'S4CORE105_INST_EXPORT_9.zip'
-      - 'S4CORE105_INST_EXPORT_10.zip'
-      - 'S4CORE105_INST_EXPORT_11.zip'
-      - 'S4CORE105_INST_EXPORT_12.zip'
-      - 'S4CORE105_INST_EXPORT_13.zip'
-      - 'S4CORE105_INST_EXPORT_14.zip'
-      - 'S4CORE105_INST_EXPORT_15.zip'
-      - 'S4CORE105_INST_EXPORT_16.zip'
-      - 'S4CORE105_INST_EXPORT_17.zip'
-      - 'S4CORE105_INST_EXPORT_18.zip'
-      - 'S4CORE105_INST_EXPORT_19.zip'
-      - 'S4CORE105_INST_EXPORT_20.zip'
-      - 'S4CORE105_INST_EXPORT_21.zip'
-      - 'S4CORE105_INST_EXPORT_22.zip'
-      - 'S4CORE105_INST_EXPORT_23.zip'
-      - 'S4CORE105_INST_EXPORT_24.zip'
-      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2020.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_ers_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ERS:S4HANA2020.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - credentials
-        - nw_config_other
-        - nw_config_ers
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ers'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2020.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2020.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2020.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
-
-        # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
-
-        # SAP Host Agent
         sap_swpm_install_saphostagent: true
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  ascs_pas:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
+
+  ers:
+    - swpm_installation_media
+    - credentials
+    - nw_config_other
+    - nw_config_ers
+    - sap_os_linux_user
+
+  aas:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_ports
+    - nw_config_other
+    - nw_config_additional_application_server_instance
+    - nw_config_host_agent
+    - sap_os_linux_user
+
+# Dictionary of lists for software filename wildcard patterns that is used during rsync operations.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_software_wildcards:
+  hana:
+    - 'SAPCAR*'
+    - 'IMDB_*'
+    - 'SAPHOSTAGENT*'
+
+  netweaver:
+    - 'SAPCAR*'
+    - 'IMDB_CLIENT*'
+    - 'SWPM20*'
+    - 'igsexe_*'
+    - 'igshelper_*'
+    - 'SAPEXE_*'
+    - 'SAPEXEDB_*'
+    - 'SUM*'
+    - 'SAPHOSTAGENT*'
+
+  dbload:
+    - 'SAPCAR*'
+    - 'IMDB_CLIENT*'
+    - 'SWPM20*'
+    - 'igsexe_*'
+    - 'igshelper_*'
+    - 'SAPEXE_*'
+    - 'SAPEXEDB_*'
+    - 'SUM*'
+    - 'SAPHOSTAGENT*'
+    - 'S4CORE*'
+    - 'S4HANAOP*'
+    - 'HANAUMML*'
+    - 'K-*'
+    - 'KD*'
+    - 'KE*'
+    - 'KIT*'
+    - 'SAPPAAPL*'
+    - 'SAP_BASIS*'

--- a/deploy_scenarios/sap_s4hana_distributed_ha/ansible_extravars_ibmpowervm_vm_base.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/ansible_extravars_ibmpowervm_vm_base.yml
@@ -13,5 +13,5 @@ sap_vm_provision_nfs_mount_point_opts: "ENTER_STRING_VALUE_HERE"  # NFS Mount op
 sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host: "ENTER_STRING_VALUE_HERE"
 sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_port: "ENTER_STRING_VALUE_HERE" # Default, 22 for SSH
 sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_login: "ENTER_STRING_VALUE_HERE"
-sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_login_password: "ENTER_STRING_VALUE_HERE"
+sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_login_password: ''
 sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_version: "4"

--- a/deploy_scenarios/sap_s4hana_distributed_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/ansible_playbook.yml
@@ -276,8 +276,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
@@ -285,7 +286,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['software_files_hana_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['sap_software_files_hana_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_hana_install_media_files
 
@@ -293,7 +294,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_ascs_ha']['software_files_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_ascs_ha']['sap_software_files_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_nwas_ascs_install_media_files
 
@@ -301,7 +302,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_ers_ha']['software_files_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_ers_ha']['sap_software_files_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_nwas_ers_install_media_files
 
@@ -309,7 +310,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_aas']['software_files_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_aas']['sap_software_files_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_nwas_aas_install_media_files
 

--- a/deploy_scenarios/sap_s4hana_distributed_ha/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/optional/ansible_extravars_interactive.yml
@@ -44,134 +44,92 @@ sap_software_install_dictionary:
 
   sap_s4hana_2025_distributed:
 
-    softwarecenter_search_list_x86_64:
-      # Database
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
       - 'SAPPAAPL4_2405_0-80004547.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
-      # Media
-      - 'S4HANAOP109_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_INST_EXPORT_2.zip'
-      - 'S4HANAOP109_INST_EXPORT_3.zip'
-      - 'S4HANAOP109_INST_EXPORT_4.zip'
-      - 'S4HANAOP109_INST_EXPORT_5.zip'
-      - 'S4HANAOP109_INST_EXPORT_6.zip'
-      - 'S4HANAOP109_INST_EXPORT_7.zip'
-      - 'S4HANAOP109_INST_EXPORT_8.zip'
-      - 'S4HANAOP109_INST_EXPORT_9.zip'
-      - 'S4HANAOP109_INST_EXPORT_10.zip'
-      - 'S4HANAOP109_INST_EXPORT_11.zip'
-      - 'S4HANAOP109_INST_EXPORT_12.zip'
-      - 'S4HANAOP109_INST_EXPORT_13.zip'
-      - 'S4HANAOP109_INST_EXPORT_14.zip'
-      - 'S4HANAOP109_INST_EXPORT_15.zip'
-      - 'S4HANAOP109_INST_EXPORT_16.zip'
-      - 'S4HANAOP109_INST_EXPORT_17.zip'
-      - 'S4HANAOP109_INST_EXPORT_18.zip'
-      - 'S4HANAOP109_INST_EXPORT_19.zip'
-      - 'S4HANAOP109_INST_EXPORT_20.zip'
-      - 'S4HANAOP109_INST_EXPORT_21.zip'
-      - 'S4HANAOP109_INST_EXPORT_22.zip'
-      - 'S4HANAOP109_INST_EXPORT_23.zip'
-      - 'S4HANAOP109_INST_EXPORT_24.zip'
-      - 'S4HANAOP109_INST_EXPORT_25.zip'
-      - 'S4HANAOP109_INST_EXPORT_26.zip'
-      - 'S4HANAOP109_INST_EXPORT_27.zip'
-      - 'S4HANAOP109_INST_EXPORT_28.zip'
-      - 'S4HANAOP109_INST_EXPORT_29.zip'
-      - 'S4HANAOP109_INST_EXPORT_30.zip'
-      - 'S4HANAOP109_INST_EXPORT_31.zip'
-      - 'S4HANAOP109_INST_EXPORT_32.zip'
-      - 'S4HANAOP109_INST_EXPORT_33.zip'
-      - 'S4HANAOP109_INST_EXPORT_34.zip'
-      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_ERP_LANG_EN.SAR'
       - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007716.EXE'
       - 'SWPM20SP23_2-80003424.SAR'
       # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
-      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
-      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
       - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
-      # Media
-      - 'S4HANAOP109_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_INST_EXPORT_2.zip'
-      - 'S4HANAOP109_INST_EXPORT_3.zip'
-      - 'S4HANAOP109_INST_EXPORT_4.zip'
-      - 'S4HANAOP109_INST_EXPORT_5.zip'
-      - 'S4HANAOP109_INST_EXPORT_6.zip'
-      - 'S4HANAOP109_INST_EXPORT_7.zip'
-      - 'S4HANAOP109_INST_EXPORT_8.zip'
-      - 'S4HANAOP109_INST_EXPORT_9.zip'
-      - 'S4HANAOP109_INST_EXPORT_10.zip'
-      - 'S4HANAOP109_INST_EXPORT_11.zip'
-      - 'S4HANAOP109_INST_EXPORT_12.zip'
-      - 'S4HANAOP109_INST_EXPORT_13.zip'
-      - 'S4HANAOP109_INST_EXPORT_14.zip'
-      - 'S4HANAOP109_INST_EXPORT_15.zip'
-      - 'S4HANAOP109_INST_EXPORT_16.zip'
-      - 'S4HANAOP109_INST_EXPORT_17.zip'
-      - 'S4HANAOP109_INST_EXPORT_18.zip'
-      - 'S4HANAOP109_INST_EXPORT_19.zip'
-      - 'S4HANAOP109_INST_EXPORT_20.zip'
-      - 'S4HANAOP109_INST_EXPORT_21.zip'
-      - 'S4HANAOP109_INST_EXPORT_22.zip'
-      - 'S4HANAOP109_INST_EXPORT_23.zip'
-      - 'S4HANAOP109_INST_EXPORT_24.zip'
-      - 'S4HANAOP109_INST_EXPORT_25.zip'
-      - 'S4HANAOP109_INST_EXPORT_26.zip'
-      - 'S4HANAOP109_INST_EXPORT_27.zip'
-      - 'S4HANAOP109_INST_EXPORT_28.zip'
-      - 'S4HANAOP109_INST_EXPORT_29.zip'
-      - 'S4HANAOP109_INST_EXPORT_30.zip'
-      - 'S4HANAOP109_INST_EXPORT_31.zip'
-      - 'S4HANAOP109_INST_EXPORT_32.zip'
-      - 'S4HANAOP109_INST_EXPORT_33.zip'
-      - 'S4HANAOP109_INST_EXPORT_34.zip'
-      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_ERP_LANG_EN.SAR'
       - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007726.EXE'
       - 'SWPM20SP23_2-80003426.SAR'
-      # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
-      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
-      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    # This list assigned from shared dictionary, because it is same with other products or host types.
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs_ha:
 
@@ -179,140 +137,60 @@ sap_software_install_dictionary:
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2025.CORE.HDB.ABAPHA
 
       # List of INI file sections to generate using sap_install.sap_swpm role (List).
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_ers_ha:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ERS:S4HANA2025.CORE.HDB.ABAPHA
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - credentials
-        - nw_config_other
-        - nw_config_ers
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ers'] }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload_ha:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2025.CORE.HDB.ABAPHA
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2025.CORE.HDB.ABAP
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2025.CORE.HDB.PD
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
 
       sap_swpm_inifile_dictionary:
 
@@ -323,30 +201,16 @@ sap_software_install_dictionary:
         # SAP Host Agent
         sap_swpm_install_saphostagent: true
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2023_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
-      # Database
-      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
-      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
-      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
-      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
-      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
-      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
-      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+    sap_software_list_independent:
+      # Application Media
       - 'S4CORE108_INST_EXPORT_1.zip'
       - 'S4CORE108_INST_EXPORT_2.zip'
       - 'S4CORE108_INST_EXPORT_3.zip'
@@ -379,987 +243,451 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
-      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Application Server
       - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
+      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
+      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
+      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+      - 'igsexe_4-70005417.sar' # IGS 7.81
       # Tools
       - 'SAPCAR_1300-70007716.EXE'
       - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
       - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
-      - 'S4CORE108_INST_EXPORT_1.zip'
-      - 'S4CORE108_INST_EXPORT_2.zip'
-      - 'S4CORE108_INST_EXPORT_3.zip'
-      - 'S4CORE108_INST_EXPORT_4.zip'
-      - 'S4CORE108_INST_EXPORT_5.zip'
-      - 'S4CORE108_INST_EXPORT_6.zip'
-      - 'S4CORE108_INST_EXPORT_7.zip'
-      - 'S4CORE108_INST_EXPORT_8.zip'
-      - 'S4CORE108_INST_EXPORT_9.zip'
-      - 'S4CORE108_INST_EXPORT_10.zip'
-      - 'S4CORE108_INST_EXPORT_11.zip'
-      - 'S4CORE108_INST_EXPORT_12.zip'
-      - 'S4CORE108_INST_EXPORT_13.zip'
-      - 'S4CORE108_INST_EXPORT_14.zip'
-      - 'S4CORE108_INST_EXPORT_15.zip'
-      - 'S4CORE108_INST_EXPORT_16.zip'
-      - 'S4CORE108_INST_EXPORT_17.zip'
-      - 'S4CORE108_INST_EXPORT_18.zip'
-      - 'S4CORE108_INST_EXPORT_19.zip'
-      - 'S4CORE108_INST_EXPORT_20.zip'
-      - 'S4CORE108_INST_EXPORT_21.zip'
-      - 'S4CORE108_INST_EXPORT_22.zip'
-      - 'S4CORE108_INST_EXPORT_23.zip'
-      - 'S4CORE108_INST_EXPORT_24.zip'
-      - 'S4CORE108_INST_EXPORT_25.zip'
-      - 'S4CORE108_INST_EXPORT_26.zip'
-      - 'S4CORE108_INST_EXPORT_27.zip'
-      - 'S4CORE108_INST_EXPORT_28.zip'
-      - 'S4CORE108_INST_EXPORT_29.zip'
-      - 'S4CORE108_INST_EXPORT_30.zip'
-      - 'S4HANAOP108_ERP_LANG_EN.SAR'
-      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
       - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
       # Tools
       - 'SAPCAR_1300-70007726.EXE'
       - 'SWPM20SP20_1-80003426.SAR'
       # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs_ha:
-
-      # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2023.CORE.HDB.ABAPHA
-
-      # List of INI file sections to generate using sap_install.sap_swpm role (List).
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_ers_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ERS:S4HANA2023.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - credentials
-        - nw_config_other
-        - nw_config_ers
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ers'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2023.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2023.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2023.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
-
-        # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
-
-        # SAP Host Agent
         sap_swpm_install_saphostagent: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2022_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE107_INST_EXPORT_1.zip'
+      - 'S4CORE107_INST_EXPORT_2.zip'
+      - 'S4CORE107_INST_EXPORT_3.zip'
+      - 'S4CORE107_INST_EXPORT_4.zip'
+      - 'S4CORE107_INST_EXPORT_5.zip'
+      - 'S4CORE107_INST_EXPORT_6.zip'
+      - 'S4CORE107_INST_EXPORT_7.zip'
+      - 'S4CORE107_INST_EXPORT_8.zip'
+      - 'S4CORE107_INST_EXPORT_9.zip'
+      - 'S4CORE107_INST_EXPORT_10.zip'
+      - 'S4CORE107_INST_EXPORT_11.zip'
+      - 'S4CORE107_INST_EXPORT_12.zip'
+      - 'S4CORE107_INST_EXPORT_13.zip'
+      - 'S4CORE107_INST_EXPORT_14.zip'
+      - 'S4CORE107_INST_EXPORT_15.zip'
+      - 'S4CORE107_INST_EXPORT_16.zip'
+      - 'S4CORE107_INST_EXPORT_17.zip'
+      - 'S4CORE107_INST_EXPORT_18.zip'
+      - 'S4CORE107_INST_EXPORT_19.zip'
+      - 'S4CORE107_INST_EXPORT_20.zip'
+      - 'S4CORE107_INST_EXPORT_21.zip'
+      - 'S4CORE107_INST_EXPORT_22.zip'
+      - 'S4CORE107_INST_EXPORT_23.zip'
+      - 'S4CORE107_INST_EXPORT_24.zip'
+      - 'S4CORE107_INST_EXPORT_25.zip'
+      - 'S4CORE107_INST_EXPORT_26.zip'
+      - 'S4CORE107_INST_EXPORT_27.zip'
+      - 'S4CORE107_INST_EXPORT_28.zip'
+      - 'S4CORE107_INST_EXPORT_29.zip'
+      - 'S4CORE107_INST_EXPORT_30.zip'
+      - 'S4HANAOP107_ERP_LANG_EN.SAR'
+      # - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
+      # - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_51-70006642.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006641.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
-      - 'S4CORE107_INST_EXPORT_1.zip'
-      - 'S4CORE107_INST_EXPORT_2.zip'
-      - 'S4CORE107_INST_EXPORT_3.zip'
-      - 'S4CORE107_INST_EXPORT_4.zip'
-      - 'S4CORE107_INST_EXPORT_5.zip'
-      - 'S4CORE107_INST_EXPORT_6.zip'
-      - 'S4CORE107_INST_EXPORT_7.zip'
-      - 'S4CORE107_INST_EXPORT_8.zip'
-      - 'S4CORE107_INST_EXPORT_9.zip'
-      - 'S4CORE107_INST_EXPORT_10.zip'
-      - 'S4CORE107_INST_EXPORT_11.zip'
-      - 'S4CORE107_INST_EXPORT_12.zip'
-      - 'S4CORE107_INST_EXPORT_13.zip'
-      - 'S4CORE107_INST_EXPORT_14.zip'
-      - 'S4CORE107_INST_EXPORT_15.zip'
-      - 'S4CORE107_INST_EXPORT_16.zip'
-      - 'S4CORE107_INST_EXPORT_17.zip'
-      - 'S4CORE107_INST_EXPORT_18.zip'
-      - 'S4CORE107_INST_EXPORT_19.zip'
-      - 'S4CORE107_INST_EXPORT_20.zip'
-      - 'S4CORE107_INST_EXPORT_21.zip'
-      - 'S4CORE107_INST_EXPORT_22.zip'
-      - 'S4CORE107_INST_EXPORT_23.zip'
-      - 'S4CORE107_INST_EXPORT_24.zip'
-      - 'S4CORE107_INST_EXPORT_25.zip'
-      - 'S4CORE107_INST_EXPORT_26.zip'
-      - 'S4CORE107_INST_EXPORT_27.zip'
-      - 'S4CORE107_INST_EXPORT_28.zip'
-      - 'S4CORE107_INST_EXPORT_29.zip'
-      - 'S4CORE107_INST_EXPORT_30.zip'
-      - 'S4HANAOP107_ERP_LANG_EN.SAR'
-    #  - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
-    #  - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
-    #  - 'SAPPAAPL4_2203_2-80004547.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
-    #  - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # - 'SAPPAAPL4_2203_2-80004547.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
+      # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_51-70006667.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006666.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
-      - 'S4CORE107_INST_EXPORT_1.zip'
-      - 'S4CORE107_INST_EXPORT_2.zip'
-      - 'S4CORE107_INST_EXPORT_3.zip'
-      - 'S4CORE107_INST_EXPORT_4.zip'
-      - 'S4CORE107_INST_EXPORT_5.zip'
-      - 'S4CORE107_INST_EXPORT_6.zip'
-      - 'S4CORE107_INST_EXPORT_7.zip'
-      - 'S4CORE107_INST_EXPORT_8.zip'
-      - 'S4CORE107_INST_EXPORT_9.zip'
-      - 'S4CORE107_INST_EXPORT_10.zip'
-      - 'S4CORE107_INST_EXPORT_11.zip'
-      - 'S4CORE107_INST_EXPORT_12.zip'
-      - 'S4CORE107_INST_EXPORT_13.zip'
-      - 'S4CORE107_INST_EXPORT_14.zip'
-      - 'S4CORE107_INST_EXPORT_15.zip'
-      - 'S4CORE107_INST_EXPORT_16.zip'
-      - 'S4CORE107_INST_EXPORT_17.zip'
-      - 'S4CORE107_INST_EXPORT_18.zip'
-      - 'S4CORE107_INST_EXPORT_19.zip'
-      - 'S4CORE107_INST_EXPORT_20.zip'
-      - 'S4CORE107_INST_EXPORT_21.zip'
-      - 'S4CORE107_INST_EXPORT_22.zip'
-      - 'S4CORE107_INST_EXPORT_23.zip'
-      - 'S4CORE107_INST_EXPORT_24.zip'
-      - 'S4CORE107_INST_EXPORT_25.zip'
-      - 'S4CORE107_INST_EXPORT_26.zip'
-      - 'S4CORE107_INST_EXPORT_27.zip'
-      - 'S4CORE107_INST_EXPORT_28.zip'
-      - 'S4CORE107_INST_EXPORT_29.zip'
-      - 'S4CORE107_INST_EXPORT_30.zip'
-      - 'S4HANAOP107_ERP_LANG_EN.SAR'
-    #  - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
-    #  - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
-    #  - 'SAPPAAPL4_2203_2-80004546.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
-    #  - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # - 'SAPPAAPL4_2203_2-80004546.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
+      # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2022.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_ers_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ERS:S4HANA2022.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - credentials
-        - nw_config_other
-        - nw_config_ers
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ers'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2022.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2022.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2022.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
-
-        # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
-
-        # SAP Host Agent
         sap_swpm_install_saphostagent: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2021_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE106_INST_EXPORT_1.zip'
+      - 'S4CORE106_INST_EXPORT_2.zip'
+      - 'S4CORE106_INST_EXPORT_3.zip'
+      - 'S4CORE106_INST_EXPORT_4.zip'
+      - 'S4CORE106_INST_EXPORT_5.zip'
+      - 'S4CORE106_INST_EXPORT_6.zip'
+      - 'S4CORE106_INST_EXPORT_7.zip'
+      - 'S4CORE106_INST_EXPORT_8.zip'
+      - 'S4CORE106_INST_EXPORT_9.zip'
+      - 'S4CORE106_INST_EXPORT_10.zip'
+      - 'S4CORE106_INST_EXPORT_11.zip'
+      - 'S4CORE106_INST_EXPORT_12.zip'
+      - 'S4CORE106_INST_EXPORT_13.zip'
+      - 'S4CORE106_INST_EXPORT_14.zip'
+      - 'S4CORE106_INST_EXPORT_15.zip'
+      - 'S4CORE106_INST_EXPORT_16.zip'
+      - 'S4CORE106_INST_EXPORT_17.zip'
+      - 'S4CORE106_INST_EXPORT_18.zip'
+      - 'S4CORE106_INST_EXPORT_19.zip'
+      - 'S4CORE106_INST_EXPORT_20.zip'
+      - 'S4CORE106_INST_EXPORT_21.zip'
+      - 'S4CORE106_INST_EXPORT_22.zip'
+      - 'S4CORE106_INST_EXPORT_23.zip'
+      - 'S4CORE106_INST_EXPORT_24.zip'
+      - 'S4CORE106_INST_EXPORT_25.zip'
+      - 'S4CORE106_INST_EXPORT_26.zip'
+      - 'S4CORE106_INST_EXPORT_27.zip'
+      - 'S4CORE106_INST_EXPORT_28.zip'
+      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004822.SAR'
-      - 'S4CORE106_INST_EXPORT_1.zip'
-      - 'S4CORE106_INST_EXPORT_2.zip'
-      - 'S4CORE106_INST_EXPORT_3.zip'
-      - 'S4CORE106_INST_EXPORT_4.zip'
-      - 'S4CORE106_INST_EXPORT_5.zip'
-      - 'S4CORE106_INST_EXPORT_6.zip'
-      - 'S4CORE106_INST_EXPORT_7.zip'
-      - 'S4CORE106_INST_EXPORT_8.zip'
-      - 'S4CORE106_INST_EXPORT_9.zip'
-      - 'S4CORE106_INST_EXPORT_10.zip'
-      - 'S4CORE106_INST_EXPORT_11.zip'
-      - 'S4CORE106_INST_EXPORT_12.zip'
-      - 'S4CORE106_INST_EXPORT_13.zip'
-      - 'S4CORE106_INST_EXPORT_14.zip'
-      - 'S4CORE106_INST_EXPORT_15.zip'
-      - 'S4CORE106_INST_EXPORT_16.zip'
-      - 'S4CORE106_INST_EXPORT_17.zip'
-      - 'S4CORE106_INST_EXPORT_18.zip'
-      - 'S4CORE106_INST_EXPORT_19.zip'
-      - 'S4CORE106_INST_EXPORT_20.zip'
-      - 'S4CORE106_INST_EXPORT_21.zip'
-      - 'S4CORE106_INST_EXPORT_22.zip'
-      - 'S4CORE106_INST_EXPORT_23.zip'
-      - 'S4CORE106_INST_EXPORT_24.zip'
-      - 'S4CORE106_INST_EXPORT_25.zip'
-      - 'S4CORE106_INST_EXPORT_26.zip'
-      - 'S4CORE106_INST_EXPORT_27.zip'
-      - 'S4CORE106_INST_EXPORT_28.zip'
-      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004831.SAR'
-      - 'S4CORE106_INST_EXPORT_1.zip'
-      - 'S4CORE106_INST_EXPORT_2.zip'
-      - 'S4CORE106_INST_EXPORT_3.zip'
-      - 'S4CORE106_INST_EXPORT_4.zip'
-      - 'S4CORE106_INST_EXPORT_5.zip'
-      - 'S4CORE106_INST_EXPORT_6.zip'
-      - 'S4CORE106_INST_EXPORT_7.zip'
-      - 'S4CORE106_INST_EXPORT_8.zip'
-      - 'S4CORE106_INST_EXPORT_9.zip'
-      - 'S4CORE106_INST_EXPORT_10.zip'
-      - 'S4CORE106_INST_EXPORT_11.zip'
-      - 'S4CORE106_INST_EXPORT_12.zip'
-      - 'S4CORE106_INST_EXPORT_13.zip'
-      - 'S4CORE106_INST_EXPORT_14.zip'
-      - 'S4CORE106_INST_EXPORT_15.zip'
-      - 'S4CORE106_INST_EXPORT_16.zip'
-      - 'S4CORE106_INST_EXPORT_17.zip'
-      - 'S4CORE106_INST_EXPORT_18.zip'
-      - 'S4CORE106_INST_EXPORT_19.zip'
-      - 'S4CORE106_INST_EXPORT_20.zip'
-      - 'S4CORE106_INST_EXPORT_21.zip'
-      - 'S4CORE106_INST_EXPORT_22.zip'
-      - 'S4CORE106_INST_EXPORT_23.zip'
-      - 'S4CORE106_INST_EXPORT_24.zip'
-      - 'S4CORE106_INST_EXPORT_25.zip'
-      - 'S4CORE106_INST_EXPORT_26.zip'
-      - 'S4CORE106_INST_EXPORT_27.zip'
-      - 'S4CORE106_INST_EXPORT_28.zip'
-      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2021.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_ers_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ERS:S4HANA2021.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - credentials
-        - nw_config_other
-        - nw_config_ers
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ers'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2021.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2021.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2021.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
-
-        # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
-
-        # SAP Host Agent
         sap_swpm_install_saphostagent: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2020_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE105_INST_EXPORT_1.zip'
+      - 'S4CORE105_INST_EXPORT_2.zip'
+      - 'S4CORE105_INST_EXPORT_3.zip'
+      - 'S4CORE105_INST_EXPORT_4.zip'
+      - 'S4CORE105_INST_EXPORT_5.zip'
+      - 'S4CORE105_INST_EXPORT_6.zip'
+      - 'S4CORE105_INST_EXPORT_7.zip'
+      - 'S4CORE105_INST_EXPORT_8.zip'
+      - 'S4CORE105_INST_EXPORT_9.zip'
+      - 'S4CORE105_INST_EXPORT_10.zip'
+      - 'S4CORE105_INST_EXPORT_11.zip'
+      - 'S4CORE105_INST_EXPORT_12.zip'
+      - 'S4CORE105_INST_EXPORT_13.zip'
+      - 'S4CORE105_INST_EXPORT_14.zip'
+      - 'S4CORE105_INST_EXPORT_15.zip'
+      - 'S4CORE105_INST_EXPORT_16.zip'
+      - 'S4CORE105_INST_EXPORT_17.zip'
+      - 'S4CORE105_INST_EXPORT_18.zip'
+      - 'S4CORE105_INST_EXPORT_19.zip'
+      - 'S4CORE105_INST_EXPORT_20.zip'
+      - 'S4CORE105_INST_EXPORT_21.zip'
+      - 'S4CORE105_INST_EXPORT_22.zip'
+      - 'S4CORE105_INST_EXPORT_23.zip'
+      - 'S4CORE105_INST_EXPORT_24.zip'
+      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004822.SAR'
-      - 'S4CORE105_INST_EXPORT_1.zip'
-      - 'S4CORE105_INST_EXPORT_2.zip'
-      - 'S4CORE105_INST_EXPORT_3.zip'
-      - 'S4CORE105_INST_EXPORT_4.zip'
-      - 'S4CORE105_INST_EXPORT_5.zip'
-      - 'S4CORE105_INST_EXPORT_6.zip'
-      - 'S4CORE105_INST_EXPORT_7.zip'
-      - 'S4CORE105_INST_EXPORT_8.zip'
-      - 'S4CORE105_INST_EXPORT_9.zip'
-      - 'S4CORE105_INST_EXPORT_10.zip'
-      - 'S4CORE105_INST_EXPORT_11.zip'
-      - 'S4CORE105_INST_EXPORT_12.zip'
-      - 'S4CORE105_INST_EXPORT_13.zip'
-      - 'S4CORE105_INST_EXPORT_14.zip'
-      - 'S4CORE105_INST_EXPORT_15.zip'
-      - 'S4CORE105_INST_EXPORT_16.zip'
-      - 'S4CORE105_INST_EXPORT_17.zip'
-      - 'S4CORE105_INST_EXPORT_18.zip'
-      - 'S4CORE105_INST_EXPORT_19.zip'
-      - 'S4CORE105_INST_EXPORT_20.zip'
-      - 'S4CORE105_INST_EXPORT_21.zip'
-      - 'S4CORE105_INST_EXPORT_22.zip'
-      - 'S4CORE105_INST_EXPORT_23.zip'
-      - 'S4CORE105_INST_EXPORT_24.zip'
-      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004831.SAR'
-      - 'S4CORE105_INST_EXPORT_1.zip'
-      - 'S4CORE105_INST_EXPORT_2.zip'
-      - 'S4CORE105_INST_EXPORT_3.zip'
-      - 'S4CORE105_INST_EXPORT_4.zip'
-      - 'S4CORE105_INST_EXPORT_5.zip'
-      - 'S4CORE105_INST_EXPORT_6.zip'
-      - 'S4CORE105_INST_EXPORT_7.zip'
-      - 'S4CORE105_INST_EXPORT_8.zip'
-      - 'S4CORE105_INST_EXPORT_9.zip'
-      - 'S4CORE105_INST_EXPORT_10.zip'
-      - 'S4CORE105_INST_EXPORT_11.zip'
-      - 'S4CORE105_INST_EXPORT_12.zip'
-      - 'S4CORE105_INST_EXPORT_13.zip'
-      - 'S4CORE105_INST_EXPORT_14.zip'
-      - 'S4CORE105_INST_EXPORT_15.zip'
-      - 'S4CORE105_INST_EXPORT_16.zip'
-      - 'S4CORE105_INST_EXPORT_17.zip'
-      - 'S4CORE105_INST_EXPORT_18.zip'
-      - 'S4CORE105_INST_EXPORT_19.zip'
-      - 'S4CORE105_INST_EXPORT_20.zip'
-      - 'S4CORE105_INST_EXPORT_21.zip'
-      - 'S4CORE105_INST_EXPORT_22.zip'
-      - 'S4CORE105_INST_EXPORT_23.zip'
-      - 'S4CORE105_INST_EXPORT_24.zip'
-      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2020.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_ers_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ERS:S4HANA2020.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - credentials
-        - nw_config_other
-        - nw_config_ers
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ers'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2020.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2020.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2020.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
-
-        # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
-
-        # SAP Host Agent
         sap_swpm_install_saphostagent: true
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  ascs_pas:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
+
+  ers:
+    - swpm_installation_media
+    - credentials
+    - nw_config_other
+    - nw_config_ers
+    - sap_os_linux_user
+
+  aas:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_ports
+    - nw_config_other
+    - nw_config_additional_application_server_instance
+    - nw_config_host_agent
+    - sap_os_linux_user
+
+# Dictionary of lists for software filename wildcard patterns that is used during rsync operations.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_software_wildcards:
+  hana:
+    - 'SAPCAR*'
+    - 'IMDB_*'
+    - 'SAPHOSTAGENT*'
+
+  netweaver:
+    - 'SAPCAR*'
+    - 'IMDB_CLIENT*'
+    - 'SWPM20*'
+    - 'igsexe_*'
+    - 'igshelper_*'
+    - 'SAPEXE_*'
+    - 'SAPEXEDB_*'
+    - 'SUM*'
+    - 'SAPHOSTAGENT*'
+
+  dbload:
+    - 'SAPCAR*'
+    - 'IMDB_CLIENT*'
+    - 'SWPM20*'
+    - 'igsexe_*'
+    - 'igshelper_*'
+    - 'SAPEXE_*'
+    - 'SAPEXEDB_*'
+    - 'SUM*'
+    - 'SAPHOSTAGENT*'
+    - 'S4CORE*'
+    - 'S4HANAOP*'
+    - 'HANAUMML*'
+    - 'K-*'
+    - 'KD*'
+    - 'KE*'
+    - 'KIT*'
+    - 'SAPPAAPL*'
+    - 'SAP_BASIS*'
 
 
 #### Interactive Prompt Control Variables ####

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_extravars.yml
@@ -32,7 +32,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -182,17 +182,21 @@ sap_software_install_dictionary:
 
   sap_s4hana_2025_distributed:
 
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
+    sap_software_list_x86_64:
       - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
       - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    # This list assigned from shared dictionary, because it is same with other products or host types.
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs_ha:
 
@@ -200,25 +204,10 @@ sap_software_install_dictionary:
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2025.CORE.HDB.ABAPHA
 
       # List of INI file sections to generate using sap_install.sap_swpm role (List).
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
 
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -227,32 +216,20 @@ sap_software_install_dictionary:
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_ers_ha:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ERS:S4HANA2025.CORE.HDB.ABAPHA
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - credentials
-        - nw_config_other
-        - nw_config_ers
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ers'] }}"
 
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -261,42 +238,20 @@ sap_software_install_dictionary:
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload_ha:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2025.CORE.HDB.ABAPHA
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
 
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -305,51 +260,20 @@ sap_software_install_dictionary:
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
-        - 'MP_*.xml'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2025.CORE.HDB.ABAP
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
 
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -358,93 +282,48 @@ sap_software_install_dictionary:
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2025.CORE.HDB.PD
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
 
       sap_swpm_inifile_dictionary:
-
         # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2023_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
+
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs_ha:
-
-      # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2023.CORE.HDB.ABAPHA
-
-      # List of INI file sections to generate using sap_install.sap_swpm role (List).
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -452,33 +331,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_ers_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ERS:S4HANA2023.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - credentials
-        - nw_config_other
-        - nw_config_ers
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ers'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -486,43 +344,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2023.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -530,52 +357,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2023.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -583,93 +370,37 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2023.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
-
         # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2022_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
+
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2022.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -677,33 +408,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_ers_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ERS:S4HANA2022.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - credentials
-        - nw_config_other
-        - nw_config_ers
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ers'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -711,43 +421,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2022.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -755,52 +434,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2022.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -808,93 +447,37 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2022.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
-
         # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2021_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
+
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2021.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -902,33 +485,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_ers_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ERS:S4HANA2021.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - credentials
-        - nw_config_other
-        - nw_config_ers
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ers'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -936,43 +498,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2021.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -980,52 +511,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2021.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -1033,39 +524,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2021.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
-
         # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
@@ -1074,14 +538,88 @@ sap_software_install_dictionary:
         # When passing the SAP Maintenance Planner Stack XML file to SAP SWPM sapinst,
         # the Product Catalog ID suffix .PD is rejected by SAP SWPM 2.0 with "no component with this ID was found in product catalog"
         # sap_swpm_mp_stack_path: ''
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  ascs_pas:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
+    - maintenance_plan_stack_tms_config
+    - maintenance_plan_stack_spam_config
+    - maintenance_plan_stack_sum_config
+
+  ers:
+    - swpm_installation_media
+    - credentials
+    - nw_config_other
+    - nw_config_ers
+    - sap_os_linux_user
+
+  aas:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_ports
+    - nw_config_other
+    - nw_config_additional_application_server_instance
+    - nw_config_host_agent
+    - sap_os_linux_user
+
+# Dictionary of lists for software filename wildcard patterns that is used during rsync operations.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_software_wildcards:
+  hana:
+    - 'SAPCAR*'
+    - 'IMDB_*'
+    - 'SAPHOSTAGENT*'
+
+  netweaver:
+    - 'SAPCAR*'
+    - 'IMDB_CLIENT*'
+    - 'SWPM20*'
+    - 'igsexe_*'
+    - 'igshelper_*'
+    - 'SAPEXE_*'
+    - 'SAPEXEDB_*'
+    - 'SUM*'
+    - 'SAPHOSTAGENT*'
+    - 'MP_*.xml'
+
+  dbload:
+    - 'SAPCAR*'
+    - 'IMDB_CLIENT*'
+    - 'SWPM20*'
+    - 'igsexe_*'
+    - 'igshelper_*'
+    - 'SAPEXE_*'
+    - 'SAPEXEDB_*'
+    - 'SUM*'
+    - 'SAPHOSTAGENT*'
+    - 'S4CORE*'
+    - 'S4HANAOP*'
+    - 'HANAUMML*'
+    - 'K-*'
+    - 'KD*'
+    - 'KE*'
+    - 'KIT*'
+    - 'SAPPAAPL*'
+    - 'SAP_BASIS*'
+    - 'MP_*.xml'

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_extravars_ibmpowervm_vm_base.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_extravars_ibmpowervm_vm_base.yml
@@ -13,5 +13,5 @@ sap_vm_provision_nfs_mount_point_opts: "ENTER_STRING_VALUE_HERE"  # NFS Mount op
 sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host: "ENTER_STRING_VALUE_HERE"
 sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_port: "ENTER_STRING_VALUE_HERE" # Default, 22 for SSH
 sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_login: "ENTER_STRING_VALUE_HERE"
-sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_login_password: "ENTER_STRING_VALUE_HERE"
+sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_login_password: ''
 sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_version: "4"

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_playbook.yml
@@ -276,8 +276,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
         sap_software_download_mp_transaction: "{{ sap_maintenance_planner_transaction_name }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
@@ -286,7 +287,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['software_files_hana_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['sap_software_files_hana_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_hana_install_media_files
 
@@ -294,7 +295,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_ascs_ha']['software_files_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_ascs_ha']['sap_software_files_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_nwas_ascs_install_media_files
 
@@ -302,7 +303,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_ers_ha']['software_files_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_ers_ha']['sap_software_files_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_nwas_ers_install_media_files
 
@@ -310,7 +311,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_aas']['software_files_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_aas']['sap_software_files_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_nwas_aas_install_media_files
 

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/optional/ansible_extravars_interactive.yml
@@ -50,17 +50,21 @@ sap_software_install_dictionary:
 
   sap_s4hana_2025_distributed:
 
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
+    sap_software_list_x86_64:
       - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
       - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    # This list assigned from shared dictionary, because it is same with other products or host types.
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs_ha:
 
@@ -68,25 +72,10 @@ sap_software_install_dictionary:
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2025.CORE.HDB.ABAPHA
 
       # List of INI file sections to generate using sap_install.sap_swpm role (List).
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
 
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -95,32 +84,20 @@ sap_software_install_dictionary:
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_ers_ha:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ERS:S4HANA2025.CORE.HDB.ABAPHA
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - credentials
-        - nw_config_other
-        - nw_config_ers
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ers'] }}"
 
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -129,42 +106,20 @@ sap_software_install_dictionary:
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload_ha:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2025.CORE.HDB.ABAPHA
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
 
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -173,51 +128,20 @@ sap_software_install_dictionary:
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
-        - 'MP_*.xml'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2025.CORE.HDB.ABAP
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
 
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -226,93 +150,48 @@ sap_software_install_dictionary:
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2025.CORE.HDB.PD
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
 
       sap_swpm_inifile_dictionary:
-
         # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2023_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
+
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs_ha:
-
-      # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2023.CORE.HDB.ABAPHA
-
-      # List of INI file sections to generate using sap_install.sap_swpm role (List).
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -320,33 +199,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_ers_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ERS:S4HANA2023.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - credentials
-        - nw_config_other
-        - nw_config_ers
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ers'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -354,43 +212,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2023.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -398,52 +225,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2023.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -451,93 +238,37 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2023.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
-
         # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2022_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
+
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2022.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -545,33 +276,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_ers_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ERS:S4HANA2022.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - credentials
-        - nw_config_other
-        - nw_config_ers
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ers'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -579,43 +289,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2022.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -623,52 +302,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2022.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -676,93 +315,37 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2022.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
-
         # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2021_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
+
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2021.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -770,33 +353,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_ers_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ERS:S4HANA2021.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - credentials
-        - nw_config_other
-        - nw_config_ers
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ers'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -804,43 +366,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2021.CORE.HDB.ABAPHA
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -848,52 +379,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2021.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -901,39 +392,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas_ha:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2021.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
-
         # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
@@ -942,17 +406,91 @@ sap_software_install_dictionary:
         # When passing the SAP Maintenance Planner Stack XML file to SAP SWPM sapinst,
         # the Product Catalog ID suffix .PD is rejected by SAP SWPM 2.0 with "no component with this ID was found in product catalog"
         # sap_swpm_mp_stack_path: ''
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  ascs_pas:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
+    - maintenance_plan_stack_tms_config
+    - maintenance_plan_stack_spam_config
+    - maintenance_plan_stack_sum_config
+
+  ers:
+    - swpm_installation_media
+    - credentials
+    - nw_config_other
+    - nw_config_ers
+    - sap_os_linux_user
+
+  aas:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_ports
+    - nw_config_other
+    - nw_config_additional_application_server_instance
+    - nw_config_host_agent
+    - sap_os_linux_user
+
+# Dictionary of lists for software filename wildcard patterns that is used during rsync operations.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_software_wildcards:
+  hana:
+    - 'SAPCAR*'
+    - 'IMDB_*'
+    - 'SAPHOSTAGENT*'
+
+  netweaver:
+    - 'SAPCAR*'
+    - 'IMDB_CLIENT*'
+    - 'SWPM20*'
+    - 'igsexe_*'
+    - 'igshelper_*'
+    - 'SAPEXE_*'
+    - 'SAPEXEDB_*'
+    - 'SUM*'
+    - 'SAPHOSTAGENT*'
+    - 'MP_*.xml'
+
+  dbload:
+    - 'SAPCAR*'
+    - 'IMDB_CLIENT*'
+    - 'SWPM20*'
+    - 'igsexe_*'
+    - 'igshelper_*'
+    - 'SAPEXE_*'
+    - 'SAPEXEDB_*'
+    - 'SUM*'
+    - 'SAPHOSTAGENT*'
+    - 'S4CORE*'
+    - 'S4HANAOP*'
+    - 'HANAUMML*'
+    - 'K-*'
+    - 'KD*'
+    - 'KE*'
+    - 'KIT*'
+    - 'SAPPAAPL*'
+    - 'SAP_BASIS*'
+    - 'MP_*.xml'
 
 
 #### Interactive Prompt Control Variables ####

--- a/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_extravars.yml
@@ -31,7 +31,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -137,37 +137,30 @@ sap_software_install_dictionary:
 
   sap_s4hana_2025_distributed:
 
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
+    sap_software_list_x86_64:
       - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
       - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    # This list assigned from shared dictionary, because it is same with other products or host types.
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs:
 
-        # SWPM product catalog ID for the installation (String).
+      # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2025.CORE.HDB.ABAP
 
-        # List of INI file sections to generate using sap_install.sap_swpm role (List).
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
 
       sap_swpm_inifile_dictionary:
 
@@ -179,35 +172,18 @@ sap_software_install_dictionary:
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2025.CORE.HDB.ABAP
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
 
       sap_swpm_inifile_dictionary:
 
@@ -219,44 +195,18 @@ sap_software_install_dictionary:
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2025.CORE.HDB.ABAP
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
 
       sap_swpm_inifile_dictionary:
 
@@ -268,34 +218,18 @@ sap_software_install_dictionary:
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2025.CORE.HDB.PD
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
 
       sap_swpm_inifile_dictionary:
 
@@ -303,54 +237,30 @@ sap_software_install_dictionary:
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2023_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
+
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs:
-
-        # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2023.CORE.HDB.ABAP
-
-        # List of INI file sections to generate using sap_install.sap_swpm role (List).
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -358,39 +268,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2023.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -398,48 +281,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2023.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -447,92 +294,37 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2023.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
-
         # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2022_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
+
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2022.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -540,43 +332,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2022.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -584,52 +345,13 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
 
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2022.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -637,93 +359,38 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2022.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
 
         # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2021_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
+
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2021.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -731,43 +398,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2021.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -775,52 +411,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2021.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -828,40 +424,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2021.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
-
         # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
@@ -870,14 +438,81 @@ sap_software_install_dictionary:
         # When passing the SAP Maintenance Planner Stack XML file to SAP SWPM sapinst,
         # the Product Catalog ID suffix .PD is rejected by SAP SWPM 2.0 with "no component with this ID was found in product catalog"
         # sap_swpm_mp_stack_path: ''
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  ascs_pas:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
+    - maintenance_plan_stack_tms_config
+    - maintenance_plan_stack_spam_config
+    - maintenance_plan_stack_sum_config
+
+  aas:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_ports
+    - nw_config_other
+    - nw_config_additional_application_server_instance
+    - nw_config_host_agent
+    - sap_os_linux_user
+
+# Dictionary of lists for software filename wildcard patterns that is used during rsync operations.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_software_wildcards:
+  hana:
+    - 'SAPCAR*'
+    - 'IMDB_*'
+    - 'SAPHOSTAGENT*'
+
+  netweaver:
+    - 'SAPCAR*'
+    - 'IMDB_CLIENT*'
+    - 'SWPM20*'
+    - 'igsexe_*'
+    - 'igshelper_*'
+    - 'SAPEXE_*'
+    - 'SAPEXEDB_*'
+    - 'SUM*'
+    - 'SAPHOSTAGENT*'
+    - 'MP_*.xml'
+
+  dbload:
+    - 'SAPCAR*'
+    - 'IMDB_CLIENT*'
+    - 'SWPM20*'
+    - 'igsexe_*'
+    - 'igshelper_*'
+    - 'SAPEXE_*'
+    - 'SAPEXEDB_*'
+    - 'SUM*'
+    - 'SAPHOSTAGENT*'
+    - 'S4CORE*'
+    - 'S4HANAOP*'
+    - 'HANAUMML*'
+    - 'K-*'
+    - 'KD*'
+    - 'KE*'
+    - 'KIT*'
+    - 'SAPPAAPL*'
+    - 'SAP_BASIS*'
+    - 'MP_*.xml'

--- a/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_playbook.yml
@@ -270,8 +270,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
         sap_software_download_mp_transaction: "{{ sap_maintenance_planner_transaction_name }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
@@ -280,7 +281,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['software_files_hana_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['sap_software_files_hana_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_hana_install_media_files
 
@@ -288,7 +289,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_ascs']['software_files_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_ascs']['sap_software_files_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_nwas_ascs_install_media_files
 
@@ -296,7 +297,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_aas']['software_files_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_aas']['sap_software_files_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_nwas_aas_install_media_files
 

--- a/deploy_scenarios/sap_s4hana_distributed_maintplan/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_maintplan/optional/ansible_extravars_interactive.yml
@@ -46,37 +46,30 @@ sap_software_install_dictionary:
 
   sap_s4hana_2025_distributed:
 
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
+    sap_software_list_x86_64:
       - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
       - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    # This list assigned from shared dictionary, because it is same with other products or host types.
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs:
 
-        # SWPM product catalog ID for the installation (String).
+      # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2025.CORE.HDB.ABAP
 
-        # List of INI file sections to generate using sap_install.sap_swpm role (List).
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
 
       sap_swpm_inifile_dictionary:
 
@@ -88,35 +81,18 @@ sap_software_install_dictionary:
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2025.CORE.HDB.ABAP
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
 
       sap_swpm_inifile_dictionary:
 
@@ -128,44 +104,18 @@ sap_software_install_dictionary:
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2025.CORE.HDB.ABAP
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
 
       sap_swpm_inifile_dictionary:
 
@@ -177,34 +127,18 @@ sap_software_install_dictionary:
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2025.CORE.HDB.PD
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
 
       sap_swpm_inifile_dictionary:
 
@@ -212,54 +146,30 @@ sap_software_install_dictionary:
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*'
-        - 'SAPEXEDB_*'
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      # List of file name patterns relevant to host type.
+      # This list assigned from shared dictionary, because it is same with other products or host types.
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2023_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
+
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs:
-
-        # SWPM product catalog ID for the installation (String).
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2023.CORE.HDB.ABAP
-
-        # List of INI file sections to generate using sap_install.sap_swpm role (List).
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -267,39 +177,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2023.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -307,48 +190,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2023.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -356,92 +203,37 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2023.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
-
         # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2022_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
+
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2022.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -449,43 +241,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2022.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -493,52 +254,13 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
 
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2022.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -546,93 +268,38 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2022.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
 
         # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
 
   sap_s4hana_2021_distributed:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
+
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     nwas_ascs:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2021.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -640,43 +307,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_pas_dbload:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_DB:S4HANA2021.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -684,52 +320,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'S4CORE*'
-        - 'S4HANAOP*'
-        - 'HANAUMML*'
-        - 'K-*'
-        - 'KD*'
-        - 'KE*'
-        - 'KIT*'
-        - 'SAPPAAPL*'
-        - 'SAP_BASIS*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['dbload'] }}"
 
     nwas_pas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ABAP_CI:S4HANA2021.CORE.HDB.ABAP
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_primary_application_server_instance
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
-        - maintenance_plan_stack_tms_config
-        - maintenance_plan_stack_spam_config
-        - maintenance_plan_stack_sum_config
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
       sap_swpm_inifile_dictionary:
-
         # SAP SWPM using SAP Maintenance Planner Stack XML
         # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
         sap_swpm_configure_tms: true
@@ -737,40 +333,12 @@ sap_software_install_dictionary:
         sap_swpm_spam_update: false
         sap_swpm_sum_prepare: true
         sap_swpm_sum_start: true
-
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
-        - 'MP_*.xml'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
     nwas_aas:
-
-      # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_DI:S4HANA2021.CORE.HDB.PD
-
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana
-        - db_config_hana
-        - db_connection_nw_hana
-        - nw_config_ports
-        - nw_config_other
-        - nw_config_additional_application_server_instance
-        - nw_config_host_agent
-        - sap_os_linux_user
-
-
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['aas'] }}"
       sap_swpm_inifile_dictionary:
-
         # Product ID suffix is not .ABAP, therefore set variables manually for sap_swpm Ansible Role to populate inifile.params
         sap_swpm_db_schema: "{{ sap_swpm_db_schema_abap }}"
         sap_swpm_db_schema_password: "{{ sap_swpm_db_schema_abap_password }}"
@@ -779,17 +347,84 @@ sap_software_install_dictionary:
         # When passing the SAP Maintenance Planner Stack XML file to SAP SWPM sapinst,
         # the Product Catalog ID suffix .PD is rejected by SAP SWPM 2.0 with "no component with this ID was found in product catalog"
         # sap_swpm_mp_stack_path: ''
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
 
-      software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'IMDB_CLIENT*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SUM*'
-        - 'SAPHOSTAGENT*'
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  ascs_pas:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
+    - maintenance_plan_stack_tms_config
+    - maintenance_plan_stack_spam_config
+    - maintenance_plan_stack_sum_config
+
+  aas:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_ports
+    - nw_config_other
+    - nw_config_additional_application_server_instance
+    - nw_config_host_agent
+    - sap_os_linux_user
+
+# Dictionary of lists for software filename wildcard patterns that is used during rsync operations.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_software_wildcards:
+  hana:
+    - 'SAPCAR*'
+    - 'IMDB_*'
+    - 'SAPHOSTAGENT*'
+
+  netweaver:
+    - 'SAPCAR*'
+    - 'IMDB_CLIENT*'
+    - 'SWPM20*'
+    - 'igsexe_*'
+    - 'igshelper_*'
+    - 'SAPEXE_*'
+    - 'SAPEXEDB_*'
+    - 'SUM*'
+    - 'SAPHOSTAGENT*'
+    - 'MP_*.xml'
+
+  dbload:
+    - 'SAPCAR*'
+    - 'IMDB_CLIENT*'
+    - 'SWPM20*'
+    - 'igsexe_*'
+    - 'igshelper_*'
+    - 'SAPEXE_*'
+    - 'SAPEXEDB_*'
+    - 'SUM*'
+    - 'SAPHOSTAGENT*'
+    - 'S4CORE*'
+    - 'S4HANAOP*'
+    - 'HANAUMML*'
+    - 'K-*'
+    - 'KD*'
+    - 'KE*'
+    - 'KIT*'
+    - 'SAPPAAPL*'
+    - 'SAP_BASIS*'
+    - 'MP_*.xml'
 
 
 #### Interactive Prompt Control Variables ####

--- a/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_extravars.yml
@@ -30,7 +30,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -130,120 +130,75 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.FNDN.HDB.ABAP
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      # Database
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Media
+      - 'S4FND109_INST_EXPORT_1.zip'
+      - 'S4FND109_INST_EXPORT_2.zip'
+      - 'S4FND109_INST_EXPORT_3.zip'
+      - 'S4FND109_INST_EXPORT_4.zip'
+      - 'S4FND109_INST_EXPORT_5.zip'
+      - 'S4FND109_INST_EXPORT_6.zip'
+      - 'S4FND109_INST_EXPORT_7.zip'
+      - 'S4FND109_INST_EXPORT_8.zip'
+      - 'S4FND109_INST_EXPORT_9.zip'
+      - 'S4FND109_INST_EXPORT_10.zip'
+      - 'S4FND109_NW_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
-      # Media
-      - 'S4FND109_INST_EXPORT_1.zip'
-      - 'S4FND109_INST_EXPORT_2.zip'
-      - 'S4FND109_INST_EXPORT_3.zip'
-      - 'S4FND109_INST_EXPORT_4.zip'
-      - 'S4FND109_INST_EXPORT_5.zip'
-      - 'S4FND109_INST_EXPORT_6.zip'
-      - 'S4FND109_INST_EXPORT_7.zip'
-      - 'S4FND109_INST_EXPORT_8.zip'
-      - 'S4FND109_INST_EXPORT_9.zip'
-      - 'S4FND109_INST_EXPORT_10.zip'
-      - 'S4FND109_NW_LANG_EN.SAR'
       - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007716.EXE'
       - 'SWPM20SP23_2-80003424.SAR'
       # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
-      - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
-      # Media
-      - 'S4FND109_INST_EXPORT_1.zip'
-      - 'S4FND109_INST_EXPORT_2.zip'
-      - 'S4FND109_INST_EXPORT_3.zip'
-      - 'S4FND109_INST_EXPORT_4.zip'
-      - 'S4FND109_INST_EXPORT_5.zip'
-      - 'S4FND109_INST_EXPORT_6.zip'
-      - 'S4FND109_INST_EXPORT_7.zip'
-      - 'S4FND109_INST_EXPORT_8.zip'
-      - 'S4FND109_INST_EXPORT_9.zip'
-      - 'S4FND109_INST_EXPORT_10.zip'
-      - 'S4FND109_NW_LANG_EN.SAR'
       - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007726.EXE'
       - 'SWPM20SP23_2-80003426.SAR'
       # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
 
 
   sap_s4hana_fndn_2023_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2023.FNDN.HDB.ABAP
 
-    # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      # Database
-      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
-      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
-      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
-      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
-      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
-      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
-      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+    sap_software_list_independent:
+      # Application Media
       - 'S4FND108_INST_EXPORT_1.zip'
       - 'S4FND108_INST_EXPORT_2.zip'
       - 'S4FND108_INST_EXPORT_3.zip'
@@ -254,37 +209,37 @@ sap_software_install_dictionary:
       - 'S4FND108_INST_EXPORT_8.zip'
       - 'S4FND108_INST_EXPORT_9.zip'
       - 'S4FND108_NW_LANG_EN.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Application Server
       - 'igshelper_17-10010245.sar'
-      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
+      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
+
+    sap_software_list_x86_64:
+      # Database Server
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
+      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
+      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
+      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+      - 'igsexe_4-70005417.sar' # IGS 7.81
       # Tools
       - 'SAPCAR_1300-70007716.EXE'
       - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
       - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
-      - 'S4FND108_INST_EXPORT_1.zip'
-      - 'S4FND108_INST_EXPORT_2.zip'
-      - 'S4FND108_INST_EXPORT_3.zip'
-      - 'S4FND108_INST_EXPORT_4.zip'
-      - 'S4FND108_INST_EXPORT_5.zip'
-      - 'S4FND108_INST_EXPORT_6.zip'
-      - 'S4FND108_INST_EXPORT_7.zip'
-      - 'S4FND108_INST_EXPORT_8.zip'
-      - 'S4FND108_INST_EXPORT_9.zip'
-      - 'S4FND108_NW_LANG_EN.SAR'
       - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
-      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
       # Tools
       - 'SAPCAR_1300-70007726.EXE'
       - 'SWPM20SP20_1-80003426.SAR'
@@ -292,130 +247,125 @@ sap_software_install_dictionary:
 
 
   sap_s4hana_fndn_2022_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2022.FNDN.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4FND107_INST_EXPORT_1.zip'
+      - 'S4FND107_INST_EXPORT_2.zip'
+      - 'S4FND107_INST_EXPORT_3.zip'
+      - 'S4FND107_INST_EXPORT_4.zip'
+      - 'S4FND107_INST_EXPORT_5.zip'
+      - 'S4FND107_INST_EXPORT_6.zip'
+      - 'S4FND107_INST_EXPORT_7.zip'
+      - 'S4FND107_INST_EXPORT_8.zip'
+      - 'S4FND107_INST_EXPORT_9.zip'
+      # - 'S4FND107_NW_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
       - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_51-70006642.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006641.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
-      - 'S4FND107_INST_EXPORT_1.zip'
-      - 'S4FND107_INST_EXPORT_2.zip'
-      - 'S4FND107_INST_EXPORT_3.zip'
-      - 'S4FND107_INST_EXPORT_4.zip'
-      - 'S4FND107_INST_EXPORT_5.zip'
-      - 'S4FND107_INST_EXPORT_6.zip'
-      - 'S4FND107_INST_EXPORT_7.zip'
-      - 'S4FND107_INST_EXPORT_8.zip'
-      - 'S4FND107_INST_EXPORT_9.zip'
-      # - 'S4FND107_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
       - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_51-70006667.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006666.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
-      - 'S4FND107_INST_EXPORT_1.zip'
-      - 'S4FND107_INST_EXPORT_2.zip'
-      - 'S4FND107_INST_EXPORT_3.zip'
-      - 'S4FND107_INST_EXPORT_4.zip'
-      - 'S4FND107_INST_EXPORT_5.zip'
-      - 'S4FND107_INST_EXPORT_6.zip'
-      - 'S4FND107_INST_EXPORT_7.zip'
-      - 'S4FND107_INST_EXPORT_8.zip'
-      - 'S4FND107_INST_EXPORT_9.zip'
-      # - 'S4FND107_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
 
   sap_s4hana_fndn_2021_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2021.FNDN.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4FND106_INST_EXPORT_1.zip'
+      - 'S4FND106_INST_EXPORT_2.zip'
+      - 'S4FND106_INST_EXPORT_3.zip'
+      - 'S4FND106_INST_EXPORT_4.zip'
+      - 'S4FND106_INST_EXPORT_5.zip'
+      - 'S4FND106_INST_EXPORT_6.zip'
+      - 'S4FND106_INST_EXPORT_7.zip'
+      - 'S4FND106_INST_EXPORT_8.zip'
+      # - 'S4FND106_NW_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
       - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004822.SAR'
-      - 'S4FND106_INST_EXPORT_1.zip'
-      - 'S4FND106_INST_EXPORT_2.zip'
-      - 'S4FND106_INST_EXPORT_3.zip'
-      - 'S4FND106_INST_EXPORT_4.zip'
-      - 'S4FND106_INST_EXPORT_5.zip'
-      - 'S4FND106_INST_EXPORT_6.zip'
-      - 'S4FND106_INST_EXPORT_7.zip'
-      - 'S4FND106_INST_EXPORT_8.zip'
-      # - 'S4FND106_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
       - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004831.SAR'
-      - 'S4FND106_INST_EXPORT_1.zip'
-      - 'S4FND106_INST_EXPORT_2.zip'
-      - 'S4FND106_INST_EXPORT_3.zip'
-      - 'S4FND106_INST_EXPORT_4.zip'
-      - 'S4FND106_INST_EXPORT_5.zip'
-      - 'S4FND106_INST_EXPORT_6.zip'
-      - 'S4FND106_INST_EXPORT_7.zip'
-      - 'S4FND106_INST_EXPORT_8.zip'
-      # - 'S4FND106_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  sandbox:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user

--- a/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_playbook.yml
@@ -255,8 +255,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 

--- a/deploy_scenarios/sap_s4hana_foundation_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_sandbox/optional/ansible_extravars_interactive.yml
@@ -38,120 +38,75 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.FNDN.HDB.ABAP
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      # Database
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Media
+      - 'S4FND109_INST_EXPORT_1.zip'
+      - 'S4FND109_INST_EXPORT_2.zip'
+      - 'S4FND109_INST_EXPORT_3.zip'
+      - 'S4FND109_INST_EXPORT_4.zip'
+      - 'S4FND109_INST_EXPORT_5.zip'
+      - 'S4FND109_INST_EXPORT_6.zip'
+      - 'S4FND109_INST_EXPORT_7.zip'
+      - 'S4FND109_INST_EXPORT_8.zip'
+      - 'S4FND109_INST_EXPORT_9.zip'
+      - 'S4FND109_INST_EXPORT_10.zip'
+      - 'S4FND109_NW_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
-      # Media
-      - 'S4FND109_INST_EXPORT_1.zip'
-      - 'S4FND109_INST_EXPORT_2.zip'
-      - 'S4FND109_INST_EXPORT_3.zip'
-      - 'S4FND109_INST_EXPORT_4.zip'
-      - 'S4FND109_INST_EXPORT_5.zip'
-      - 'S4FND109_INST_EXPORT_6.zip'
-      - 'S4FND109_INST_EXPORT_7.zip'
-      - 'S4FND109_INST_EXPORT_8.zip'
-      - 'S4FND109_INST_EXPORT_9.zip'
-      - 'S4FND109_INST_EXPORT_10.zip'
-      - 'S4FND109_NW_LANG_EN.SAR'
       - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007716.EXE'
       - 'SWPM20SP23_2-80003424.SAR'
       # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
-      - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
-      # Media
-      - 'S4FND109_INST_EXPORT_1.zip'
-      - 'S4FND109_INST_EXPORT_2.zip'
-      - 'S4FND109_INST_EXPORT_3.zip'
-      - 'S4FND109_INST_EXPORT_4.zip'
-      - 'S4FND109_INST_EXPORT_5.zip'
-      - 'S4FND109_INST_EXPORT_6.zip'
-      - 'S4FND109_INST_EXPORT_7.zip'
-      - 'S4FND109_INST_EXPORT_8.zip'
-      - 'S4FND109_INST_EXPORT_9.zip'
-      - 'S4FND109_INST_EXPORT_10.zip'
-      - 'S4FND109_NW_LANG_EN.SAR'
       - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007726.EXE'
       - 'SWPM20SP23_2-80003426.SAR'
       # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
 
 
   sap_s4hana_fndn_2023_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2023.FNDN.HDB.ABAP
 
-    # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      # Database
-      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
-      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
-      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
-      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
-      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
-      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
-      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+    sap_software_list_independent:
+      # Application Media
       - 'S4FND108_INST_EXPORT_1.zip'
       - 'S4FND108_INST_EXPORT_2.zip'
       - 'S4FND108_INST_EXPORT_3.zip'
@@ -162,37 +117,37 @@ sap_software_install_dictionary:
       - 'S4FND108_INST_EXPORT_8.zip'
       - 'S4FND108_INST_EXPORT_9.zip'
       - 'S4FND108_NW_LANG_EN.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Application Server
       - 'igshelper_17-10010245.sar'
-      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
+      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
+
+    sap_software_list_x86_64:
+      # Database Server
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
+      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
+      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
+      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+      - 'igsexe_4-70005417.sar' # IGS 7.81
       # Tools
       - 'SAPCAR_1300-70007716.EXE'
       - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
       - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
-      - 'S4FND108_INST_EXPORT_1.zip'
-      - 'S4FND108_INST_EXPORT_2.zip'
-      - 'S4FND108_INST_EXPORT_3.zip'
-      - 'S4FND108_INST_EXPORT_4.zip'
-      - 'S4FND108_INST_EXPORT_5.zip'
-      - 'S4FND108_INST_EXPORT_6.zip'
-      - 'S4FND108_INST_EXPORT_7.zip'
-      - 'S4FND108_INST_EXPORT_8.zip'
-      - 'S4FND108_INST_EXPORT_9.zip'
-      - 'S4FND108_NW_LANG_EN.SAR'
       - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
-      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
       # Tools
       - 'SAPCAR_1300-70007726.EXE'
       - 'SWPM20SP20_1-80003426.SAR'
@@ -200,133 +155,128 @@ sap_software_install_dictionary:
 
 
   sap_s4hana_fndn_2022_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2022.FNDN.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4FND107_INST_EXPORT_1.zip'
+      - 'S4FND107_INST_EXPORT_2.zip'
+      - 'S4FND107_INST_EXPORT_3.zip'
+      - 'S4FND107_INST_EXPORT_4.zip'
+      - 'S4FND107_INST_EXPORT_5.zip'
+      - 'S4FND107_INST_EXPORT_6.zip'
+      - 'S4FND107_INST_EXPORT_7.zip'
+      - 'S4FND107_INST_EXPORT_8.zip'
+      - 'S4FND107_INST_EXPORT_9.zip'
+      # - 'S4FND107_NW_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
       - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_51-70006642.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006641.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
-      - 'S4FND107_INST_EXPORT_1.zip'
-      - 'S4FND107_INST_EXPORT_2.zip'
-      - 'S4FND107_INST_EXPORT_3.zip'
-      - 'S4FND107_INST_EXPORT_4.zip'
-      - 'S4FND107_INST_EXPORT_5.zip'
-      - 'S4FND107_INST_EXPORT_6.zip'
-      - 'S4FND107_INST_EXPORT_7.zip'
-      - 'S4FND107_INST_EXPORT_8.zip'
-      - 'S4FND107_INST_EXPORT_9.zip'
-      # - 'S4FND107_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
       - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_51-70006667.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006666.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
-      - 'S4FND107_INST_EXPORT_1.zip'
-      - 'S4FND107_INST_EXPORT_2.zip'
-      - 'S4FND107_INST_EXPORT_3.zip'
-      - 'S4FND107_INST_EXPORT_4.zip'
-      - 'S4FND107_INST_EXPORT_5.zip'
-      - 'S4FND107_INST_EXPORT_6.zip'
-      - 'S4FND107_INST_EXPORT_7.zip'
-      - 'S4FND107_INST_EXPORT_8.zip'
-      - 'S4FND107_INST_EXPORT_9.zip'
-      # - 'S4FND107_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
 
   sap_s4hana_fndn_2021_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2021.FNDN.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4FND106_INST_EXPORT_1.zip'
+      - 'S4FND106_INST_EXPORT_2.zip'
+      - 'S4FND106_INST_EXPORT_3.zip'
+      - 'S4FND106_INST_EXPORT_4.zip'
+      - 'S4FND106_INST_EXPORT_5.zip'
+      - 'S4FND106_INST_EXPORT_6.zip'
+      - 'S4FND106_INST_EXPORT_7.zip'
+      - 'S4FND106_INST_EXPORT_8.zip'
+      # - 'S4FND106_NW_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
       - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004822.SAR'
-      - 'S4FND106_INST_EXPORT_1.zip'
-      - 'S4FND106_INST_EXPORT_2.zip'
-      - 'S4FND106_INST_EXPORT_3.zip'
-      - 'S4FND106_INST_EXPORT_4.zip'
-      - 'S4FND106_INST_EXPORT_5.zip'
-      - 'S4FND106_INST_EXPORT_6.zip'
-      - 'S4FND106_INST_EXPORT_7.zip'
-      - 'S4FND106_INST_EXPORT_8.zip'
-      # - 'S4FND106_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
       - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004831.SAR'
-      - 'S4FND106_INST_EXPORT_1.zip'
-      - 'S4FND106_INST_EXPORT_2.zip'
-      - 'S4FND106_INST_EXPORT_3.zip'
-      - 'S4FND106_INST_EXPORT_4.zip'
-      - 'S4FND106_INST_EXPORT_5.zip'
-      - 'S4FND106_INST_EXPORT_6.zip'
-      - 'S4FND106_INST_EXPORT_7.zip'
-      - 'S4FND106_INST_EXPORT_8.zip'
-      # - 'S4FND106_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  sandbox:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
 
 
 #### Interactive Prompt Control Variables ####

--- a/deploy_scenarios/sap_s4hana_foundation_standard/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_standard/ansible_extravars.yml
@@ -30,7 +30,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -133,125 +133,78 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.FNDN.HDB.ABAP
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
-    softwarecenter_search_list_x86_64:
-      # Database
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Media
+      - 'S4FND109_INST_EXPORT_1.zip'
+      - 'S4FND109_INST_EXPORT_2.zip'
+      - 'S4FND109_INST_EXPORT_3.zip'
+      - 'S4FND109_INST_EXPORT_4.zip'
+      - 'S4FND109_INST_EXPORT_5.zip'
+      - 'S4FND109_INST_EXPORT_6.zip'
+      - 'S4FND109_INST_EXPORT_7.zip'
+      - 'S4FND109_INST_EXPORT_8.zip'
+      - 'S4FND109_INST_EXPORT_9.zip'
+      - 'S4FND109_INST_EXPORT_10.zip'
+      - 'S4FND109_NW_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
-      # Media
-      - 'S4FND109_INST_EXPORT_1.zip'
-      - 'S4FND109_INST_EXPORT_2.zip'
-      - 'S4FND109_INST_EXPORT_3.zip'
-      - 'S4FND109_INST_EXPORT_4.zip'
-      - 'S4FND109_INST_EXPORT_5.zip'
-      - 'S4FND109_INST_EXPORT_6.zip'
-      - 'S4FND109_INST_EXPORT_7.zip'
-      - 'S4FND109_INST_EXPORT_8.zip'
-      - 'S4FND109_INST_EXPORT_9.zip'
-      - 'S4FND109_INST_EXPORT_10.zip'
-      - 'S4FND109_NW_LANG_EN.SAR'
       - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007716.EXE'
       - 'SWPM20SP23_2-80003424.SAR'
       # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
-      - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
-      # Media
-      - 'S4FND109_INST_EXPORT_1.zip'
-      - 'S4FND109_INST_EXPORT_2.zip'
-      - 'S4FND109_INST_EXPORT_3.zip'
-      - 'S4FND109_INST_EXPORT_4.zip'
-      - 'S4FND109_INST_EXPORT_5.zip'
-      - 'S4FND109_INST_EXPORT_6.zip'
-      - 'S4FND109_INST_EXPORT_7.zip'
-      - 'S4FND109_INST_EXPORT_8.zip'
-      - 'S4FND109_INST_EXPORT_9.zip'
-      - 'S4FND109_INST_EXPORT_10.zip'
-      - 'S4FND109_NW_LANG_EN.SAR'
       - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007726.EXE'
       - 'SWPM20SP23_2-80003426.SAR'
       # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    # This list assigned from shared dictionary, because it is same with other products or host types.
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
 
   sap_s4hana_fndn_2023_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2023.FNDN.HDB.ABAP
 
-    # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
-    softwarecenter_search_list_x86_64:
-      # Database
-      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
-      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
-      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
-      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
-      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
-      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
-      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+    sap_software_list_independent:
+      # Application Media
       - 'S4FND108_INST_EXPORT_1.zip'
       - 'S4FND108_INST_EXPORT_2.zip'
       - 'S4FND108_INST_EXPORT_3.zip'
@@ -262,183 +215,177 @@ sap_software_install_dictionary:
       - 'S4FND108_INST_EXPORT_8.zip'
       - 'S4FND108_INST_EXPORT_9.zip'
       - 'S4FND108_NW_LANG_EN.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Application Server
       - 'igshelper_17-10010245.sar'
-      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
+      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
+
+    sap_software_list_x86_64:
+      # Database Server
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
+      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
+      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
+      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+      - 'igsexe_4-70005417.sar' # IGS 7.81
       # Tools
       - 'SAPCAR_1300-70007716.EXE'
       - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
       - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
-      - 'S4FND108_INST_EXPORT_1.zip'
-      - 'S4FND108_INST_EXPORT_2.zip'
-      - 'S4FND108_INST_EXPORT_3.zip'
-      - 'S4FND108_INST_EXPORT_4.zip'
-      - 'S4FND108_INST_EXPORT_5.zip'
-      - 'S4FND108_INST_EXPORT_6.zip'
-      - 'S4FND108_INST_EXPORT_7.zip'
-      - 'S4FND108_INST_EXPORT_8.zip'
-      - 'S4FND108_INST_EXPORT_9.zip'
-      - 'S4FND108_NW_LANG_EN.SAR'
       - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
-      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
       # Tools
       - 'SAPCAR_1300-70007726.EXE'
       - 'SWPM20SP20_1-80003426.SAR'
       # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
 
   sap_s4hana_fndn_2022_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2022.FNDN.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4FND107_INST_EXPORT_1.zip'
+      - 'S4FND107_INST_EXPORT_2.zip'
+      - 'S4FND107_INST_EXPORT_3.zip'
+      - 'S4FND107_INST_EXPORT_4.zip'
+      - 'S4FND107_INST_EXPORT_5.zip'
+      - 'S4FND107_INST_EXPORT_6.zip'
+      - 'S4FND107_INST_EXPORT_7.zip'
+      - 'S4FND107_INST_EXPORT_8.zip'
+      - 'S4FND107_INST_EXPORT_9.zip'
+      # - 'S4FND107_NW_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
       - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_51-70006642.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006641.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
-      - 'S4FND107_INST_EXPORT_1.zip'
-      - 'S4FND107_INST_EXPORT_2.zip'
-      - 'S4FND107_INST_EXPORT_3.zip'
-      - 'S4FND107_INST_EXPORT_4.zip'
-      - 'S4FND107_INST_EXPORT_5.zip'
-      - 'S4FND107_INST_EXPORT_6.zip'
-      - 'S4FND107_INST_EXPORT_7.zip'
-      - 'S4FND107_INST_EXPORT_8.zip'
-      - 'S4FND107_INST_EXPORT_9.zip'
-      # - 'S4FND107_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
       - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_51-70006667.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006666.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
-      - 'S4FND107_INST_EXPORT_1.zip'
-      - 'S4FND107_INST_EXPORT_2.zip'
-      - 'S4FND107_INST_EXPORT_3.zip'
-      - 'S4FND107_INST_EXPORT_4.zip'
-      - 'S4FND107_INST_EXPORT_5.zip'
-      - 'S4FND107_INST_EXPORT_6.zip'
-      - 'S4FND107_INST_EXPORT_7.zip'
-      - 'S4FND107_INST_EXPORT_8.zip'
-      - 'S4FND107_INST_EXPORT_9.zip'
-      # - 'S4FND107_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
 
   sap_s4hana_fndn_2021_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2021.FNDN.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4FND106_INST_EXPORT_1.zip'
+      - 'S4FND106_INST_EXPORT_2.zip'
+      - 'S4FND106_INST_EXPORT_3.zip'
+      - 'S4FND106_INST_EXPORT_4.zip'
+      - 'S4FND106_INST_EXPORT_5.zip'
+      - 'S4FND106_INST_EXPORT_6.zip'
+      - 'S4FND106_INST_EXPORT_7.zip'
+      - 'S4FND106_INST_EXPORT_8.zip'
+      # - 'S4FND106_NW_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
       - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004822.SAR'
-      - 'S4FND106_INST_EXPORT_1.zip'
-      - 'S4FND106_INST_EXPORT_2.zip'
-      - 'S4FND106_INST_EXPORT_3.zip'
-      - 'S4FND106_INST_EXPORT_4.zip'
-      - 'S4FND106_INST_EXPORT_5.zip'
-      - 'S4FND106_INST_EXPORT_6.zip'
-      - 'S4FND106_INST_EXPORT_7.zip'
-      - 'S4FND106_INST_EXPORT_8.zip'
-      # - 'S4FND106_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
       - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004831.SAR'
-      - 'S4FND106_INST_EXPORT_1.zip'
-      - 'S4FND106_INST_EXPORT_2.zip'
-      - 'S4FND106_INST_EXPORT_3.zip'
-      - 'S4FND106_INST_EXPORT_4.zip'
-      - 'S4FND106_INST_EXPORT_5.zip'
-      - 'S4FND106_INST_EXPORT_6.zip'
-      - 'S4FND106_INST_EXPORT_7.zip'
-      - 'S4FND106_INST_EXPORT_8.zip'
-      # - 'S4FND106_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  standard:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
+
+# Dictionary of lists for software filename wildcard patterns that is used during rsync operations.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_software_wildcards:
+  hana:
+    - 'SAPCAR*'
+    - 'IMDB_*'
+    - 'SAPHOSTAGENT*'

--- a/deploy_scenarios/sap_s4hana_foundation_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_standard/ansible_playbook.yml
@@ -270,8 +270,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
@@ -279,7 +280,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['software_files_hana_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['sap_software_files_hana_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_hana_install_media_files
 

--- a/deploy_scenarios/sap_s4hana_foundation_standard/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_standard/optional/ansible_extravars_interactive.yml
@@ -41,125 +41,78 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.FNDN.HDB.ABAP
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
-    softwarecenter_search_list_x86_64:
-      # Database
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Media
+      - 'S4FND109_INST_EXPORT_1.zip'
+      - 'S4FND109_INST_EXPORT_2.zip'
+      - 'S4FND109_INST_EXPORT_3.zip'
+      - 'S4FND109_INST_EXPORT_4.zip'
+      - 'S4FND109_INST_EXPORT_5.zip'
+      - 'S4FND109_INST_EXPORT_6.zip'
+      - 'S4FND109_INST_EXPORT_7.zip'
+      - 'S4FND109_INST_EXPORT_8.zip'
+      - 'S4FND109_INST_EXPORT_9.zip'
+      - 'S4FND109_INST_EXPORT_10.zip'
+      - 'S4FND109_NW_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
-      # Media
-      - 'S4FND109_INST_EXPORT_1.zip'
-      - 'S4FND109_INST_EXPORT_2.zip'
-      - 'S4FND109_INST_EXPORT_3.zip'
-      - 'S4FND109_INST_EXPORT_4.zip'
-      - 'S4FND109_INST_EXPORT_5.zip'
-      - 'S4FND109_INST_EXPORT_6.zip'
-      - 'S4FND109_INST_EXPORT_7.zip'
-      - 'S4FND109_INST_EXPORT_8.zip'
-      - 'S4FND109_INST_EXPORT_9.zip'
-      - 'S4FND109_INST_EXPORT_10.zip'
-      - 'S4FND109_NW_LANG_EN.SAR'
       - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007716.EXE'
       - 'SWPM20SP23_2-80003424.SAR'
       # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
-      - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
-      # Media
-      - 'S4FND109_INST_EXPORT_1.zip'
-      - 'S4FND109_INST_EXPORT_2.zip'
-      - 'S4FND109_INST_EXPORT_3.zip'
-      - 'S4FND109_INST_EXPORT_4.zip'
-      - 'S4FND109_INST_EXPORT_5.zip'
-      - 'S4FND109_INST_EXPORT_6.zip'
-      - 'S4FND109_INST_EXPORT_7.zip'
-      - 'S4FND109_INST_EXPORT_8.zip'
-      - 'S4FND109_INST_EXPORT_9.zip'
-      - 'S4FND109_INST_EXPORT_10.zip'
-      - 'S4FND109_NW_LANG_EN.SAR'
       - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007726.EXE'
       - 'SWPM20SP23_2-80003426.SAR'
       # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    # This list assigned from shared dictionary, because it is same with other products or host types.
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
 
   sap_s4hana_fndn_2023_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2023.FNDN.HDB.ABAP
 
-    # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
-    softwarecenter_search_list_x86_64:
-      # Database
-      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
-      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
-      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
-      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
-      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
-      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
-      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+    sap_software_list_independent:
+      # Application Media
       - 'S4FND108_INST_EXPORT_1.zip'
       - 'S4FND108_INST_EXPORT_2.zip'
       - 'S4FND108_INST_EXPORT_3.zip'
@@ -170,186 +123,180 @@ sap_software_install_dictionary:
       - 'S4FND108_INST_EXPORT_8.zip'
       - 'S4FND108_INST_EXPORT_9.zip'
       - 'S4FND108_NW_LANG_EN.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Application Server
       - 'igshelper_17-10010245.sar'
-      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
+      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
+
+    sap_software_list_x86_64:
+      # Database Server
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
+      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
+      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
+      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+      - 'igsexe_4-70005417.sar' # IGS 7.81
       # Tools
       - 'SAPCAR_1300-70007716.EXE'
       - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
       - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
-      - 'S4FND108_INST_EXPORT_1.zip'
-      - 'S4FND108_INST_EXPORT_2.zip'
-      - 'S4FND108_INST_EXPORT_3.zip'
-      - 'S4FND108_INST_EXPORT_4.zip'
-      - 'S4FND108_INST_EXPORT_5.zip'
-      - 'S4FND108_INST_EXPORT_6.zip'
-      - 'S4FND108_INST_EXPORT_7.zip'
-      - 'S4FND108_INST_EXPORT_8.zip'
-      - 'S4FND108_INST_EXPORT_9.zip'
-      - 'S4FND108_NW_LANG_EN.SAR'
       - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
-      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
       # Tools
       - 'SAPCAR_1300-70007726.EXE'
       - 'SWPM20SP20_1-80003426.SAR'
       # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
 
   sap_s4hana_fndn_2022_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2022.FNDN.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4FND107_INST_EXPORT_1.zip'
+      - 'S4FND107_INST_EXPORT_2.zip'
+      - 'S4FND107_INST_EXPORT_3.zip'
+      - 'S4FND107_INST_EXPORT_4.zip'
+      - 'S4FND107_INST_EXPORT_5.zip'
+      - 'S4FND107_INST_EXPORT_6.zip'
+      - 'S4FND107_INST_EXPORT_7.zip'
+      - 'S4FND107_INST_EXPORT_8.zip'
+      - 'S4FND107_INST_EXPORT_9.zip'
+      # - 'S4FND107_NW_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
       - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_51-70006642.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006641.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
-      - 'S4FND107_INST_EXPORT_1.zip'
-      - 'S4FND107_INST_EXPORT_2.zip'
-      - 'S4FND107_INST_EXPORT_3.zip'
-      - 'S4FND107_INST_EXPORT_4.zip'
-      - 'S4FND107_INST_EXPORT_5.zip'
-      - 'S4FND107_INST_EXPORT_6.zip'
-      - 'S4FND107_INST_EXPORT_7.zip'
-      - 'S4FND107_INST_EXPORT_8.zip'
-      - 'S4FND107_INST_EXPORT_9.zip'
-      # - 'S4FND107_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
       - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_51-70006667.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006666.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
-      - 'S4FND107_INST_EXPORT_1.zip'
-      - 'S4FND107_INST_EXPORT_2.zip'
-      - 'S4FND107_INST_EXPORT_3.zip'
-      - 'S4FND107_INST_EXPORT_4.zip'
-      - 'S4FND107_INST_EXPORT_5.zip'
-      - 'S4FND107_INST_EXPORT_6.zip'
-      - 'S4FND107_INST_EXPORT_7.zip'
-      - 'S4FND107_INST_EXPORT_8.zip'
-      - 'S4FND107_INST_EXPORT_9.zip'
-      # - 'S4FND107_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
 
   sap_s4hana_fndn_2021_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2021.FNDN.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4FND106_INST_EXPORT_1.zip'
+      - 'S4FND106_INST_EXPORT_2.zip'
+      - 'S4FND106_INST_EXPORT_3.zip'
+      - 'S4FND106_INST_EXPORT_4.zip'
+      - 'S4FND106_INST_EXPORT_5.zip'
+      - 'S4FND106_INST_EXPORT_6.zip'
+      - 'S4FND106_INST_EXPORT_7.zip'
+      - 'S4FND106_INST_EXPORT_8.zip'
+      # - 'S4FND106_NW_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
       - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004822.SAR'
-      - 'S4FND106_INST_EXPORT_1.zip'
-      - 'S4FND106_INST_EXPORT_2.zip'
-      - 'S4FND106_INST_EXPORT_3.zip'
-      - 'S4FND106_INST_EXPORT_4.zip'
-      - 'S4FND106_INST_EXPORT_5.zip'
-      - 'S4FND106_INST_EXPORT_6.zip'
-      - 'S4FND106_INST_EXPORT_7.zip'
-      - 'S4FND106_INST_EXPORT_8.zip'
-      # - 'S4FND106_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
       - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004831.SAR'
-      - 'S4FND106_INST_EXPORT_1.zip'
-      - 'S4FND106_INST_EXPORT_2.zip'
-      - 'S4FND106_INST_EXPORT_3.zip'
-      - 'S4FND106_INST_EXPORT_4.zip'
-      - 'S4FND106_INST_EXPORT_5.zip'
-      - 'S4FND106_INST_EXPORT_6.zip'
-      - 'S4FND106_INST_EXPORT_7.zip'
-      - 'S4FND106_INST_EXPORT_8.zip'
-      # - 'S4FND106_NW_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  standard:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
+
+# Dictionary of lists for software filename wildcard patterns that is used during rsync operations.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_software_wildcards:
+  hana:
+    - 'SAPCAR*'
+    - 'IMDB_*'
+    - 'SAPHOSTAGENT*'
 
 
 #### Interactive Prompt Control Variables ####

--- a/deploy_scenarios/sap_s4hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox/ansible_extravars.yml
@@ -30,7 +30,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -130,175 +130,103 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.CORE.HDB.ABAP
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      # Database
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
       - 'SAPPAAPL4_2405_0-80004547.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
-      # Media
-      - 'S4HANAOP109_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_INST_EXPORT_2.zip'
-      - 'S4HANAOP109_INST_EXPORT_3.zip'
-      - 'S4HANAOP109_INST_EXPORT_4.zip'
-      - 'S4HANAOP109_INST_EXPORT_5.zip'
-      - 'S4HANAOP109_INST_EXPORT_6.zip'
-      - 'S4HANAOP109_INST_EXPORT_7.zip'
-      - 'S4HANAOP109_INST_EXPORT_8.zip'
-      - 'S4HANAOP109_INST_EXPORT_9.zip'
-      - 'S4HANAOP109_INST_EXPORT_10.zip'
-      - 'S4HANAOP109_INST_EXPORT_11.zip'
-      - 'S4HANAOP109_INST_EXPORT_12.zip'
-      - 'S4HANAOP109_INST_EXPORT_13.zip'
-      - 'S4HANAOP109_INST_EXPORT_14.zip'
-      - 'S4HANAOP109_INST_EXPORT_15.zip'
-      - 'S4HANAOP109_INST_EXPORT_16.zip'
-      - 'S4HANAOP109_INST_EXPORT_17.zip'
-      - 'S4HANAOP109_INST_EXPORT_18.zip'
-      - 'S4HANAOP109_INST_EXPORT_19.zip'
-      - 'S4HANAOP109_INST_EXPORT_20.zip'
-      - 'S4HANAOP109_INST_EXPORT_21.zip'
-      - 'S4HANAOP109_INST_EXPORT_22.zip'
-      - 'S4HANAOP109_INST_EXPORT_23.zip'
-      - 'S4HANAOP109_INST_EXPORT_24.zip'
-      - 'S4HANAOP109_INST_EXPORT_25.zip'
-      - 'S4HANAOP109_INST_EXPORT_26.zip'
-      - 'S4HANAOP109_INST_EXPORT_27.zip'
-      - 'S4HANAOP109_INST_EXPORT_28.zip'
-      - 'S4HANAOP109_INST_EXPORT_29.zip'
-      - 'S4HANAOP109_INST_EXPORT_30.zip'
-      - 'S4HANAOP109_INST_EXPORT_31.zip'
-      - 'S4HANAOP109_INST_EXPORT_32.zip'
-      - 'S4HANAOP109_INST_EXPORT_33.zip'
-      - 'S4HANAOP109_INST_EXPORT_34.zip'
-      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_ERP_LANG_EN.SAR'
       - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007716.EXE'
       - 'SWPM20SP23_2-80003424.SAR'
       # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
-      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
-      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
       - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
-      # Media
-      - 'S4HANAOP109_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_INST_EXPORT_2.zip'
-      - 'S4HANAOP109_INST_EXPORT_3.zip'
-      - 'S4HANAOP109_INST_EXPORT_4.zip'
-      - 'S4HANAOP109_INST_EXPORT_5.zip'
-      - 'S4HANAOP109_INST_EXPORT_6.zip'
-      - 'S4HANAOP109_INST_EXPORT_7.zip'
-      - 'S4HANAOP109_INST_EXPORT_8.zip'
-      - 'S4HANAOP109_INST_EXPORT_9.zip'
-      - 'S4HANAOP109_INST_EXPORT_10.zip'
-      - 'S4HANAOP109_INST_EXPORT_11.zip'
-      - 'S4HANAOP109_INST_EXPORT_12.zip'
-      - 'S4HANAOP109_INST_EXPORT_13.zip'
-      - 'S4HANAOP109_INST_EXPORT_14.zip'
-      - 'S4HANAOP109_INST_EXPORT_15.zip'
-      - 'S4HANAOP109_INST_EXPORT_16.zip'
-      - 'S4HANAOP109_INST_EXPORT_17.zip'
-      - 'S4HANAOP109_INST_EXPORT_18.zip'
-      - 'S4HANAOP109_INST_EXPORT_19.zip'
-      - 'S4HANAOP109_INST_EXPORT_20.zip'
-      - 'S4HANAOP109_INST_EXPORT_21.zip'
-      - 'S4HANAOP109_INST_EXPORT_22.zip'
-      - 'S4HANAOP109_INST_EXPORT_23.zip'
-      - 'S4HANAOP109_INST_EXPORT_24.zip'
-      - 'S4HANAOP109_INST_EXPORT_25.zip'
-      - 'S4HANAOP109_INST_EXPORT_26.zip'
-      - 'S4HANAOP109_INST_EXPORT_27.zip'
-      - 'S4HANAOP109_INST_EXPORT_28.zip'
-      - 'S4HANAOP109_INST_EXPORT_29.zip'
-      - 'S4HANAOP109_INST_EXPORT_30.zip'
-      - 'S4HANAOP109_INST_EXPORT_31.zip'
-      - 'S4HANAOP109_INST_EXPORT_32.zip'
-      - 'S4HANAOP109_INST_EXPORT_33.zip'
-      - 'S4HANAOP109_INST_EXPORT_34.zip'
-      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_ERP_LANG_EN.SAR'
       - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007726.EXE'
       - 'SWPM20SP23_2-80003426.SAR'
-      # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
-      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
-      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
 
 
   sap_s4hana_2023_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2023.CORE.HDB.ABAP
 
-    # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      # Database
-      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
-      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
-      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
-      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
-      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
-      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
-      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+    sap_software_list_independent:
+      # Application Media
       - 'S4CORE108_INST_EXPORT_1.zip'
       - 'S4CORE108_INST_EXPORT_2.zip'
       - 'S4CORE108_INST_EXPORT_3.zip'
@@ -331,57 +259,36 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
-      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Application Server
       - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
+      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
+      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
+      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+      - 'igsexe_4-70005417.sar' # IGS 7.81
       # Tools
       - 'SAPCAR_1300-70007716.EXE'
       - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
       - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
-      - 'S4CORE108_INST_EXPORT_1.zip'
-      - 'S4CORE108_INST_EXPORT_2.zip'
-      - 'S4CORE108_INST_EXPORT_3.zip'
-      - 'S4CORE108_INST_EXPORT_4.zip'
-      - 'S4CORE108_INST_EXPORT_5.zip'
-      - 'S4CORE108_INST_EXPORT_6.zip'
-      - 'S4CORE108_INST_EXPORT_7.zip'
-      - 'S4CORE108_INST_EXPORT_8.zip'
-      - 'S4CORE108_INST_EXPORT_9.zip'
-      - 'S4CORE108_INST_EXPORT_10.zip'
-      - 'S4CORE108_INST_EXPORT_11.zip'
-      - 'S4CORE108_INST_EXPORT_12.zip'
-      - 'S4CORE108_INST_EXPORT_13.zip'
-      - 'S4CORE108_INST_EXPORT_14.zip'
-      - 'S4CORE108_INST_EXPORT_15.zip'
-      - 'S4CORE108_INST_EXPORT_16.zip'
-      - 'S4CORE108_INST_EXPORT_17.zip'
-      - 'S4CORE108_INST_EXPORT_18.zip'
-      - 'S4CORE108_INST_EXPORT_19.zip'
-      - 'S4CORE108_INST_EXPORT_20.zip'
-      - 'S4CORE108_INST_EXPORT_21.zip'
-      - 'S4CORE108_INST_EXPORT_22.zip'
-      - 'S4CORE108_INST_EXPORT_23.zip'
-      - 'S4CORE108_INST_EXPORT_24.zip'
-      - 'S4CORE108_INST_EXPORT_25.zip'
-      - 'S4CORE108_INST_EXPORT_26.zip'
-      - 'S4CORE108_INST_EXPORT_27.zip'
-      - 'S4CORE108_INST_EXPORT_28.zip'
-      - 'S4CORE108_INST_EXPORT_29.zip'
-      - 'S4CORE108_INST_EXPORT_30.zip'
-      - 'S4HANAOP108_ERP_LANG_EN.SAR'
-      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
       - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
       # Tools
       - 'SAPCAR_1300-70007726.EXE'
       - 'SWPM20SP20_1-80003426.SAR'
@@ -389,316 +296,240 @@ sap_software_install_dictionary:
 
 
   sap_s4hana_2022_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2022.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE107_INST_EXPORT_1.zip'
+      - 'S4CORE107_INST_EXPORT_2.zip'
+      - 'S4CORE107_INST_EXPORT_3.zip'
+      - 'S4CORE107_INST_EXPORT_4.zip'
+      - 'S4CORE107_INST_EXPORT_5.zip'
+      - 'S4CORE107_INST_EXPORT_6.zip'
+      - 'S4CORE107_INST_EXPORT_7.zip'
+      - 'S4CORE107_INST_EXPORT_8.zip'
+      - 'S4CORE107_INST_EXPORT_9.zip'
+      - 'S4CORE107_INST_EXPORT_10.zip'
+      - 'S4CORE107_INST_EXPORT_11.zip'
+      - 'S4CORE107_INST_EXPORT_12.zip'
+      - 'S4CORE107_INST_EXPORT_13.zip'
+      - 'S4CORE107_INST_EXPORT_14.zip'
+      - 'S4CORE107_INST_EXPORT_15.zip'
+      - 'S4CORE107_INST_EXPORT_16.zip'
+      - 'S4CORE107_INST_EXPORT_17.zip'
+      - 'S4CORE107_INST_EXPORT_18.zip'
+      - 'S4CORE107_INST_EXPORT_19.zip'
+      - 'S4CORE107_INST_EXPORT_20.zip'
+      - 'S4CORE107_INST_EXPORT_21.zip'
+      - 'S4CORE107_INST_EXPORT_22.zip'
+      - 'S4CORE107_INST_EXPORT_23.zip'
+      - 'S4CORE107_INST_EXPORT_24.zip'
+      - 'S4CORE107_INST_EXPORT_25.zip'
+      - 'S4CORE107_INST_EXPORT_26.zip'
+      - 'S4CORE107_INST_EXPORT_27.zip'
+      - 'S4CORE107_INST_EXPORT_28.zip'
+      - 'S4CORE107_INST_EXPORT_29.zip'
+      - 'S4CORE107_INST_EXPORT_30.zip'
+      - 'S4HANAOP107_ERP_LANG_EN.SAR'
+      # - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
+      # - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_51-70006642.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006641.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
-      - 'S4CORE107_INST_EXPORT_1.zip'
-      - 'S4CORE107_INST_EXPORT_2.zip'
-      - 'S4CORE107_INST_EXPORT_3.zip'
-      - 'S4CORE107_INST_EXPORT_4.zip'
-      - 'S4CORE107_INST_EXPORT_5.zip'
-      - 'S4CORE107_INST_EXPORT_6.zip'
-      - 'S4CORE107_INST_EXPORT_7.zip'
-      - 'S4CORE107_INST_EXPORT_8.zip'
-      - 'S4CORE107_INST_EXPORT_9.zip'
-      - 'S4CORE107_INST_EXPORT_10.zip'
-      - 'S4CORE107_INST_EXPORT_11.zip'
-      - 'S4CORE107_INST_EXPORT_12.zip'
-      - 'S4CORE107_INST_EXPORT_13.zip'
-      - 'S4CORE107_INST_EXPORT_14.zip'
-      - 'S4CORE107_INST_EXPORT_15.zip'
-      - 'S4CORE107_INST_EXPORT_16.zip'
-      - 'S4CORE107_INST_EXPORT_17.zip'
-      - 'S4CORE107_INST_EXPORT_18.zip'
-      - 'S4CORE107_INST_EXPORT_19.zip'
-      - 'S4CORE107_INST_EXPORT_20.zip'
-      - 'S4CORE107_INST_EXPORT_21.zip'
-      - 'S4CORE107_INST_EXPORT_22.zip'
-      - 'S4CORE107_INST_EXPORT_23.zip'
-      - 'S4CORE107_INST_EXPORT_24.zip'
-      - 'S4CORE107_INST_EXPORT_25.zip'
-      - 'S4CORE107_INST_EXPORT_26.zip'
-      - 'S4CORE107_INST_EXPORT_27.zip'
-      - 'S4CORE107_INST_EXPORT_28.zip'
-      - 'S4CORE107_INST_EXPORT_29.zip'
-      - 'S4CORE107_INST_EXPORT_30.zip'
-      - 'S4HANAOP107_ERP_LANG_EN.SAR'
-      # - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
-      # - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
+      - 'igsexe_4-70005417.sar' # IGS 7.81
       # - 'SAPPAAPL4_2203_2-80004547.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_51-70006667.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006666.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
-      - 'S4CORE107_INST_EXPORT_1.zip'
-      - 'S4CORE107_INST_EXPORT_2.zip'
-      - 'S4CORE107_INST_EXPORT_3.zip'
-      - 'S4CORE107_INST_EXPORT_4.zip'
-      - 'S4CORE107_INST_EXPORT_5.zip'
-      - 'S4CORE107_INST_EXPORT_6.zip'
-      - 'S4CORE107_INST_EXPORT_7.zip'
-      - 'S4CORE107_INST_EXPORT_8.zip'
-      - 'S4CORE107_INST_EXPORT_9.zip'
-      - 'S4CORE107_INST_EXPORT_10.zip'
-      - 'S4CORE107_INST_EXPORT_11.zip'
-      - 'S4CORE107_INST_EXPORT_12.zip'
-      - 'S4CORE107_INST_EXPORT_13.zip'
-      - 'S4CORE107_INST_EXPORT_14.zip'
-      - 'S4CORE107_INST_EXPORT_15.zip'
-      - 'S4CORE107_INST_EXPORT_16.zip'
-      - 'S4CORE107_INST_EXPORT_17.zip'
-      - 'S4CORE107_INST_EXPORT_18.zip'
-      - 'S4CORE107_INST_EXPORT_19.zip'
-      - 'S4CORE107_INST_EXPORT_20.zip'
-      - 'S4CORE107_INST_EXPORT_21.zip'
-      - 'S4CORE107_INST_EXPORT_22.zip'
-      - 'S4CORE107_INST_EXPORT_23.zip'
-      - 'S4CORE107_INST_EXPORT_24.zip'
-      - 'S4CORE107_INST_EXPORT_25.zip'
-      - 'S4CORE107_INST_EXPORT_26.zip'
-      - 'S4CORE107_INST_EXPORT_27.zip'
-      - 'S4CORE107_INST_EXPORT_28.zip'
-      - 'S4CORE107_INST_EXPORT_29.zip'
-      - 'S4CORE107_INST_EXPORT_30.zip'
-      - 'S4HANAOP107_ERP_LANG_EN.SAR'
-      # - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
-      # - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
+      - 'igsexe_4-70005446.sar' # IGS 7.81
       # - 'SAPPAAPL4_2203_2-80004546.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
       # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
 
   sap_s4hana_2021_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2021.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE106_INST_EXPORT_1.zip'
+      - 'S4CORE106_INST_EXPORT_2.zip'
+      - 'S4CORE106_INST_EXPORT_3.zip'
+      - 'S4CORE106_INST_EXPORT_4.zip'
+      - 'S4CORE106_INST_EXPORT_5.zip'
+      - 'S4CORE106_INST_EXPORT_6.zip'
+      - 'S4CORE106_INST_EXPORT_7.zip'
+      - 'S4CORE106_INST_EXPORT_8.zip'
+      - 'S4CORE106_INST_EXPORT_9.zip'
+      - 'S4CORE106_INST_EXPORT_10.zip'
+      - 'S4CORE106_INST_EXPORT_11.zip'
+      - 'S4CORE106_INST_EXPORT_12.zip'
+      - 'S4CORE106_INST_EXPORT_13.zip'
+      - 'S4CORE106_INST_EXPORT_14.zip'
+      - 'S4CORE106_INST_EXPORT_15.zip'
+      - 'S4CORE106_INST_EXPORT_16.zip'
+      - 'S4CORE106_INST_EXPORT_17.zip'
+      - 'S4CORE106_INST_EXPORT_18.zip'
+      - 'S4CORE106_INST_EXPORT_19.zip'
+      - 'S4CORE106_INST_EXPORT_20.zip'
+      - 'S4CORE106_INST_EXPORT_21.zip'
+      - 'S4CORE106_INST_EXPORT_22.zip'
+      - 'S4CORE106_INST_EXPORT_23.zip'
+      - 'S4CORE106_INST_EXPORT_24.zip'
+      - 'S4CORE106_INST_EXPORT_25.zip'
+      - 'S4CORE106_INST_EXPORT_26.zip'
+      - 'S4CORE106_INST_EXPORT_27.zip'
+      - 'S4CORE106_INST_EXPORT_28.zip'
+      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004822.SAR'
-      - 'S4CORE106_INST_EXPORT_1.zip'
-      - 'S4CORE106_INST_EXPORT_2.zip'
-      - 'S4CORE106_INST_EXPORT_3.zip'
-      - 'S4CORE106_INST_EXPORT_4.zip'
-      - 'S4CORE106_INST_EXPORT_5.zip'
-      - 'S4CORE106_INST_EXPORT_6.zip'
-      - 'S4CORE106_INST_EXPORT_7.zip'
-      - 'S4CORE106_INST_EXPORT_8.zip'
-      - 'S4CORE106_INST_EXPORT_9.zip'
-      - 'S4CORE106_INST_EXPORT_10.zip'
-      - 'S4CORE106_INST_EXPORT_11.zip'
-      - 'S4CORE106_INST_EXPORT_12.zip'
-      - 'S4CORE106_INST_EXPORT_13.zip'
-      - 'S4CORE106_INST_EXPORT_14.zip'
-      - 'S4CORE106_INST_EXPORT_15.zip'
-      - 'S4CORE106_INST_EXPORT_16.zip'
-      - 'S4CORE106_INST_EXPORT_17.zip'
-      - 'S4CORE106_INST_EXPORT_18.zip'
-      - 'S4CORE106_INST_EXPORT_19.zip'
-      - 'S4CORE106_INST_EXPORT_20.zip'
-      - 'S4CORE106_INST_EXPORT_21.zip'
-      - 'S4CORE106_INST_EXPORT_22.zip'
-      - 'S4CORE106_INST_EXPORT_23.zip'
-      - 'S4CORE106_INST_EXPORT_24.zip'
-      - 'S4CORE106_INST_EXPORT_25.zip'
-      - 'S4CORE106_INST_EXPORT_26.zip'
-      - 'S4CORE106_INST_EXPORT_27.zip'
-      - 'S4CORE106_INST_EXPORT_28.zip'
-      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004831.SAR'
-      - 'S4CORE106_INST_EXPORT_1.zip'
-      - 'S4CORE106_INST_EXPORT_2.zip'
-      - 'S4CORE106_INST_EXPORT_3.zip'
-      - 'S4CORE106_INST_EXPORT_4.zip'
-      - 'S4CORE106_INST_EXPORT_5.zip'
-      - 'S4CORE106_INST_EXPORT_6.zip'
-      - 'S4CORE106_INST_EXPORT_7.zip'
-      - 'S4CORE106_INST_EXPORT_8.zip'
-      - 'S4CORE106_INST_EXPORT_9.zip'
-      - 'S4CORE106_INST_EXPORT_10.zip'
-      - 'S4CORE106_INST_EXPORT_11.zip'
-      - 'S4CORE106_INST_EXPORT_12.zip'
-      - 'S4CORE106_INST_EXPORT_13.zip'
-      - 'S4CORE106_INST_EXPORT_14.zip'
-      - 'S4CORE106_INST_EXPORT_15.zip'
-      - 'S4CORE106_INST_EXPORT_16.zip'
-      - 'S4CORE106_INST_EXPORT_17.zip'
-      - 'S4CORE106_INST_EXPORT_18.zip'
-      - 'S4CORE106_INST_EXPORT_19.zip'
-      - 'S4CORE106_INST_EXPORT_20.zip'
-      - 'S4CORE106_INST_EXPORT_21.zip'
-      - 'S4CORE106_INST_EXPORT_22.zip'
-      - 'S4CORE106_INST_EXPORT_23.zip'
-      - 'S4CORE106_INST_EXPORT_24.zip'
-      - 'S4CORE106_INST_EXPORT_25.zip'
-      - 'S4CORE106_INST_EXPORT_26.zip'
-      - 'S4CORE106_INST_EXPORT_27.zip'
-      - 'S4CORE106_INST_EXPORT_28.zip'
-      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
 
   sap_s4hana_2020_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2020.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE105_INST_EXPORT_1.zip'
+      - 'S4CORE105_INST_EXPORT_2.zip'
+      - 'S4CORE105_INST_EXPORT_3.zip'
+      - 'S4CORE105_INST_EXPORT_4.zip'
+      - 'S4CORE105_INST_EXPORT_5.zip'
+      - 'S4CORE105_INST_EXPORT_6.zip'
+      - 'S4CORE105_INST_EXPORT_7.zip'
+      - 'S4CORE105_INST_EXPORT_8.zip'
+      - 'S4CORE105_INST_EXPORT_9.zip'
+      - 'S4CORE105_INST_EXPORT_10.zip'
+      - 'S4CORE105_INST_EXPORT_11.zip'
+      - 'S4CORE105_INST_EXPORT_12.zip'
+      - 'S4CORE105_INST_EXPORT_13.zip'
+      - 'S4CORE105_INST_EXPORT_14.zip'
+      - 'S4CORE105_INST_EXPORT_15.zip'
+      - 'S4CORE105_INST_EXPORT_16.zip'
+      - 'S4CORE105_INST_EXPORT_17.zip'
+      - 'S4CORE105_INST_EXPORT_18.zip'
+      - 'S4CORE105_INST_EXPORT_19.zip'
+      - 'S4CORE105_INST_EXPORT_20.zip'
+      - 'S4CORE105_INST_EXPORT_21.zip'
+      - 'S4CORE105_INST_EXPORT_22.zip'
+      - 'S4CORE105_INST_EXPORT_23.zip'
+      - 'S4CORE105_INST_EXPORT_24.zip'
+      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004822.SAR'
-      - 'S4CORE105_INST_EXPORT_1.zip'
-      - 'S4CORE105_INST_EXPORT_2.zip'
-      - 'S4CORE105_INST_EXPORT_3.zip'
-      - 'S4CORE105_INST_EXPORT_4.zip'
-      - 'S4CORE105_INST_EXPORT_5.zip'
-      - 'S4CORE105_INST_EXPORT_6.zip'
-      - 'S4CORE105_INST_EXPORT_7.zip'
-      - 'S4CORE105_INST_EXPORT_8.zip'
-      - 'S4CORE105_INST_EXPORT_9.zip'
-      - 'S4CORE105_INST_EXPORT_10.zip'
-      - 'S4CORE105_INST_EXPORT_11.zip'
-      - 'S4CORE105_INST_EXPORT_12.zip'
-      - 'S4CORE105_INST_EXPORT_13.zip'
-      - 'S4CORE105_INST_EXPORT_14.zip'
-      - 'S4CORE105_INST_EXPORT_15.zip'
-      - 'S4CORE105_INST_EXPORT_16.zip'
-      - 'S4CORE105_INST_EXPORT_17.zip'
-      - 'S4CORE105_INST_EXPORT_18.zip'
-      - 'S4CORE105_INST_EXPORT_19.zip'
-      - 'S4CORE105_INST_EXPORT_20.zip'
-      - 'S4CORE105_INST_EXPORT_21.zip'
-      - 'S4CORE105_INST_EXPORT_22.zip'
-      - 'S4CORE105_INST_EXPORT_23.zip'
-      - 'S4CORE105_INST_EXPORT_24.zip'
-      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004831.SAR'
-      - 'S4CORE105_INST_EXPORT_1.zip'
-      - 'S4CORE105_INST_EXPORT_2.zip'
-      - 'S4CORE105_INST_EXPORT_3.zip'
-      - 'S4CORE105_INST_EXPORT_4.zip'
-      - 'S4CORE105_INST_EXPORT_5.zip'
-      - 'S4CORE105_INST_EXPORT_6.zip'
-      - 'S4CORE105_INST_EXPORT_7.zip'
-      - 'S4CORE105_INST_EXPORT_8.zip'
-      - 'S4CORE105_INST_EXPORT_9.zip'
-      - 'S4CORE105_INST_EXPORT_10.zip'
-      - 'S4CORE105_INST_EXPORT_11.zip'
-      - 'S4CORE105_INST_EXPORT_12.zip'
-      - 'S4CORE105_INST_EXPORT_13.zip'
-      - 'S4CORE105_INST_EXPORT_14.zip'
-      - 'S4CORE105_INST_EXPORT_15.zip'
-      - 'S4CORE105_INST_EXPORT_16.zip'
-      - 'S4CORE105_INST_EXPORT_17.zip'
-      - 'S4CORE105_INST_EXPORT_18.zip'
-      - 'S4CORE105_INST_EXPORT_19.zip'
-      - 'S4CORE105_INST_EXPORT_20.zip'
-      - 'S4CORE105_INST_EXPORT_21.zip'
-      - 'S4CORE105_INST_EXPORT_22.zip'
-      - 'S4CORE105_INST_EXPORT_23.zip'
-      - 'S4CORE105_INST_EXPORT_24.zip'
-      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  sandbox:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user

--- a/deploy_scenarios/sap_s4hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox/ansible_playbook.yml
@@ -255,8 +255,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 

--- a/deploy_scenarios/sap_s4hana_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox/optional/ansible_extravars_interactive.yml
@@ -38,175 +38,103 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.CORE.HDB.ABAP
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      # Database
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
       - 'SAPPAAPL4_2405_0-80004547.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
-      # Media
-      - 'S4HANAOP109_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_INST_EXPORT_2.zip'
-      - 'S4HANAOP109_INST_EXPORT_3.zip'
-      - 'S4HANAOP109_INST_EXPORT_4.zip'
-      - 'S4HANAOP109_INST_EXPORT_5.zip'
-      - 'S4HANAOP109_INST_EXPORT_6.zip'
-      - 'S4HANAOP109_INST_EXPORT_7.zip'
-      - 'S4HANAOP109_INST_EXPORT_8.zip'
-      - 'S4HANAOP109_INST_EXPORT_9.zip'
-      - 'S4HANAOP109_INST_EXPORT_10.zip'
-      - 'S4HANAOP109_INST_EXPORT_11.zip'
-      - 'S4HANAOP109_INST_EXPORT_12.zip'
-      - 'S4HANAOP109_INST_EXPORT_13.zip'
-      - 'S4HANAOP109_INST_EXPORT_14.zip'
-      - 'S4HANAOP109_INST_EXPORT_15.zip'
-      - 'S4HANAOP109_INST_EXPORT_16.zip'
-      - 'S4HANAOP109_INST_EXPORT_17.zip'
-      - 'S4HANAOP109_INST_EXPORT_18.zip'
-      - 'S4HANAOP109_INST_EXPORT_19.zip'
-      - 'S4HANAOP109_INST_EXPORT_20.zip'
-      - 'S4HANAOP109_INST_EXPORT_21.zip'
-      - 'S4HANAOP109_INST_EXPORT_22.zip'
-      - 'S4HANAOP109_INST_EXPORT_23.zip'
-      - 'S4HANAOP109_INST_EXPORT_24.zip'
-      - 'S4HANAOP109_INST_EXPORT_25.zip'
-      - 'S4HANAOP109_INST_EXPORT_26.zip'
-      - 'S4HANAOP109_INST_EXPORT_27.zip'
-      - 'S4HANAOP109_INST_EXPORT_28.zip'
-      - 'S4HANAOP109_INST_EXPORT_29.zip'
-      - 'S4HANAOP109_INST_EXPORT_30.zip'
-      - 'S4HANAOP109_INST_EXPORT_31.zip'
-      - 'S4HANAOP109_INST_EXPORT_32.zip'
-      - 'S4HANAOP109_INST_EXPORT_33.zip'
-      - 'S4HANAOP109_INST_EXPORT_34.zip'
-      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_ERP_LANG_EN.SAR'
       - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007716.EXE'
       - 'SWPM20SP23_2-80003424.SAR'
       # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
-      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
-      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
       - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
-      # Media
-      - 'S4HANAOP109_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_INST_EXPORT_2.zip'
-      - 'S4HANAOP109_INST_EXPORT_3.zip'
-      - 'S4HANAOP109_INST_EXPORT_4.zip'
-      - 'S4HANAOP109_INST_EXPORT_5.zip'
-      - 'S4HANAOP109_INST_EXPORT_6.zip'
-      - 'S4HANAOP109_INST_EXPORT_7.zip'
-      - 'S4HANAOP109_INST_EXPORT_8.zip'
-      - 'S4HANAOP109_INST_EXPORT_9.zip'
-      - 'S4HANAOP109_INST_EXPORT_10.zip'
-      - 'S4HANAOP109_INST_EXPORT_11.zip'
-      - 'S4HANAOP109_INST_EXPORT_12.zip'
-      - 'S4HANAOP109_INST_EXPORT_13.zip'
-      - 'S4HANAOP109_INST_EXPORT_14.zip'
-      - 'S4HANAOP109_INST_EXPORT_15.zip'
-      - 'S4HANAOP109_INST_EXPORT_16.zip'
-      - 'S4HANAOP109_INST_EXPORT_17.zip'
-      - 'S4HANAOP109_INST_EXPORT_18.zip'
-      - 'S4HANAOP109_INST_EXPORT_19.zip'
-      - 'S4HANAOP109_INST_EXPORT_20.zip'
-      - 'S4HANAOP109_INST_EXPORT_21.zip'
-      - 'S4HANAOP109_INST_EXPORT_22.zip'
-      - 'S4HANAOP109_INST_EXPORT_23.zip'
-      - 'S4HANAOP109_INST_EXPORT_24.zip'
-      - 'S4HANAOP109_INST_EXPORT_25.zip'
-      - 'S4HANAOP109_INST_EXPORT_26.zip'
-      - 'S4HANAOP109_INST_EXPORT_27.zip'
-      - 'S4HANAOP109_INST_EXPORT_28.zip'
-      - 'S4HANAOP109_INST_EXPORT_29.zip'
-      - 'S4HANAOP109_INST_EXPORT_30.zip'
-      - 'S4HANAOP109_INST_EXPORT_31.zip'
-      - 'S4HANAOP109_INST_EXPORT_32.zip'
-      - 'S4HANAOP109_INST_EXPORT_33.zip'
-      - 'S4HANAOP109_INST_EXPORT_34.zip'
-      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_ERP_LANG_EN.SAR'
       - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007726.EXE'
       - 'SWPM20SP23_2-80003426.SAR'
-      # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
-      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
-      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
 
 
   sap_s4hana_2023_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2023.CORE.HDB.ABAP
 
-    # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      # Database
-      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
-      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
-      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
-      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
-      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
-      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
-      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+    sap_software_list_independent:
+      # Application Media
       - 'S4CORE108_INST_EXPORT_1.zip'
       - 'S4CORE108_INST_EXPORT_2.zip'
       - 'S4CORE108_INST_EXPORT_3.zip'
@@ -239,57 +167,36 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
-      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Application Server
       - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
+      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
+      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
+      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+      - 'igsexe_4-70005417.sar' # IGS 7.81
       # Tools
       - 'SAPCAR_1300-70007716.EXE'
       - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
       - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
-      - 'S4CORE108_INST_EXPORT_1.zip'
-      - 'S4CORE108_INST_EXPORT_2.zip'
-      - 'S4CORE108_INST_EXPORT_3.zip'
-      - 'S4CORE108_INST_EXPORT_4.zip'
-      - 'S4CORE108_INST_EXPORT_5.zip'
-      - 'S4CORE108_INST_EXPORT_6.zip'
-      - 'S4CORE108_INST_EXPORT_7.zip'
-      - 'S4CORE108_INST_EXPORT_8.zip'
-      - 'S4CORE108_INST_EXPORT_9.zip'
-      - 'S4CORE108_INST_EXPORT_10.zip'
-      - 'S4CORE108_INST_EXPORT_11.zip'
-      - 'S4CORE108_INST_EXPORT_12.zip'
-      - 'S4CORE108_INST_EXPORT_13.zip'
-      - 'S4CORE108_INST_EXPORT_14.zip'
-      - 'S4CORE108_INST_EXPORT_15.zip'
-      - 'S4CORE108_INST_EXPORT_16.zip'
-      - 'S4CORE108_INST_EXPORT_17.zip'
-      - 'S4CORE108_INST_EXPORT_18.zip'
-      - 'S4CORE108_INST_EXPORT_19.zip'
-      - 'S4CORE108_INST_EXPORT_20.zip'
-      - 'S4CORE108_INST_EXPORT_21.zip'
-      - 'S4CORE108_INST_EXPORT_22.zip'
-      - 'S4CORE108_INST_EXPORT_23.zip'
-      - 'S4CORE108_INST_EXPORT_24.zip'
-      - 'S4CORE108_INST_EXPORT_25.zip'
-      - 'S4CORE108_INST_EXPORT_26.zip'
-      - 'S4CORE108_INST_EXPORT_27.zip'
-      - 'S4CORE108_INST_EXPORT_28.zip'
-      - 'S4CORE108_INST_EXPORT_29.zip'
-      - 'S4CORE108_INST_EXPORT_30.zip'
-      - 'S4HANAOP108_ERP_LANG_EN.SAR'
-      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
       - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
       # Tools
       - 'SAPCAR_1300-70007726.EXE'
       - 'SWPM20SP20_1-80003426.SAR'
@@ -297,319 +204,243 @@ sap_software_install_dictionary:
 
 
   sap_s4hana_2022_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2022.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE107_INST_EXPORT_1.zip'
+      - 'S4CORE107_INST_EXPORT_2.zip'
+      - 'S4CORE107_INST_EXPORT_3.zip'
+      - 'S4CORE107_INST_EXPORT_4.zip'
+      - 'S4CORE107_INST_EXPORT_5.zip'
+      - 'S4CORE107_INST_EXPORT_6.zip'
+      - 'S4CORE107_INST_EXPORT_7.zip'
+      - 'S4CORE107_INST_EXPORT_8.zip'
+      - 'S4CORE107_INST_EXPORT_9.zip'
+      - 'S4CORE107_INST_EXPORT_10.zip'
+      - 'S4CORE107_INST_EXPORT_11.zip'
+      - 'S4CORE107_INST_EXPORT_12.zip'
+      - 'S4CORE107_INST_EXPORT_13.zip'
+      - 'S4CORE107_INST_EXPORT_14.zip'
+      - 'S4CORE107_INST_EXPORT_15.zip'
+      - 'S4CORE107_INST_EXPORT_16.zip'
+      - 'S4CORE107_INST_EXPORT_17.zip'
+      - 'S4CORE107_INST_EXPORT_18.zip'
+      - 'S4CORE107_INST_EXPORT_19.zip'
+      - 'S4CORE107_INST_EXPORT_20.zip'
+      - 'S4CORE107_INST_EXPORT_21.zip'
+      - 'S4CORE107_INST_EXPORT_22.zip'
+      - 'S4CORE107_INST_EXPORT_23.zip'
+      - 'S4CORE107_INST_EXPORT_24.zip'
+      - 'S4CORE107_INST_EXPORT_25.zip'
+      - 'S4CORE107_INST_EXPORT_26.zip'
+      - 'S4CORE107_INST_EXPORT_27.zip'
+      - 'S4CORE107_INST_EXPORT_28.zip'
+      - 'S4CORE107_INST_EXPORT_29.zip'
+      - 'S4CORE107_INST_EXPORT_30.zip'
+      - 'S4HANAOP107_ERP_LANG_EN.SAR'
+      # - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
+      # - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_51-70006642.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006641.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
-      - 'S4CORE107_INST_EXPORT_1.zip'
-      - 'S4CORE107_INST_EXPORT_2.zip'
-      - 'S4CORE107_INST_EXPORT_3.zip'
-      - 'S4CORE107_INST_EXPORT_4.zip'
-      - 'S4CORE107_INST_EXPORT_5.zip'
-      - 'S4CORE107_INST_EXPORT_6.zip'
-      - 'S4CORE107_INST_EXPORT_7.zip'
-      - 'S4CORE107_INST_EXPORT_8.zip'
-      - 'S4CORE107_INST_EXPORT_9.zip'
-      - 'S4CORE107_INST_EXPORT_10.zip'
-      - 'S4CORE107_INST_EXPORT_11.zip'
-      - 'S4CORE107_INST_EXPORT_12.zip'
-      - 'S4CORE107_INST_EXPORT_13.zip'
-      - 'S4CORE107_INST_EXPORT_14.zip'
-      - 'S4CORE107_INST_EXPORT_15.zip'
-      - 'S4CORE107_INST_EXPORT_16.zip'
-      - 'S4CORE107_INST_EXPORT_17.zip'
-      - 'S4CORE107_INST_EXPORT_18.zip'
-      - 'S4CORE107_INST_EXPORT_19.zip'
-      - 'S4CORE107_INST_EXPORT_20.zip'
-      - 'S4CORE107_INST_EXPORT_21.zip'
-      - 'S4CORE107_INST_EXPORT_22.zip'
-      - 'S4CORE107_INST_EXPORT_23.zip'
-      - 'S4CORE107_INST_EXPORT_24.zip'
-      - 'S4CORE107_INST_EXPORT_25.zip'
-      - 'S4CORE107_INST_EXPORT_26.zip'
-      - 'S4CORE107_INST_EXPORT_27.zip'
-      - 'S4CORE107_INST_EXPORT_28.zip'
-      - 'S4CORE107_INST_EXPORT_29.zip'
-      - 'S4CORE107_INST_EXPORT_30.zip'
-      - 'S4HANAOP107_ERP_LANG_EN.SAR'
-      # - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
-      # - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
+      - 'igsexe_4-70005417.sar' # IGS 7.81
       # - 'SAPPAAPL4_2203_2-80004547.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_51-70006667.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006666.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
-      - 'S4CORE107_INST_EXPORT_1.zip'
-      - 'S4CORE107_INST_EXPORT_2.zip'
-      - 'S4CORE107_INST_EXPORT_3.zip'
-      - 'S4CORE107_INST_EXPORT_4.zip'
-      - 'S4CORE107_INST_EXPORT_5.zip'
-      - 'S4CORE107_INST_EXPORT_6.zip'
-      - 'S4CORE107_INST_EXPORT_7.zip'
-      - 'S4CORE107_INST_EXPORT_8.zip'
-      - 'S4CORE107_INST_EXPORT_9.zip'
-      - 'S4CORE107_INST_EXPORT_10.zip'
-      - 'S4CORE107_INST_EXPORT_11.zip'
-      - 'S4CORE107_INST_EXPORT_12.zip'
-      - 'S4CORE107_INST_EXPORT_13.zip'
-      - 'S4CORE107_INST_EXPORT_14.zip'
-      - 'S4CORE107_INST_EXPORT_15.zip'
-      - 'S4CORE107_INST_EXPORT_16.zip'
-      - 'S4CORE107_INST_EXPORT_17.zip'
-      - 'S4CORE107_INST_EXPORT_18.zip'
-      - 'S4CORE107_INST_EXPORT_19.zip'
-      - 'S4CORE107_INST_EXPORT_20.zip'
-      - 'S4CORE107_INST_EXPORT_21.zip'
-      - 'S4CORE107_INST_EXPORT_22.zip'
-      - 'S4CORE107_INST_EXPORT_23.zip'
-      - 'S4CORE107_INST_EXPORT_24.zip'
-      - 'S4CORE107_INST_EXPORT_25.zip'
-      - 'S4CORE107_INST_EXPORT_26.zip'
-      - 'S4CORE107_INST_EXPORT_27.zip'
-      - 'S4CORE107_INST_EXPORT_28.zip'
-      - 'S4CORE107_INST_EXPORT_29.zip'
-      - 'S4CORE107_INST_EXPORT_30.zip'
-      - 'S4HANAOP107_ERP_LANG_EN.SAR'
-      # - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
-      # - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
+      - 'igsexe_4-70005446.sar' # IGS 7.81
       # - 'SAPPAAPL4_2203_2-80004546.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
       # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
 
   sap_s4hana_2021_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2021.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE106_INST_EXPORT_1.zip'
+      - 'S4CORE106_INST_EXPORT_2.zip'
+      - 'S4CORE106_INST_EXPORT_3.zip'
+      - 'S4CORE106_INST_EXPORT_4.zip'
+      - 'S4CORE106_INST_EXPORT_5.zip'
+      - 'S4CORE106_INST_EXPORT_6.zip'
+      - 'S4CORE106_INST_EXPORT_7.zip'
+      - 'S4CORE106_INST_EXPORT_8.zip'
+      - 'S4CORE106_INST_EXPORT_9.zip'
+      - 'S4CORE106_INST_EXPORT_10.zip'
+      - 'S4CORE106_INST_EXPORT_11.zip'
+      - 'S4CORE106_INST_EXPORT_12.zip'
+      - 'S4CORE106_INST_EXPORT_13.zip'
+      - 'S4CORE106_INST_EXPORT_14.zip'
+      - 'S4CORE106_INST_EXPORT_15.zip'
+      - 'S4CORE106_INST_EXPORT_16.zip'
+      - 'S4CORE106_INST_EXPORT_17.zip'
+      - 'S4CORE106_INST_EXPORT_18.zip'
+      - 'S4CORE106_INST_EXPORT_19.zip'
+      - 'S4CORE106_INST_EXPORT_20.zip'
+      - 'S4CORE106_INST_EXPORT_21.zip'
+      - 'S4CORE106_INST_EXPORT_22.zip'
+      - 'S4CORE106_INST_EXPORT_23.zip'
+      - 'S4CORE106_INST_EXPORT_24.zip'
+      - 'S4CORE106_INST_EXPORT_25.zip'
+      - 'S4CORE106_INST_EXPORT_26.zip'
+      - 'S4CORE106_INST_EXPORT_27.zip'
+      - 'S4CORE106_INST_EXPORT_28.zip'
+      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004822.SAR'
-      - 'S4CORE106_INST_EXPORT_1.zip'
-      - 'S4CORE106_INST_EXPORT_2.zip'
-      - 'S4CORE106_INST_EXPORT_3.zip'
-      - 'S4CORE106_INST_EXPORT_4.zip'
-      - 'S4CORE106_INST_EXPORT_5.zip'
-      - 'S4CORE106_INST_EXPORT_6.zip'
-      - 'S4CORE106_INST_EXPORT_7.zip'
-      - 'S4CORE106_INST_EXPORT_8.zip'
-      - 'S4CORE106_INST_EXPORT_9.zip'
-      - 'S4CORE106_INST_EXPORT_10.zip'
-      - 'S4CORE106_INST_EXPORT_11.zip'
-      - 'S4CORE106_INST_EXPORT_12.zip'
-      - 'S4CORE106_INST_EXPORT_13.zip'
-      - 'S4CORE106_INST_EXPORT_14.zip'
-      - 'S4CORE106_INST_EXPORT_15.zip'
-      - 'S4CORE106_INST_EXPORT_16.zip'
-      - 'S4CORE106_INST_EXPORT_17.zip'
-      - 'S4CORE106_INST_EXPORT_18.zip'
-      - 'S4CORE106_INST_EXPORT_19.zip'
-      - 'S4CORE106_INST_EXPORT_20.zip'
-      - 'S4CORE106_INST_EXPORT_21.zip'
-      - 'S4CORE106_INST_EXPORT_22.zip'
-      - 'S4CORE106_INST_EXPORT_23.zip'
-      - 'S4CORE106_INST_EXPORT_24.zip'
-      - 'S4CORE106_INST_EXPORT_25.zip'
-      - 'S4CORE106_INST_EXPORT_26.zip'
-      - 'S4CORE106_INST_EXPORT_27.zip'
-      - 'S4CORE106_INST_EXPORT_28.zip'
-      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004831.SAR'
-      - 'S4CORE106_INST_EXPORT_1.zip'
-      - 'S4CORE106_INST_EXPORT_2.zip'
-      - 'S4CORE106_INST_EXPORT_3.zip'
-      - 'S4CORE106_INST_EXPORT_4.zip'
-      - 'S4CORE106_INST_EXPORT_5.zip'
-      - 'S4CORE106_INST_EXPORT_6.zip'
-      - 'S4CORE106_INST_EXPORT_7.zip'
-      - 'S4CORE106_INST_EXPORT_8.zip'
-      - 'S4CORE106_INST_EXPORT_9.zip'
-      - 'S4CORE106_INST_EXPORT_10.zip'
-      - 'S4CORE106_INST_EXPORT_11.zip'
-      - 'S4CORE106_INST_EXPORT_12.zip'
-      - 'S4CORE106_INST_EXPORT_13.zip'
-      - 'S4CORE106_INST_EXPORT_14.zip'
-      - 'S4CORE106_INST_EXPORT_15.zip'
-      - 'S4CORE106_INST_EXPORT_16.zip'
-      - 'S4CORE106_INST_EXPORT_17.zip'
-      - 'S4CORE106_INST_EXPORT_18.zip'
-      - 'S4CORE106_INST_EXPORT_19.zip'
-      - 'S4CORE106_INST_EXPORT_20.zip'
-      - 'S4CORE106_INST_EXPORT_21.zip'
-      - 'S4CORE106_INST_EXPORT_22.zip'
-      - 'S4CORE106_INST_EXPORT_23.zip'
-      - 'S4CORE106_INST_EXPORT_24.zip'
-      - 'S4CORE106_INST_EXPORT_25.zip'
-      - 'S4CORE106_INST_EXPORT_26.zip'
-      - 'S4CORE106_INST_EXPORT_27.zip'
-      - 'S4CORE106_INST_EXPORT_28.zip'
-      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
 
   sap_s4hana_2020_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2020.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE105_INST_EXPORT_1.zip'
+      - 'S4CORE105_INST_EXPORT_2.zip'
+      - 'S4CORE105_INST_EXPORT_3.zip'
+      - 'S4CORE105_INST_EXPORT_4.zip'
+      - 'S4CORE105_INST_EXPORT_5.zip'
+      - 'S4CORE105_INST_EXPORT_6.zip'
+      - 'S4CORE105_INST_EXPORT_7.zip'
+      - 'S4CORE105_INST_EXPORT_8.zip'
+      - 'S4CORE105_INST_EXPORT_9.zip'
+      - 'S4CORE105_INST_EXPORT_10.zip'
+      - 'S4CORE105_INST_EXPORT_11.zip'
+      - 'S4CORE105_INST_EXPORT_12.zip'
+      - 'S4CORE105_INST_EXPORT_13.zip'
+      - 'S4CORE105_INST_EXPORT_14.zip'
+      - 'S4CORE105_INST_EXPORT_15.zip'
+      - 'S4CORE105_INST_EXPORT_16.zip'
+      - 'S4CORE105_INST_EXPORT_17.zip'
+      - 'S4CORE105_INST_EXPORT_18.zip'
+      - 'S4CORE105_INST_EXPORT_19.zip'
+      - 'S4CORE105_INST_EXPORT_20.zip'
+      - 'S4CORE105_INST_EXPORT_21.zip'
+      - 'S4CORE105_INST_EXPORT_22.zip'
+      - 'S4CORE105_INST_EXPORT_23.zip'
+      - 'S4CORE105_INST_EXPORT_24.zip'
+      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004822.SAR'
-      - 'S4CORE105_INST_EXPORT_1.zip'
-      - 'S4CORE105_INST_EXPORT_2.zip'
-      - 'S4CORE105_INST_EXPORT_3.zip'
-      - 'S4CORE105_INST_EXPORT_4.zip'
-      - 'S4CORE105_INST_EXPORT_5.zip'
-      - 'S4CORE105_INST_EXPORT_6.zip'
-      - 'S4CORE105_INST_EXPORT_7.zip'
-      - 'S4CORE105_INST_EXPORT_8.zip'
-      - 'S4CORE105_INST_EXPORT_9.zip'
-      - 'S4CORE105_INST_EXPORT_10.zip'
-      - 'S4CORE105_INST_EXPORT_11.zip'
-      - 'S4CORE105_INST_EXPORT_12.zip'
-      - 'S4CORE105_INST_EXPORT_13.zip'
-      - 'S4CORE105_INST_EXPORT_14.zip'
-      - 'S4CORE105_INST_EXPORT_15.zip'
-      - 'S4CORE105_INST_EXPORT_16.zip'
-      - 'S4CORE105_INST_EXPORT_17.zip'
-      - 'S4CORE105_INST_EXPORT_18.zip'
-      - 'S4CORE105_INST_EXPORT_19.zip'
-      - 'S4CORE105_INST_EXPORT_20.zip'
-      - 'S4CORE105_INST_EXPORT_21.zip'
-      - 'S4CORE105_INST_EXPORT_22.zip'
-      - 'S4CORE105_INST_EXPORT_23.zip'
-      - 'S4CORE105_INST_EXPORT_24.zip'
-      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004831.SAR'
-      - 'S4CORE105_INST_EXPORT_1.zip'
-      - 'S4CORE105_INST_EXPORT_2.zip'
-      - 'S4CORE105_INST_EXPORT_3.zip'
-      - 'S4CORE105_INST_EXPORT_4.zip'
-      - 'S4CORE105_INST_EXPORT_5.zip'
-      - 'S4CORE105_INST_EXPORT_6.zip'
-      - 'S4CORE105_INST_EXPORT_7.zip'
-      - 'S4CORE105_INST_EXPORT_8.zip'
-      - 'S4CORE105_INST_EXPORT_9.zip'
-      - 'S4CORE105_INST_EXPORT_10.zip'
-      - 'S4CORE105_INST_EXPORT_11.zip'
-      - 'S4CORE105_INST_EXPORT_12.zip'
-      - 'S4CORE105_INST_EXPORT_13.zip'
-      - 'S4CORE105_INST_EXPORT_14.zip'
-      - 'S4CORE105_INST_EXPORT_15.zip'
-      - 'S4CORE105_INST_EXPORT_16.zip'
-      - 'S4CORE105_INST_EXPORT_17.zip'
-      - 'S4CORE105_INST_EXPORT_18.zip'
-      - 'S4CORE105_INST_EXPORT_19.zip'
-      - 'S4CORE105_INST_EXPORT_20.zip'
-      - 'S4CORE105_INST_EXPORT_21.zip'
-      - 'S4CORE105_INST_EXPORT_22.zip'
-      - 'S4CORE105_INST_EXPORT_23.zip'
-      - 'S4CORE105_INST_EXPORT_24.zip'
-      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  sandbox:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
 
 
 #### Interactive Prompt Control Variables ####

--- a/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_extravars.yml
@@ -30,7 +30,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -129,41 +129,30 @@ sap_software_install_dictionary:
 
   sap_s4hana_2025_sandbox:
 
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
+    sap_software_list_x86_64:
       - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
       - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    # This list assigned from shared dictionary, because it is same with other products or host types.
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.CORE.HDB.ABAP
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
-      - maintenance_plan_stack_tms_config
-      - maintenance_plan_stack_spam_config
-      - maintenance_plan_stack_sum_config
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
     sap_swpm_inifile_dictionary:
-
       # SAP SWPM using SAP Maintenance Planner Stack XML
       # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
       sap_swpm_configure_tms: true
@@ -174,42 +163,24 @@ sap_software_install_dictionary:
 
 
   sap_s4hana_2023_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
+
+    sap_software_list_independent: []
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
-    # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2023.CORE.HDB.ABAP
 
-    # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
-      - maintenance_plan_stack_tms_config
-      - maintenance_plan_stack_spam_config
-      - maintenance_plan_stack_sum_config
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
     sap_swpm_inifile_dictionary:
-
       # SAP SWPM using SAP Maintenance Planner Stack XML
       # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
       sap_swpm_configure_tms: true
@@ -220,26 +191,22 @@ sap_software_install_dictionary:
 
 
   sap_s4hana_2022_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
+    sap_software_list_independent: []
+
+    # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
+
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
+
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
+
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2022.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
-      - maintenance_plan_stack_tms_config
-      - maintenance_plan_stack_spam_config
-      - maintenance_plan_stack_sum_config
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
     sap_swpm_inifile_dictionary:
 
@@ -253,26 +220,22 @@ sap_software_install_dictionary:
 
 
   sap_s4hana_2021_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
+    sap_software_list_independent: []
+
+    # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
+
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
+
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
+
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2021.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
-      - maintenance_plan_stack_tms_config
-      - maintenance_plan_stack_spam_config
-      - maintenance_plan_stack_sum_config
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
     sap_swpm_inifile_dictionary:
 
@@ -283,3 +246,34 @@ sap_software_install_dictionary:
       sap_swpm_spam_update: false
       sap_swpm_sum_prepare: true
       sap_swpm_sum_start: true
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  sandbox:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
+    - maintenance_plan_stack_tms_config
+    - maintenance_plan_stack_spam_config
+    - maintenance_plan_stack_sum_config
+
+# Dictionary of lists for software filename wildcard patterns that is used during rsync operations.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_software_wildcards:
+  hana:
+    - 'SAPCAR*'
+    - 'IMDB_*'
+    - 'SAPHOSTAGENT*'

--- a/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_playbook.yml
@@ -255,8 +255,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
         sap_software_download_mp_transaction: "{{ sap_maintenance_planner_transaction_name }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 

--- a/deploy_scenarios/sap_s4hana_sandbox_maintplan/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_maintplan/optional/ansible_extravars_interactive.yml
@@ -40,41 +40,30 @@ sap_software_install_dictionary:
 
   sap_s4hana_2025_sandbox:
 
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
+    sap_software_list_x86_64:
       - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
       - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    # This list assigned from shared dictionary, because it is same with other products or host types.
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.CORE.HDB.ABAP
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
-      - maintenance_plan_stack_tms_config
-      - maintenance_plan_stack_spam_config
-      - maintenance_plan_stack_sum_config
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
     sap_swpm_inifile_dictionary:
-
       # SAP SWPM using SAP Maintenance Planner Stack XML
       # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
       sap_swpm_configure_tms: true
@@ -85,42 +74,24 @@ sap_software_install_dictionary:
 
 
   sap_s4hana_2023_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
+
+    sap_software_list_independent: []
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
-    # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2023.CORE.HDB.ABAP
 
-    # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
-      - maintenance_plan_stack_tms_config
-      - maintenance_plan_stack_spam_config
-      - maintenance_plan_stack_sum_config
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
     sap_swpm_inifile_dictionary:
-
       # SAP SWPM using SAP Maintenance Planner Stack XML
       # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
       sap_swpm_configure_tms: true
@@ -131,26 +102,22 @@ sap_software_install_dictionary:
 
 
   sap_s4hana_2022_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
+    sap_software_list_independent: []
+
+    # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
+
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
+
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
+
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2022.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
-      - maintenance_plan_stack_tms_config
-      - maintenance_plan_stack_spam_config
-      - maintenance_plan_stack_sum_config
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
     sap_swpm_inifile_dictionary:
 
@@ -164,26 +131,22 @@ sap_software_install_dictionary:
 
 
   sap_s4hana_2021_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
+    sap_software_list_independent: []
+
+    # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
+
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
+
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
+
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2021.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
-      - maintenance_plan_stack_tms_config
-      - maintenance_plan_stack_spam_config
-      - maintenance_plan_stack_sum_config
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
     sap_swpm_inifile_dictionary:
 
@@ -195,6 +158,36 @@ sap_software_install_dictionary:
       sap_swpm_sum_prepare: true
       sap_swpm_sum_start: true
 
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  sandbox:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
+    - maintenance_plan_stack_tms_config
+    - maintenance_plan_stack_spam_config
+    - maintenance_plan_stack_sum_config
+
+# Dictionary of lists for software filename wildcard patterns that is used during rsync operations.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_software_wildcards:
+  hana:
+    - 'SAPCAR*'
+    - 'IMDB_*'
+    - 'SAPHOSTAGENT*'
 
 #### Interactive Prompt Control Variables ####
 # Do not change these variables unless you intend to modify the interactive prompt behavior!

--- a/deploy_scenarios/sap_s4hana_sandbox_syscopy/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_syscopy/ansible_extravars.yml
@@ -30,7 +30,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -97,9 +97,9 @@ sap_swpm_db_systemdb_password: ''  # Password for the SYSTEM user in the SAP HAN
 
 # System Copy restore from backup/export
 # Passwords are determined by backup file:
-sap_swpm_ddic_000_password: "ENTER_STRING_VALUE_HERE"  # Password for the DDIC user in client 000 of the Database Schema (String).
-sap_swpm_db_schema_abap_password: "ENTER_STRING_VALUE_HERE"  # Password for the ABAP schema user in the backup file (String).
-sap_swpm_backup_system_password: "ENTER_STRING_VALUE_HERE"  #  Password of user 'SYSTEM' inside the SAP HANA Tenant Database Schema (String).
+sap_swpm_ddic_000_password: ''  # Password for the DDIC user in client 000 of the Database Schema (String).
+sap_swpm_db_schema_abap_password: ''  # Password for the ABAP schema user in the backup file (String).
+sap_swpm_backup_system_password: ''  #  Password of user 'SYSTEM' inside the SAP HANA Tenant Database Schema (String).
 # Determined by backup file:
 sap_swpm_db_schema_abap: "ENTER_STRING_VALUE_HERE"  # Name of the ABAP schema contained in the SAP HANA Complete Data Backup files (String).
 sap_swpm_backup_location: "ENTER_STRING_VALUE_HERE"  # SAP HANA complete data backup files location (String).
@@ -140,179 +140,103 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.CORE.HDB.CP
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - credentials_syscopy
-      - db_config_hana
-      - db_connection_nw_hana
-      - db_restore_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      # Database
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
       - 'SAPPAAPL4_2405_0-80004547.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
-      # Media
-      - 'S4HANAOP109_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_INST_EXPORT_2.zip'
-      - 'S4HANAOP109_INST_EXPORT_3.zip'
-      - 'S4HANAOP109_INST_EXPORT_4.zip'
-      - 'S4HANAOP109_INST_EXPORT_5.zip'
-      - 'S4HANAOP109_INST_EXPORT_6.zip'
-      - 'S4HANAOP109_INST_EXPORT_7.zip'
-      - 'S4HANAOP109_INST_EXPORT_8.zip'
-      - 'S4HANAOP109_INST_EXPORT_9.zip'
-      - 'S4HANAOP109_INST_EXPORT_10.zip'
-      - 'S4HANAOP109_INST_EXPORT_11.zip'
-      - 'S4HANAOP109_INST_EXPORT_12.zip'
-      - 'S4HANAOP109_INST_EXPORT_13.zip'
-      - 'S4HANAOP109_INST_EXPORT_14.zip'
-      - 'S4HANAOP109_INST_EXPORT_15.zip'
-      - 'S4HANAOP109_INST_EXPORT_16.zip'
-      - 'S4HANAOP109_INST_EXPORT_17.zip'
-      - 'S4HANAOP109_INST_EXPORT_18.zip'
-      - 'S4HANAOP109_INST_EXPORT_19.zip'
-      - 'S4HANAOP109_INST_EXPORT_20.zip'
-      - 'S4HANAOP109_INST_EXPORT_21.zip'
-      - 'S4HANAOP109_INST_EXPORT_22.zip'
-      - 'S4HANAOP109_INST_EXPORT_23.zip'
-      - 'S4HANAOP109_INST_EXPORT_24.zip'
-      - 'S4HANAOP109_INST_EXPORT_25.zip'
-      - 'S4HANAOP109_INST_EXPORT_26.zip'
-      - 'S4HANAOP109_INST_EXPORT_27.zip'
-      - 'S4HANAOP109_INST_EXPORT_28.zip'
-      - 'S4HANAOP109_INST_EXPORT_29.zip'
-      - 'S4HANAOP109_INST_EXPORT_30.zip'
-      - 'S4HANAOP109_INST_EXPORT_31.zip'
-      - 'S4HANAOP109_INST_EXPORT_32.zip'
-      - 'S4HANAOP109_INST_EXPORT_33.zip'
-      - 'S4HANAOP109_INST_EXPORT_34.zip'
-      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_ERP_LANG_EN.SAR'
       - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007716.EXE'
       - 'SWPM20SP23_2-80003424.SAR'
       # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
-      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
-      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
       - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
-      # Media
-      - 'S4HANAOP109_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_INST_EXPORT_2.zip'
-      - 'S4HANAOP109_INST_EXPORT_3.zip'
-      - 'S4HANAOP109_INST_EXPORT_4.zip'
-      - 'S4HANAOP109_INST_EXPORT_5.zip'
-      - 'S4HANAOP109_INST_EXPORT_6.zip'
-      - 'S4HANAOP109_INST_EXPORT_7.zip'
-      - 'S4HANAOP109_INST_EXPORT_8.zip'
-      - 'S4HANAOP109_INST_EXPORT_9.zip'
-      - 'S4HANAOP109_INST_EXPORT_10.zip'
-      - 'S4HANAOP109_INST_EXPORT_11.zip'
-      - 'S4HANAOP109_INST_EXPORT_12.zip'
-      - 'S4HANAOP109_INST_EXPORT_13.zip'
-      - 'S4HANAOP109_INST_EXPORT_14.zip'
-      - 'S4HANAOP109_INST_EXPORT_15.zip'
-      - 'S4HANAOP109_INST_EXPORT_16.zip'
-      - 'S4HANAOP109_INST_EXPORT_17.zip'
-      - 'S4HANAOP109_INST_EXPORT_18.zip'
-      - 'S4HANAOP109_INST_EXPORT_19.zip'
-      - 'S4HANAOP109_INST_EXPORT_20.zip'
-      - 'S4HANAOP109_INST_EXPORT_21.zip'
-      - 'S4HANAOP109_INST_EXPORT_22.zip'
-      - 'S4HANAOP109_INST_EXPORT_23.zip'
-      - 'S4HANAOP109_INST_EXPORT_24.zip'
-      - 'S4HANAOP109_INST_EXPORT_25.zip'
-      - 'S4HANAOP109_INST_EXPORT_26.zip'
-      - 'S4HANAOP109_INST_EXPORT_27.zip'
-      - 'S4HANAOP109_INST_EXPORT_28.zip'
-      - 'S4HANAOP109_INST_EXPORT_29.zip'
-      - 'S4HANAOP109_INST_EXPORT_30.zip'
-      - 'S4HANAOP109_INST_EXPORT_31.zip'
-      - 'S4HANAOP109_INST_EXPORT_32.zip'
-      - 'S4HANAOP109_INST_EXPORT_33.zip'
-      - 'S4HANAOP109_INST_EXPORT_34.zip'
-      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_ERP_LANG_EN.SAR'
       - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007726.EXE'
       - 'SWPM20SP23_2-80003426.SAR'
-      # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
-      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
-      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
 
 
   sap_s4hana_2023_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2023.CORE.HDB.CP
 
-    # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - credentials_syscopy
-      - db_config_hana
-      - db_connection_nw_hana
-      - db_restore_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      # Database
-      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
-      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
-      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
-      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
-      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
-      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
-      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+    sap_software_list_independent:
+      # Application Media
       - 'S4CORE108_INST_EXPORT_1.zip'
       - 'S4CORE108_INST_EXPORT_2.zip'
       - 'S4CORE108_INST_EXPORT_3.zip'
@@ -345,57 +269,36 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
-      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Application Server
       - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
+      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
+      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
+      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+      - 'igsexe_4-70005417.sar' # IGS 7.81
       # Tools
       - 'SAPCAR_1300-70007716.EXE'
       - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
       - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
-      - 'S4CORE108_INST_EXPORT_1.zip'
-      - 'S4CORE108_INST_EXPORT_2.zip'
-      - 'S4CORE108_INST_EXPORT_3.zip'
-      - 'S4CORE108_INST_EXPORT_4.zip'
-      - 'S4CORE108_INST_EXPORT_5.zip'
-      - 'S4CORE108_INST_EXPORT_6.zip'
-      - 'S4CORE108_INST_EXPORT_7.zip'
-      - 'S4CORE108_INST_EXPORT_8.zip'
-      - 'S4CORE108_INST_EXPORT_9.zip'
-      - 'S4CORE108_INST_EXPORT_10.zip'
-      - 'S4CORE108_INST_EXPORT_11.zip'
-      - 'S4CORE108_INST_EXPORT_12.zip'
-      - 'S4CORE108_INST_EXPORT_13.zip'
-      - 'S4CORE108_INST_EXPORT_14.zip'
-      - 'S4CORE108_INST_EXPORT_15.zip'
-      - 'S4CORE108_INST_EXPORT_16.zip'
-      - 'S4CORE108_INST_EXPORT_17.zip'
-      - 'S4CORE108_INST_EXPORT_18.zip'
-      - 'S4CORE108_INST_EXPORT_19.zip'
-      - 'S4CORE108_INST_EXPORT_20.zip'
-      - 'S4CORE108_INST_EXPORT_21.zip'
-      - 'S4CORE108_INST_EXPORT_22.zip'
-      - 'S4CORE108_INST_EXPORT_23.zip'
-      - 'S4CORE108_INST_EXPORT_24.zip'
-      - 'S4CORE108_INST_EXPORT_25.zip'
-      - 'S4CORE108_INST_EXPORT_26.zip'
-      - 'S4CORE108_INST_EXPORT_27.zip'
-      - 'S4CORE108_INST_EXPORT_28.zip'
-      - 'S4CORE108_INST_EXPORT_29.zip'
-      - 'S4CORE108_INST_EXPORT_30.zip'
-      - 'S4HANAOP108_ERP_LANG_EN.SAR'
-      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
       - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
       # Tools
       - 'SAPCAR_1300-70007726.EXE'
       - 'SWPM20SP20_1-80003426.SAR'
@@ -403,322 +306,242 @@ sap_software_install_dictionary:
 
 
   sap_s4hana_2022_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2022.CORE.HDB.CP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - credentials_syscopy
-      - db_config_hana
-      - db_connection_nw_hana
-      - db_restore_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE107_INST_EXPORT_1.zip'
+      - 'S4CORE107_INST_EXPORT_2.zip'
+      - 'S4CORE107_INST_EXPORT_3.zip'
+      - 'S4CORE107_INST_EXPORT_4.zip'
+      - 'S4CORE107_INST_EXPORT_5.zip'
+      - 'S4CORE107_INST_EXPORT_6.zip'
+      - 'S4CORE107_INST_EXPORT_7.zip'
+      - 'S4CORE107_INST_EXPORT_8.zip'
+      - 'S4CORE107_INST_EXPORT_9.zip'
+      - 'S4CORE107_INST_EXPORT_10.zip'
+      - 'S4CORE107_INST_EXPORT_11.zip'
+      - 'S4CORE107_INST_EXPORT_12.zip'
+      - 'S4CORE107_INST_EXPORT_13.zip'
+      - 'S4CORE107_INST_EXPORT_14.zip'
+      - 'S4CORE107_INST_EXPORT_15.zip'
+      - 'S4CORE107_INST_EXPORT_16.zip'
+      - 'S4CORE107_INST_EXPORT_17.zip'
+      - 'S4CORE107_INST_EXPORT_18.zip'
+      - 'S4CORE107_INST_EXPORT_19.zip'
+      - 'S4CORE107_INST_EXPORT_20.zip'
+      - 'S4CORE107_INST_EXPORT_21.zip'
+      - 'S4CORE107_INST_EXPORT_22.zip'
+      - 'S4CORE107_INST_EXPORT_23.zip'
+      - 'S4CORE107_INST_EXPORT_24.zip'
+      - 'S4CORE107_INST_EXPORT_25.zip'
+      - 'S4CORE107_INST_EXPORT_26.zip'
+      - 'S4CORE107_INST_EXPORT_27.zip'
+      - 'S4CORE107_INST_EXPORT_28.zip'
+      - 'S4CORE107_INST_EXPORT_29.zip'
+      - 'S4CORE107_INST_EXPORT_30.zip'
+      - 'S4HANAOP107_ERP_LANG_EN.SAR'
+      # - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
+      # - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_51-70006642.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006641.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
-      - 'S4CORE107_INST_EXPORT_1.zip'
-      - 'S4CORE107_INST_EXPORT_2.zip'
-      - 'S4CORE107_INST_EXPORT_3.zip'
-      - 'S4CORE107_INST_EXPORT_4.zip'
-      - 'S4CORE107_INST_EXPORT_5.zip'
-      - 'S4CORE107_INST_EXPORT_6.zip'
-      - 'S4CORE107_INST_EXPORT_7.zip'
-      - 'S4CORE107_INST_EXPORT_8.zip'
-      - 'S4CORE107_INST_EXPORT_9.zip'
-      - 'S4CORE107_INST_EXPORT_10.zip'
-      - 'S4CORE107_INST_EXPORT_11.zip'
-      - 'S4CORE107_INST_EXPORT_12.zip'
-      - 'S4CORE107_INST_EXPORT_13.zip'
-      - 'S4CORE107_INST_EXPORT_14.zip'
-      - 'S4CORE107_INST_EXPORT_15.zip'
-      - 'S4CORE107_INST_EXPORT_16.zip'
-      - 'S4CORE107_INST_EXPORT_17.zip'
-      - 'S4CORE107_INST_EXPORT_18.zip'
-      - 'S4CORE107_INST_EXPORT_19.zip'
-      - 'S4CORE107_INST_EXPORT_20.zip'
-      - 'S4CORE107_INST_EXPORT_21.zip'
-      - 'S4CORE107_INST_EXPORT_22.zip'
-      - 'S4CORE107_INST_EXPORT_23.zip'
-      - 'S4CORE107_INST_EXPORT_24.zip'
-      - 'S4CORE107_INST_EXPORT_25.zip'
-      - 'S4CORE107_INST_EXPORT_26.zip'
-      - 'S4CORE107_INST_EXPORT_27.zip'
-      - 'S4CORE107_INST_EXPORT_28.zip'
-      - 'S4CORE107_INST_EXPORT_29.zip'
-      - 'S4CORE107_INST_EXPORT_30.zip'
-      - 'S4HANAOP107_ERP_LANG_EN.SAR'
-      # - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
-      # - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
+      - 'igsexe_4-70005417.sar' # IGS 7.81
       # - 'SAPPAAPL4_2203_2-80004547.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_51-70006667.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006666.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
-      - 'S4CORE107_INST_EXPORT_1.zip'
-      - 'S4CORE107_INST_EXPORT_2.zip'
-      - 'S4CORE107_INST_EXPORT_3.zip'
-      - 'S4CORE107_INST_EXPORT_4.zip'
-      - 'S4CORE107_INST_EXPORT_5.zip'
-      - 'S4CORE107_INST_EXPORT_6.zip'
-      - 'S4CORE107_INST_EXPORT_7.zip'
-      - 'S4CORE107_INST_EXPORT_8.zip'
-      - 'S4CORE107_INST_EXPORT_9.zip'
-      - 'S4CORE107_INST_EXPORT_10.zip'
-      - 'S4CORE107_INST_EXPORT_11.zip'
-      - 'S4CORE107_INST_EXPORT_12.zip'
-      - 'S4CORE107_INST_EXPORT_13.zip'
-      - 'S4CORE107_INST_EXPORT_14.zip'
-      - 'S4CORE107_INST_EXPORT_15.zip'
-      - 'S4CORE107_INST_EXPORT_16.zip'
-      - 'S4CORE107_INST_EXPORT_17.zip'
-      - 'S4CORE107_INST_EXPORT_18.zip'
-      - 'S4CORE107_INST_EXPORT_19.zip'
-      - 'S4CORE107_INST_EXPORT_20.zip'
-      - 'S4CORE107_INST_EXPORT_21.zip'
-      - 'S4CORE107_INST_EXPORT_22.zip'
-      - 'S4CORE107_INST_EXPORT_23.zip'
-      - 'S4CORE107_INST_EXPORT_24.zip'
-      - 'S4CORE107_INST_EXPORT_25.zip'
-      - 'S4CORE107_INST_EXPORT_26.zip'
-      - 'S4CORE107_INST_EXPORT_27.zip'
-      - 'S4CORE107_INST_EXPORT_28.zip'
-      - 'S4CORE107_INST_EXPORT_29.zip'
-      - 'S4CORE107_INST_EXPORT_30.zip'
-      - 'S4HANAOP107_ERP_LANG_EN.SAR'
-      # - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
-      # - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
+      - 'igsexe_4-70005446.sar' # IGS 7.81
       # - 'SAPPAAPL4_2203_2-80004546.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
       # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
 
   sap_s4hana_2021_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2021.CORE.HDB.CP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - credentials_syscopy
-      - db_config_hana
-      - db_connection_nw_hana
-      - db_restore_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE106_INST_EXPORT_1.zip'
+      - 'S4CORE106_INST_EXPORT_2.zip'
+      - 'S4CORE106_INST_EXPORT_3.zip'
+      - 'S4CORE106_INST_EXPORT_4.zip'
+      - 'S4CORE106_INST_EXPORT_5.zip'
+      - 'S4CORE106_INST_EXPORT_6.zip'
+      - 'S4CORE106_INST_EXPORT_7.zip'
+      - 'S4CORE106_INST_EXPORT_8.zip'
+      - 'S4CORE106_INST_EXPORT_9.zip'
+      - 'S4CORE106_INST_EXPORT_10.zip'
+      - 'S4CORE106_INST_EXPORT_11.zip'
+      - 'S4CORE106_INST_EXPORT_12.zip'
+      - 'S4CORE106_INST_EXPORT_13.zip'
+      - 'S4CORE106_INST_EXPORT_14.zip'
+      - 'S4CORE106_INST_EXPORT_15.zip'
+      - 'S4CORE106_INST_EXPORT_16.zip'
+      - 'S4CORE106_INST_EXPORT_17.zip'
+      - 'S4CORE106_INST_EXPORT_18.zip'
+      - 'S4CORE106_INST_EXPORT_19.zip'
+      - 'S4CORE106_INST_EXPORT_20.zip'
+      - 'S4CORE106_INST_EXPORT_21.zip'
+      - 'S4CORE106_INST_EXPORT_22.zip'
+      - 'S4CORE106_INST_EXPORT_23.zip'
+      - 'S4CORE106_INST_EXPORT_24.zip'
+      - 'S4CORE106_INST_EXPORT_25.zip'
+      - 'S4CORE106_INST_EXPORT_26.zip'
+      - 'S4CORE106_INST_EXPORT_27.zip'
+      - 'S4CORE106_INST_EXPORT_28.zip'
+      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004822.SAR'
-      - 'S4CORE106_INST_EXPORT_1.zip'
-      - 'S4CORE106_INST_EXPORT_2.zip'
-      - 'S4CORE106_INST_EXPORT_3.zip'
-      - 'S4CORE106_INST_EXPORT_4.zip'
-      - 'S4CORE106_INST_EXPORT_5.zip'
-      - 'S4CORE106_INST_EXPORT_6.zip'
-      - 'S4CORE106_INST_EXPORT_7.zip'
-      - 'S4CORE106_INST_EXPORT_8.zip'
-      - 'S4CORE106_INST_EXPORT_9.zip'
-      - 'S4CORE106_INST_EXPORT_10.zip'
-      - 'S4CORE106_INST_EXPORT_11.zip'
-      - 'S4CORE106_INST_EXPORT_12.zip'
-      - 'S4CORE106_INST_EXPORT_13.zip'
-      - 'S4CORE106_INST_EXPORT_14.zip'
-      - 'S4CORE106_INST_EXPORT_15.zip'
-      - 'S4CORE106_INST_EXPORT_16.zip'
-      - 'S4CORE106_INST_EXPORT_17.zip'
-      - 'S4CORE106_INST_EXPORT_18.zip'
-      - 'S4CORE106_INST_EXPORT_19.zip'
-      - 'S4CORE106_INST_EXPORT_20.zip'
-      - 'S4CORE106_INST_EXPORT_21.zip'
-      - 'S4CORE106_INST_EXPORT_22.zip'
-      - 'S4CORE106_INST_EXPORT_23.zip'
-      - 'S4CORE106_INST_EXPORT_24.zip'
-      - 'S4CORE106_INST_EXPORT_25.zip'
-      - 'S4CORE106_INST_EXPORT_26.zip'
-      - 'S4CORE106_INST_EXPORT_27.zip'
-      - 'S4CORE106_INST_EXPORT_28.zip'
-      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004831.SAR'
-      - 'S4CORE106_INST_EXPORT_1.zip'
-      - 'S4CORE106_INST_EXPORT_2.zip'
-      - 'S4CORE106_INST_EXPORT_3.zip'
-      - 'S4CORE106_INST_EXPORT_4.zip'
-      - 'S4CORE106_INST_EXPORT_5.zip'
-      - 'S4CORE106_INST_EXPORT_6.zip'
-      - 'S4CORE106_INST_EXPORT_7.zip'
-      - 'S4CORE106_INST_EXPORT_8.zip'
-      - 'S4CORE106_INST_EXPORT_9.zip'
-      - 'S4CORE106_INST_EXPORT_10.zip'
-      - 'S4CORE106_INST_EXPORT_11.zip'
-      - 'S4CORE106_INST_EXPORT_12.zip'
-      - 'S4CORE106_INST_EXPORT_13.zip'
-      - 'S4CORE106_INST_EXPORT_14.zip'
-      - 'S4CORE106_INST_EXPORT_15.zip'
-      - 'S4CORE106_INST_EXPORT_16.zip'
-      - 'S4CORE106_INST_EXPORT_17.zip'
-      - 'S4CORE106_INST_EXPORT_18.zip'
-      - 'S4CORE106_INST_EXPORT_19.zip'
-      - 'S4CORE106_INST_EXPORT_20.zip'
-      - 'S4CORE106_INST_EXPORT_21.zip'
-      - 'S4CORE106_INST_EXPORT_22.zip'
-      - 'S4CORE106_INST_EXPORT_23.zip'
-      - 'S4CORE106_INST_EXPORT_24.zip'
-      - 'S4CORE106_INST_EXPORT_25.zip'
-      - 'S4CORE106_INST_EXPORT_26.zip'
-      - 'S4CORE106_INST_EXPORT_27.zip'
-      - 'S4CORE106_INST_EXPORT_28.zip'
-      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
 
   sap_s4hana_2020_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2020.CORE.HDB.CP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - credentials_syscopy
-      - db_config_hana
-      - db_connection_nw_hana
-      - db_restore_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE105_INST_EXPORT_1.zip'
+      - 'S4CORE105_INST_EXPORT_2.zip'
+      - 'S4CORE105_INST_EXPORT_3.zip'
+      - 'S4CORE105_INST_EXPORT_4.zip'
+      - 'S4CORE105_INST_EXPORT_5.zip'
+      - 'S4CORE105_INST_EXPORT_6.zip'
+      - 'S4CORE105_INST_EXPORT_7.zip'
+      - 'S4CORE105_INST_EXPORT_8.zip'
+      - 'S4CORE105_INST_EXPORT_9.zip'
+      - 'S4CORE105_INST_EXPORT_10.zip'
+      - 'S4CORE105_INST_EXPORT_11.zip'
+      - 'S4CORE105_INST_EXPORT_12.zip'
+      - 'S4CORE105_INST_EXPORT_13.zip'
+      - 'S4CORE105_INST_EXPORT_14.zip'
+      - 'S4CORE105_INST_EXPORT_15.zip'
+      - 'S4CORE105_INST_EXPORT_16.zip'
+      - 'S4CORE105_INST_EXPORT_17.zip'
+      - 'S4CORE105_INST_EXPORT_18.zip'
+      - 'S4CORE105_INST_EXPORT_19.zip'
+      - 'S4CORE105_INST_EXPORT_20.zip'
+      - 'S4CORE105_INST_EXPORT_21.zip'
+      - 'S4CORE105_INST_EXPORT_22.zip'
+      - 'S4CORE105_INST_EXPORT_23.zip'
+      - 'S4CORE105_INST_EXPORT_24.zip'
+      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004822.SAR'
-      - 'S4CORE105_INST_EXPORT_1.zip'
-      - 'S4CORE105_INST_EXPORT_2.zip'
-      - 'S4CORE105_INST_EXPORT_3.zip'
-      - 'S4CORE105_INST_EXPORT_4.zip'
-      - 'S4CORE105_INST_EXPORT_5.zip'
-      - 'S4CORE105_INST_EXPORT_6.zip'
-      - 'S4CORE105_INST_EXPORT_7.zip'
-      - 'S4CORE105_INST_EXPORT_8.zip'
-      - 'S4CORE105_INST_EXPORT_9.zip'
-      - 'S4CORE105_INST_EXPORT_10.zip'
-      - 'S4CORE105_INST_EXPORT_11.zip'
-      - 'S4CORE105_INST_EXPORT_12.zip'
-      - 'S4CORE105_INST_EXPORT_13.zip'
-      - 'S4CORE105_INST_EXPORT_14.zip'
-      - 'S4CORE105_INST_EXPORT_15.zip'
-      - 'S4CORE105_INST_EXPORT_16.zip'
-      - 'S4CORE105_INST_EXPORT_17.zip'
-      - 'S4CORE105_INST_EXPORT_18.zip'
-      - 'S4CORE105_INST_EXPORT_19.zip'
-      - 'S4CORE105_INST_EXPORT_20.zip'
-      - 'S4CORE105_INST_EXPORT_21.zip'
-      - 'S4CORE105_INST_EXPORT_22.zip'
-      - 'S4CORE105_INST_EXPORT_23.zip'
-      - 'S4CORE105_INST_EXPORT_24.zip'
-      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004831.SAR'
-      - 'S4CORE105_INST_EXPORT_1.zip'
-      - 'S4CORE105_INST_EXPORT_2.zip'
-      - 'S4CORE105_INST_EXPORT_3.zip'
-      - 'S4CORE105_INST_EXPORT_4.zip'
-      - 'S4CORE105_INST_EXPORT_5.zip'
-      - 'S4CORE105_INST_EXPORT_6.zip'
-      - 'S4CORE105_INST_EXPORT_7.zip'
-      - 'S4CORE105_INST_EXPORT_8.zip'
-      - 'S4CORE105_INST_EXPORT_9.zip'
-      - 'S4CORE105_INST_EXPORT_10.zip'
-      - 'S4CORE105_INST_EXPORT_11.zip'
-      - 'S4CORE105_INST_EXPORT_12.zip'
-      - 'S4CORE105_INST_EXPORT_13.zip'
-      - 'S4CORE105_INST_EXPORT_14.zip'
-      - 'S4CORE105_INST_EXPORT_15.zip'
-      - 'S4CORE105_INST_EXPORT_16.zip'
-      - 'S4CORE105_INST_EXPORT_17.zip'
-      - 'S4CORE105_INST_EXPORT_18.zip'
-      - 'S4CORE105_INST_EXPORT_19.zip'
-      - 'S4CORE105_INST_EXPORT_20.zip'
-      - 'S4CORE105_INST_EXPORT_21.zip'
-      - 'S4CORE105_INST_EXPORT_22.zip'
-      - 'S4CORE105_INST_EXPORT_23.zip'
-      - 'S4CORE105_INST_EXPORT_24.zip'
-      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  sandbox:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - credentials_syscopy
+    - db_config_hana
+    - db_connection_nw_hana
+    - db_restore_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user

--- a/deploy_scenarios/sap_s4hana_sandbox_syscopy/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_syscopy/ansible_playbook.yml
@@ -255,8 +255,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 

--- a/deploy_scenarios/sap_s4hana_sandbox_syscopy/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_syscopy/optional/ansible_extravars_interactive.yml
@@ -38,177 +38,103 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.CORE.HDB.CP
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - credentials_syscopy
-      - db_config_hana
-      - db_connection_nw_hana
-      - db_restore_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      # Database
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
       - 'SAPPAAPL4_2405_0-80004547.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
-      # Media
-      - 'S4HANAOP109_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_INST_EXPORT_2.zip'
-      - 'S4HANAOP109_INST_EXPORT_3.zip'
-      - 'S4HANAOP109_INST_EXPORT_4.zip'
-      - 'S4HANAOP109_INST_EXPORT_5.zip'
-      - 'S4HANAOP109_INST_EXPORT_6.zip'
-      - 'S4HANAOP109_INST_EXPORT_7.zip'
-      - 'S4HANAOP109_INST_EXPORT_8.zip'
-      - 'S4HANAOP109_INST_EXPORT_9.zip'
-      - 'S4HANAOP109_INST_EXPORT_10.zip'
-      - 'S4HANAOP109_INST_EXPORT_11.zip'
-      - 'S4HANAOP109_INST_EXPORT_12.zip'
-      - 'S4HANAOP109_INST_EXPORT_13.zip'
-      - 'S4HANAOP109_INST_EXPORT_14.zip'
-      - 'S4HANAOP109_INST_EXPORT_15.zip'
-      - 'S4HANAOP109_INST_EXPORT_16.zip'
-      - 'S4HANAOP109_INST_EXPORT_17.zip'
-      - 'S4HANAOP109_INST_EXPORT_18.zip'
-      - 'S4HANAOP109_INST_EXPORT_19.zip'
-      - 'S4HANAOP109_INST_EXPORT_20.zip'
-      - 'S4HANAOP109_INST_EXPORT_21.zip'
-      - 'S4HANAOP109_INST_EXPORT_22.zip'
-      - 'S4HANAOP109_INST_EXPORT_23.zip'
-      - 'S4HANAOP109_INST_EXPORT_24.zip'
-      - 'S4HANAOP109_INST_EXPORT_25.zip'
-      - 'S4HANAOP109_INST_EXPORT_26.zip'
-      - 'S4HANAOP109_INST_EXPORT_27.zip'
-      - 'S4HANAOP109_INST_EXPORT_28.zip'
-      - 'S4HANAOP109_INST_EXPORT_29.zip'
-      - 'S4HANAOP109_INST_EXPORT_30.zip'
-      - 'S4HANAOP109_INST_EXPORT_31.zip'
-      - 'S4HANAOP109_INST_EXPORT_32.zip'
-      - 'S4HANAOP109_INST_EXPORT_33.zip'
-      - 'S4HANAOP109_INST_EXPORT_34.zip'
-      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_ERP_LANG_EN.SAR'
       - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007716.EXE'
       - 'SWPM20SP23_2-80003424.SAR'
       # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
-      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
-      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
       - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
-      # Media
-      - 'S4HANAOP109_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_INST_EXPORT_2.zip'
-      - 'S4HANAOP109_INST_EXPORT_3.zip'
-      - 'S4HANAOP109_INST_EXPORT_4.zip'
-      - 'S4HANAOP109_INST_EXPORT_5.zip'
-      - 'S4HANAOP109_INST_EXPORT_6.zip'
-      - 'S4HANAOP109_INST_EXPORT_7.zip'
-      - 'S4HANAOP109_INST_EXPORT_8.zip'
-      - 'S4HANAOP109_INST_EXPORT_9.zip'
-      - 'S4HANAOP109_INST_EXPORT_10.zip'
-      - 'S4HANAOP109_INST_EXPORT_11.zip'
-      - 'S4HANAOP109_INST_EXPORT_12.zip'
-      - 'S4HANAOP109_INST_EXPORT_13.zip'
-      - 'S4HANAOP109_INST_EXPORT_14.zip'
-      - 'S4HANAOP109_INST_EXPORT_15.zip'
-      - 'S4HANAOP109_INST_EXPORT_16.zip'
-      - 'S4HANAOP109_INST_EXPORT_17.zip'
-      - 'S4HANAOP109_INST_EXPORT_18.zip'
-      - 'S4HANAOP109_INST_EXPORT_19.zip'
-      - 'S4HANAOP109_INST_EXPORT_20.zip'
-      - 'S4HANAOP109_INST_EXPORT_21.zip'
-      - 'S4HANAOP109_INST_EXPORT_22.zip'
-      - 'S4HANAOP109_INST_EXPORT_23.zip'
-      - 'S4HANAOP109_INST_EXPORT_24.zip'
-      - 'S4HANAOP109_INST_EXPORT_25.zip'
-      - 'S4HANAOP109_INST_EXPORT_26.zip'
-      - 'S4HANAOP109_INST_EXPORT_27.zip'
-      - 'S4HANAOP109_INST_EXPORT_28.zip'
-      - 'S4HANAOP109_INST_EXPORT_29.zip'
-      - 'S4HANAOP109_INST_EXPORT_30.zip'
-      - 'S4HANAOP109_INST_EXPORT_31.zip'
-      - 'S4HANAOP109_INST_EXPORT_32.zip'
-      - 'S4HANAOP109_INST_EXPORT_33.zip'
-      - 'S4HANAOP109_INST_EXPORT_34.zip'
-      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_ERP_LANG_EN.SAR'
       - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007726.EXE'
       - 'SWPM20SP23_2-80003426.SAR'
-      # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
-      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
-      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
 
 
   sap_s4hana_2023_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # SWPM product catalog ID for the installation (String).
-    sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2023.CORE.HDB.ABAP
+    sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2023.CORE.HDB.CP
 
-    # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      # Database
-      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
-      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
-      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
-      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
-      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
-      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
-      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+    sap_software_list_independent:
+      # Application Media
       - 'S4CORE108_INST_EXPORT_1.zip'
       - 'S4CORE108_INST_EXPORT_2.zip'
       - 'S4CORE108_INST_EXPORT_3.zip'
@@ -241,57 +167,36 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
-      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Application Server
       - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
+      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
+      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
+      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+      - 'igsexe_4-70005417.sar' # IGS 7.81
       # Tools
       - 'SAPCAR_1300-70007716.EXE'
       - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
       - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
-      - 'S4CORE108_INST_EXPORT_1.zip'
-      - 'S4CORE108_INST_EXPORT_2.zip'
-      - 'S4CORE108_INST_EXPORT_3.zip'
-      - 'S4CORE108_INST_EXPORT_4.zip'
-      - 'S4CORE108_INST_EXPORT_5.zip'
-      - 'S4CORE108_INST_EXPORT_6.zip'
-      - 'S4CORE108_INST_EXPORT_7.zip'
-      - 'S4CORE108_INST_EXPORT_8.zip'
-      - 'S4CORE108_INST_EXPORT_9.zip'
-      - 'S4CORE108_INST_EXPORT_10.zip'
-      - 'S4CORE108_INST_EXPORT_11.zip'
-      - 'S4CORE108_INST_EXPORT_12.zip'
-      - 'S4CORE108_INST_EXPORT_13.zip'
-      - 'S4CORE108_INST_EXPORT_14.zip'
-      - 'S4CORE108_INST_EXPORT_15.zip'
-      - 'S4CORE108_INST_EXPORT_16.zip'
-      - 'S4CORE108_INST_EXPORT_17.zip'
-      - 'S4CORE108_INST_EXPORT_18.zip'
-      - 'S4CORE108_INST_EXPORT_19.zip'
-      - 'S4CORE108_INST_EXPORT_20.zip'
-      - 'S4CORE108_INST_EXPORT_21.zip'
-      - 'S4CORE108_INST_EXPORT_22.zip'
-      - 'S4CORE108_INST_EXPORT_23.zip'
-      - 'S4CORE108_INST_EXPORT_24.zip'
-      - 'S4CORE108_INST_EXPORT_25.zip'
-      - 'S4CORE108_INST_EXPORT_26.zip'
-      - 'S4CORE108_INST_EXPORT_27.zip'
-      - 'S4CORE108_INST_EXPORT_28.zip'
-      - 'S4CORE108_INST_EXPORT_29.zip'
-      - 'S4CORE108_INST_EXPORT_30.zip'
-      - 'S4HANAOP108_ERP_LANG_EN.SAR'
-      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
       - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
       # Tools
       - 'SAPCAR_1300-70007726.EXE'
       - 'SWPM20SP20_1-80003426.SAR'
@@ -299,319 +204,245 @@ sap_software_install_dictionary:
 
 
   sap_s4hana_2022_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
-    sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2022.CORE.HDB.ABAP
+    sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2022.CORE.HDB.CP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE107_INST_EXPORT_1.zip'
+      - 'S4CORE107_INST_EXPORT_2.zip'
+      - 'S4CORE107_INST_EXPORT_3.zip'
+      - 'S4CORE107_INST_EXPORT_4.zip'
+      - 'S4CORE107_INST_EXPORT_5.zip'
+      - 'S4CORE107_INST_EXPORT_6.zip'
+      - 'S4CORE107_INST_EXPORT_7.zip'
+      - 'S4CORE107_INST_EXPORT_8.zip'
+      - 'S4CORE107_INST_EXPORT_9.zip'
+      - 'S4CORE107_INST_EXPORT_10.zip'
+      - 'S4CORE107_INST_EXPORT_11.zip'
+      - 'S4CORE107_INST_EXPORT_12.zip'
+      - 'S4CORE107_INST_EXPORT_13.zip'
+      - 'S4CORE107_INST_EXPORT_14.zip'
+      - 'S4CORE107_INST_EXPORT_15.zip'
+      - 'S4CORE107_INST_EXPORT_16.zip'
+      - 'S4CORE107_INST_EXPORT_17.zip'
+      - 'S4CORE107_INST_EXPORT_18.zip'
+      - 'S4CORE107_INST_EXPORT_19.zip'
+      - 'S4CORE107_INST_EXPORT_20.zip'
+      - 'S4CORE107_INST_EXPORT_21.zip'
+      - 'S4CORE107_INST_EXPORT_22.zip'
+      - 'S4CORE107_INST_EXPORT_23.zip'
+      - 'S4CORE107_INST_EXPORT_24.zip'
+      - 'S4CORE107_INST_EXPORT_25.zip'
+      - 'S4CORE107_INST_EXPORT_26.zip'
+      - 'S4CORE107_INST_EXPORT_27.zip'
+      - 'S4CORE107_INST_EXPORT_28.zip'
+      - 'S4CORE107_INST_EXPORT_29.zip'
+      - 'S4CORE107_INST_EXPORT_30.zip'
+      - 'S4HANAOP107_ERP_LANG_EN.SAR'
+      # - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
+      # - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_51-70006642.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006641.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
-      - 'S4CORE107_INST_EXPORT_1.zip'
-      - 'S4CORE107_INST_EXPORT_2.zip'
-      - 'S4CORE107_INST_EXPORT_3.zip'
-      - 'S4CORE107_INST_EXPORT_4.zip'
-      - 'S4CORE107_INST_EXPORT_5.zip'
-      - 'S4CORE107_INST_EXPORT_6.zip'
-      - 'S4CORE107_INST_EXPORT_7.zip'
-      - 'S4CORE107_INST_EXPORT_8.zip'
-      - 'S4CORE107_INST_EXPORT_9.zip'
-      - 'S4CORE107_INST_EXPORT_10.zip'
-      - 'S4CORE107_INST_EXPORT_11.zip'
-      - 'S4CORE107_INST_EXPORT_12.zip'
-      - 'S4CORE107_INST_EXPORT_13.zip'
-      - 'S4CORE107_INST_EXPORT_14.zip'
-      - 'S4CORE107_INST_EXPORT_15.zip'
-      - 'S4CORE107_INST_EXPORT_16.zip'
-      - 'S4CORE107_INST_EXPORT_17.zip'
-      - 'S4CORE107_INST_EXPORT_18.zip'
-      - 'S4CORE107_INST_EXPORT_19.zip'
-      - 'S4CORE107_INST_EXPORT_20.zip'
-      - 'S4CORE107_INST_EXPORT_21.zip'
-      - 'S4CORE107_INST_EXPORT_22.zip'
-      - 'S4CORE107_INST_EXPORT_23.zip'
-      - 'S4CORE107_INST_EXPORT_24.zip'
-      - 'S4CORE107_INST_EXPORT_25.zip'
-      - 'S4CORE107_INST_EXPORT_26.zip'
-      - 'S4CORE107_INST_EXPORT_27.zip'
-      - 'S4CORE107_INST_EXPORT_28.zip'
-      - 'S4CORE107_INST_EXPORT_29.zip'
-      - 'S4CORE107_INST_EXPORT_30.zip'
-      - 'S4HANAOP107_ERP_LANG_EN.SAR'
-      # - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
-      # - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
+      - 'igsexe_4-70005417.sar' # IGS 7.81
       # - 'SAPPAAPL4_2203_2-80004547.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_51-70006667.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006666.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
-      - 'S4CORE107_INST_EXPORT_1.zip'
-      - 'S4CORE107_INST_EXPORT_2.zip'
-      - 'S4CORE107_INST_EXPORT_3.zip'
-      - 'S4CORE107_INST_EXPORT_4.zip'
-      - 'S4CORE107_INST_EXPORT_5.zip'
-      - 'S4CORE107_INST_EXPORT_6.zip'
-      - 'S4CORE107_INST_EXPORT_7.zip'
-      - 'S4CORE107_INST_EXPORT_8.zip'
-      - 'S4CORE107_INST_EXPORT_9.zip'
-      - 'S4CORE107_INST_EXPORT_10.zip'
-      - 'S4CORE107_INST_EXPORT_11.zip'
-      - 'S4CORE107_INST_EXPORT_12.zip'
-      - 'S4CORE107_INST_EXPORT_13.zip'
-      - 'S4CORE107_INST_EXPORT_14.zip'
-      - 'S4CORE107_INST_EXPORT_15.zip'
-      - 'S4CORE107_INST_EXPORT_16.zip'
-      - 'S4CORE107_INST_EXPORT_17.zip'
-      - 'S4CORE107_INST_EXPORT_18.zip'
-      - 'S4CORE107_INST_EXPORT_19.zip'
-      - 'S4CORE107_INST_EXPORT_20.zip'
-      - 'S4CORE107_INST_EXPORT_21.zip'
-      - 'S4CORE107_INST_EXPORT_22.zip'
-      - 'S4CORE107_INST_EXPORT_23.zip'
-      - 'S4CORE107_INST_EXPORT_24.zip'
-      - 'S4CORE107_INST_EXPORT_25.zip'
-      - 'S4CORE107_INST_EXPORT_26.zip'
-      - 'S4CORE107_INST_EXPORT_27.zip'
-      - 'S4CORE107_INST_EXPORT_28.zip'
-      - 'S4CORE107_INST_EXPORT_29.zip'
-      - 'S4CORE107_INST_EXPORT_30.zip'
-      - 'S4HANAOP107_ERP_LANG_EN.SAR'
-      # - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
-      # - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
+      - 'igsexe_4-70005446.sar' # IGS 7.81
       # - 'SAPPAAPL4_2203_2-80004546.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
       # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
 
   sap_s4hana_2021_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
-    sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2021.CORE.HDB.ABAP
+    sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2021.CORE.HDB.CP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE106_INST_EXPORT_1.zip'
+      - 'S4CORE106_INST_EXPORT_2.zip'
+      - 'S4CORE106_INST_EXPORT_3.zip'
+      - 'S4CORE106_INST_EXPORT_4.zip'
+      - 'S4CORE106_INST_EXPORT_5.zip'
+      - 'S4CORE106_INST_EXPORT_6.zip'
+      - 'S4CORE106_INST_EXPORT_7.zip'
+      - 'S4CORE106_INST_EXPORT_8.zip'
+      - 'S4CORE106_INST_EXPORT_9.zip'
+      - 'S4CORE106_INST_EXPORT_10.zip'
+      - 'S4CORE106_INST_EXPORT_11.zip'
+      - 'S4CORE106_INST_EXPORT_12.zip'
+      - 'S4CORE106_INST_EXPORT_13.zip'
+      - 'S4CORE106_INST_EXPORT_14.zip'
+      - 'S4CORE106_INST_EXPORT_15.zip'
+      - 'S4CORE106_INST_EXPORT_16.zip'
+      - 'S4CORE106_INST_EXPORT_17.zip'
+      - 'S4CORE106_INST_EXPORT_18.zip'
+      - 'S4CORE106_INST_EXPORT_19.zip'
+      - 'S4CORE106_INST_EXPORT_20.zip'
+      - 'S4CORE106_INST_EXPORT_21.zip'
+      - 'S4CORE106_INST_EXPORT_22.zip'
+      - 'S4CORE106_INST_EXPORT_23.zip'
+      - 'S4CORE106_INST_EXPORT_24.zip'
+      - 'S4CORE106_INST_EXPORT_25.zip'
+      - 'S4CORE106_INST_EXPORT_26.zip'
+      - 'S4CORE106_INST_EXPORT_27.zip'
+      - 'S4CORE106_INST_EXPORT_28.zip'
+      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004822.SAR'
-      - 'S4CORE106_INST_EXPORT_1.zip'
-      - 'S4CORE106_INST_EXPORT_2.zip'
-      - 'S4CORE106_INST_EXPORT_3.zip'
-      - 'S4CORE106_INST_EXPORT_4.zip'
-      - 'S4CORE106_INST_EXPORT_5.zip'
-      - 'S4CORE106_INST_EXPORT_6.zip'
-      - 'S4CORE106_INST_EXPORT_7.zip'
-      - 'S4CORE106_INST_EXPORT_8.zip'
-      - 'S4CORE106_INST_EXPORT_9.zip'
-      - 'S4CORE106_INST_EXPORT_10.zip'
-      - 'S4CORE106_INST_EXPORT_11.zip'
-      - 'S4CORE106_INST_EXPORT_12.zip'
-      - 'S4CORE106_INST_EXPORT_13.zip'
-      - 'S4CORE106_INST_EXPORT_14.zip'
-      - 'S4CORE106_INST_EXPORT_15.zip'
-      - 'S4CORE106_INST_EXPORT_16.zip'
-      - 'S4CORE106_INST_EXPORT_17.zip'
-      - 'S4CORE106_INST_EXPORT_18.zip'
-      - 'S4CORE106_INST_EXPORT_19.zip'
-      - 'S4CORE106_INST_EXPORT_20.zip'
-      - 'S4CORE106_INST_EXPORT_21.zip'
-      - 'S4CORE106_INST_EXPORT_22.zip'
-      - 'S4CORE106_INST_EXPORT_23.zip'
-      - 'S4CORE106_INST_EXPORT_24.zip'
-      - 'S4CORE106_INST_EXPORT_25.zip'
-      - 'S4CORE106_INST_EXPORT_26.zip'
-      - 'S4CORE106_INST_EXPORT_27.zip'
-      - 'S4CORE106_INST_EXPORT_28.zip'
-      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004831.SAR'
-      - 'S4CORE106_INST_EXPORT_1.zip'
-      - 'S4CORE106_INST_EXPORT_2.zip'
-      - 'S4CORE106_INST_EXPORT_3.zip'
-      - 'S4CORE106_INST_EXPORT_4.zip'
-      - 'S4CORE106_INST_EXPORT_5.zip'
-      - 'S4CORE106_INST_EXPORT_6.zip'
-      - 'S4CORE106_INST_EXPORT_7.zip'
-      - 'S4CORE106_INST_EXPORT_8.zip'
-      - 'S4CORE106_INST_EXPORT_9.zip'
-      - 'S4CORE106_INST_EXPORT_10.zip'
-      - 'S4CORE106_INST_EXPORT_11.zip'
-      - 'S4CORE106_INST_EXPORT_12.zip'
-      - 'S4CORE106_INST_EXPORT_13.zip'
-      - 'S4CORE106_INST_EXPORT_14.zip'
-      - 'S4CORE106_INST_EXPORT_15.zip'
-      - 'S4CORE106_INST_EXPORT_16.zip'
-      - 'S4CORE106_INST_EXPORT_17.zip'
-      - 'S4CORE106_INST_EXPORT_18.zip'
-      - 'S4CORE106_INST_EXPORT_19.zip'
-      - 'S4CORE106_INST_EXPORT_20.zip'
-      - 'S4CORE106_INST_EXPORT_21.zip'
-      - 'S4CORE106_INST_EXPORT_22.zip'
-      - 'S4CORE106_INST_EXPORT_23.zip'
-      - 'S4CORE106_INST_EXPORT_24.zip'
-      - 'S4CORE106_INST_EXPORT_25.zip'
-      - 'S4CORE106_INST_EXPORT_26.zip'
-      - 'S4CORE106_INST_EXPORT_27.zip'
-      - 'S4CORE106_INST_EXPORT_28.zip'
-      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
 
   sap_s4hana_2020_sandbox:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
-    sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2020.CORE.HDB.ABAP
+    sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2020.CORE.HDB.CP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['sandbox'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE105_INST_EXPORT_1.zip'
+      - 'S4CORE105_INST_EXPORT_2.zip'
+      - 'S4CORE105_INST_EXPORT_3.zip'
+      - 'S4CORE105_INST_EXPORT_4.zip'
+      - 'S4CORE105_INST_EXPORT_5.zip'
+      - 'S4CORE105_INST_EXPORT_6.zip'
+      - 'S4CORE105_INST_EXPORT_7.zip'
+      - 'S4CORE105_INST_EXPORT_8.zip'
+      - 'S4CORE105_INST_EXPORT_9.zip'
+      - 'S4CORE105_INST_EXPORT_10.zip'
+      - 'S4CORE105_INST_EXPORT_11.zip'
+      - 'S4CORE105_INST_EXPORT_12.zip'
+      - 'S4CORE105_INST_EXPORT_13.zip'
+      - 'S4CORE105_INST_EXPORT_14.zip'
+      - 'S4CORE105_INST_EXPORT_15.zip'
+      - 'S4CORE105_INST_EXPORT_16.zip'
+      - 'S4CORE105_INST_EXPORT_17.zip'
+      - 'S4CORE105_INST_EXPORT_18.zip'
+      - 'S4CORE105_INST_EXPORT_19.zip'
+      - 'S4CORE105_INST_EXPORT_20.zip'
+      - 'S4CORE105_INST_EXPORT_21.zip'
+      - 'S4CORE105_INST_EXPORT_22.zip'
+      - 'S4CORE105_INST_EXPORT_23.zip'
+      - 'S4CORE105_INST_EXPORT_24.zip'
+      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004822.SAR'
-      - 'S4CORE105_INST_EXPORT_1.zip'
-      - 'S4CORE105_INST_EXPORT_2.zip'
-      - 'S4CORE105_INST_EXPORT_3.zip'
-      - 'S4CORE105_INST_EXPORT_4.zip'
-      - 'S4CORE105_INST_EXPORT_5.zip'
-      - 'S4CORE105_INST_EXPORT_6.zip'
-      - 'S4CORE105_INST_EXPORT_7.zip'
-      - 'S4CORE105_INST_EXPORT_8.zip'
-      - 'S4CORE105_INST_EXPORT_9.zip'
-      - 'S4CORE105_INST_EXPORT_10.zip'
-      - 'S4CORE105_INST_EXPORT_11.zip'
-      - 'S4CORE105_INST_EXPORT_12.zip'
-      - 'S4CORE105_INST_EXPORT_13.zip'
-      - 'S4CORE105_INST_EXPORT_14.zip'
-      - 'S4CORE105_INST_EXPORT_15.zip'
-      - 'S4CORE105_INST_EXPORT_16.zip'
-      - 'S4CORE105_INST_EXPORT_17.zip'
-      - 'S4CORE105_INST_EXPORT_18.zip'
-      - 'S4CORE105_INST_EXPORT_19.zip'
-      - 'S4CORE105_INST_EXPORT_20.zip'
-      - 'S4CORE105_INST_EXPORT_21.zip'
-      - 'S4CORE105_INST_EXPORT_22.zip'
-      - 'S4CORE105_INST_EXPORT_23.zip'
-      - 'S4CORE105_INST_EXPORT_24.zip'
-      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004831.SAR'
-      - 'S4CORE105_INST_EXPORT_1.zip'
-      - 'S4CORE105_INST_EXPORT_2.zip'
-      - 'S4CORE105_INST_EXPORT_3.zip'
-      - 'S4CORE105_INST_EXPORT_4.zip'
-      - 'S4CORE105_INST_EXPORT_5.zip'
-      - 'S4CORE105_INST_EXPORT_6.zip'
-      - 'S4CORE105_INST_EXPORT_7.zip'
-      - 'S4CORE105_INST_EXPORT_8.zip'
-      - 'S4CORE105_INST_EXPORT_9.zip'
-      - 'S4CORE105_INST_EXPORT_10.zip'
-      - 'S4CORE105_INST_EXPORT_11.zip'
-      - 'S4CORE105_INST_EXPORT_12.zip'
-      - 'S4CORE105_INST_EXPORT_13.zip'
-      - 'S4CORE105_INST_EXPORT_14.zip'
-      - 'S4CORE105_INST_EXPORT_15.zip'
-      - 'S4CORE105_INST_EXPORT_16.zip'
-      - 'S4CORE105_INST_EXPORT_17.zip'
-      - 'S4CORE105_INST_EXPORT_18.zip'
-      - 'S4CORE105_INST_EXPORT_19.zip'
-      - 'S4CORE105_INST_EXPORT_20.zip'
-      - 'S4CORE105_INST_EXPORT_21.zip'
-      - 'S4CORE105_INST_EXPORT_22.zip'
-      - 'S4CORE105_INST_EXPORT_23.zip'
-      - 'S4CORE105_INST_EXPORT_24.zip'
-      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  sandbox:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - credentials_syscopy
+    - db_config_hana
+    - db_connection_nw_hana
+    - db_restore_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
 
 
 #### Interactive Prompt Control Variables ####

--- a/deploy_scenarios/sap_s4hana_standard/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_standard/ansible_extravars.yml
@@ -30,7 +30,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -133,180 +133,106 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.CORE.HDB.ABAP
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
-    softwarecenter_search_list_x86_64:
-      # Database
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
       - 'SAPPAAPL4_2405_0-80004547.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
-      # Media
-      - 'S4HANAOP109_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_INST_EXPORT_2.zip'
-      - 'S4HANAOP109_INST_EXPORT_3.zip'
-      - 'S4HANAOP109_INST_EXPORT_4.zip'
-      - 'S4HANAOP109_INST_EXPORT_5.zip'
-      - 'S4HANAOP109_INST_EXPORT_6.zip'
-      - 'S4HANAOP109_INST_EXPORT_7.zip'
-      - 'S4HANAOP109_INST_EXPORT_8.zip'
-      - 'S4HANAOP109_INST_EXPORT_9.zip'
-      - 'S4HANAOP109_INST_EXPORT_10.zip'
-      - 'S4HANAOP109_INST_EXPORT_11.zip'
-      - 'S4HANAOP109_INST_EXPORT_12.zip'
-      - 'S4HANAOP109_INST_EXPORT_13.zip'
-      - 'S4HANAOP109_INST_EXPORT_14.zip'
-      - 'S4HANAOP109_INST_EXPORT_15.zip'
-      - 'S4HANAOP109_INST_EXPORT_16.zip'
-      - 'S4HANAOP109_INST_EXPORT_17.zip'
-      - 'S4HANAOP109_INST_EXPORT_18.zip'
-      - 'S4HANAOP109_INST_EXPORT_19.zip'
-      - 'S4HANAOP109_INST_EXPORT_20.zip'
-      - 'S4HANAOP109_INST_EXPORT_21.zip'
-      - 'S4HANAOP109_INST_EXPORT_22.zip'
-      - 'S4HANAOP109_INST_EXPORT_23.zip'
-      - 'S4HANAOP109_INST_EXPORT_24.zip'
-      - 'S4HANAOP109_INST_EXPORT_25.zip'
-      - 'S4HANAOP109_INST_EXPORT_26.zip'
-      - 'S4HANAOP109_INST_EXPORT_27.zip'
-      - 'S4HANAOP109_INST_EXPORT_28.zip'
-      - 'S4HANAOP109_INST_EXPORT_29.zip'
-      - 'S4HANAOP109_INST_EXPORT_30.zip'
-      - 'S4HANAOP109_INST_EXPORT_31.zip'
-      - 'S4HANAOP109_INST_EXPORT_32.zip'
-      - 'S4HANAOP109_INST_EXPORT_33.zip'
-      - 'S4HANAOP109_INST_EXPORT_34.zip'
-      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_ERP_LANG_EN.SAR'
       - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007716.EXE'
       - 'SWPM20SP23_2-80003424.SAR'
       # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
-      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
-      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
       - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
-      # Media
-      - 'S4HANAOP109_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_INST_EXPORT_2.zip'
-      - 'S4HANAOP109_INST_EXPORT_3.zip'
-      - 'S4HANAOP109_INST_EXPORT_4.zip'
-      - 'S4HANAOP109_INST_EXPORT_5.zip'
-      - 'S4HANAOP109_INST_EXPORT_6.zip'
-      - 'S4HANAOP109_INST_EXPORT_7.zip'
-      - 'S4HANAOP109_INST_EXPORT_8.zip'
-      - 'S4HANAOP109_INST_EXPORT_9.zip'
-      - 'S4HANAOP109_INST_EXPORT_10.zip'
-      - 'S4HANAOP109_INST_EXPORT_11.zip'
-      - 'S4HANAOP109_INST_EXPORT_12.zip'
-      - 'S4HANAOP109_INST_EXPORT_13.zip'
-      - 'S4HANAOP109_INST_EXPORT_14.zip'
-      - 'S4HANAOP109_INST_EXPORT_15.zip'
-      - 'S4HANAOP109_INST_EXPORT_16.zip'
-      - 'S4HANAOP109_INST_EXPORT_17.zip'
-      - 'S4HANAOP109_INST_EXPORT_18.zip'
-      - 'S4HANAOP109_INST_EXPORT_19.zip'
-      - 'S4HANAOP109_INST_EXPORT_20.zip'
-      - 'S4HANAOP109_INST_EXPORT_21.zip'
-      - 'S4HANAOP109_INST_EXPORT_22.zip'
-      - 'S4HANAOP109_INST_EXPORT_23.zip'
-      - 'S4HANAOP109_INST_EXPORT_24.zip'
-      - 'S4HANAOP109_INST_EXPORT_25.zip'
-      - 'S4HANAOP109_INST_EXPORT_26.zip'
-      - 'S4HANAOP109_INST_EXPORT_27.zip'
-      - 'S4HANAOP109_INST_EXPORT_28.zip'
-      - 'S4HANAOP109_INST_EXPORT_29.zip'
-      - 'S4HANAOP109_INST_EXPORT_30.zip'
-      - 'S4HANAOP109_INST_EXPORT_31.zip'
-      - 'S4HANAOP109_INST_EXPORT_32.zip'
-      - 'S4HANAOP109_INST_EXPORT_33.zip'
-      - 'S4HANAOP109_INST_EXPORT_34.zip'
-      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_ERP_LANG_EN.SAR'
       - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007726.EXE'
       - 'SWPM20SP23_2-80003426.SAR'
-      # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
-      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
-      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    # This list assigned from shared dictionary, because it is same with other products or host types.
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
 
   sap_s4hana_2023_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2023.CORE.HDB.ABAP
 
-    # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
-    softwarecenter_search_list_x86_64:
-      # Database
-      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
-      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
-      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
-      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
-      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
-      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
-      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+    sap_software_list_independent:
+      # Application Media
       - 'S4CORE108_INST_EXPORT_1.zip'
       - 'S4CORE108_INST_EXPORT_2.zip'
       - 'S4CORE108_INST_EXPORT_3.zip'
@@ -339,394 +265,291 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
-      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Application Server
       - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
+      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
+      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
+      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+      - 'igsexe_4-70005417.sar' # IGS 7.81
       # Tools
       - 'SAPCAR_1300-70007716.EXE'
       - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
       - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
-      - 'S4CORE108_INST_EXPORT_1.zip'
-      - 'S4CORE108_INST_EXPORT_2.zip'
-      - 'S4CORE108_INST_EXPORT_3.zip'
-      - 'S4CORE108_INST_EXPORT_4.zip'
-      - 'S4CORE108_INST_EXPORT_5.zip'
-      - 'S4CORE108_INST_EXPORT_6.zip'
-      - 'S4CORE108_INST_EXPORT_7.zip'
-      - 'S4CORE108_INST_EXPORT_8.zip'
-      - 'S4CORE108_INST_EXPORT_9.zip'
-      - 'S4CORE108_INST_EXPORT_10.zip'
-      - 'S4CORE108_INST_EXPORT_11.zip'
-      - 'S4CORE108_INST_EXPORT_12.zip'
-      - 'S4CORE108_INST_EXPORT_13.zip'
-      - 'S4CORE108_INST_EXPORT_14.zip'
-      - 'S4CORE108_INST_EXPORT_15.zip'
-      - 'S4CORE108_INST_EXPORT_16.zip'
-      - 'S4CORE108_INST_EXPORT_17.zip'
-      - 'S4CORE108_INST_EXPORT_18.zip'
-      - 'S4CORE108_INST_EXPORT_19.zip'
-      - 'S4CORE108_INST_EXPORT_20.zip'
-      - 'S4CORE108_INST_EXPORT_21.zip'
-      - 'S4CORE108_INST_EXPORT_22.zip'
-      - 'S4CORE108_INST_EXPORT_23.zip'
-      - 'S4CORE108_INST_EXPORT_24.zip'
-      - 'S4CORE108_INST_EXPORT_25.zip'
-      - 'S4CORE108_INST_EXPORT_26.zip'
-      - 'S4CORE108_INST_EXPORT_27.zip'
-      - 'S4CORE108_INST_EXPORT_28.zip'
-      - 'S4CORE108_INST_EXPORT_29.zip'
-      - 'S4CORE108_INST_EXPORT_30.zip'
-      - 'S4HANAOP108_ERP_LANG_EN.SAR'
-      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
       - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
       # Tools
       - 'SAPCAR_1300-70007726.EXE'
       - 'SWPM20SP20_1-80003426.SAR'
       # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
 
   sap_s4hana_2022_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2022.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE107_INST_EXPORT_1.zip'
+      - 'S4CORE107_INST_EXPORT_2.zip'
+      - 'S4CORE107_INST_EXPORT_3.zip'
+      - 'S4CORE107_INST_EXPORT_4.zip'
+      - 'S4CORE107_INST_EXPORT_5.zip'
+      - 'S4CORE107_INST_EXPORT_6.zip'
+      - 'S4CORE107_INST_EXPORT_7.zip'
+      - 'S4CORE107_INST_EXPORT_8.zip'
+      - 'S4CORE107_INST_EXPORT_9.zip'
+      - 'S4CORE107_INST_EXPORT_10.zip'
+      - 'S4CORE107_INST_EXPORT_11.zip'
+      - 'S4CORE107_INST_EXPORT_12.zip'
+      - 'S4CORE107_INST_EXPORT_13.zip'
+      - 'S4CORE107_INST_EXPORT_14.zip'
+      - 'S4CORE107_INST_EXPORT_15.zip'
+      - 'S4CORE107_INST_EXPORT_16.zip'
+      - 'S4CORE107_INST_EXPORT_17.zip'
+      - 'S4CORE107_INST_EXPORT_18.zip'
+      - 'S4CORE107_INST_EXPORT_19.zip'
+      - 'S4CORE107_INST_EXPORT_20.zip'
+      - 'S4CORE107_INST_EXPORT_21.zip'
+      - 'S4CORE107_INST_EXPORT_22.zip'
+      - 'S4CORE107_INST_EXPORT_23.zip'
+      - 'S4CORE107_INST_EXPORT_24.zip'
+      - 'S4CORE107_INST_EXPORT_25.zip'
+      - 'S4CORE107_INST_EXPORT_26.zip'
+      - 'S4CORE107_INST_EXPORT_27.zip'
+      - 'S4CORE107_INST_EXPORT_28.zip'
+      - 'S4CORE107_INST_EXPORT_29.zip'
+      - 'S4CORE107_INST_EXPORT_30.zip'
+      - 'S4HANAOP107_ERP_LANG_EN.SAR'
+      # - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
+      # - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_51-70006642.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006641.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
-      - 'S4CORE107_INST_EXPORT_1.zip'
-      - 'S4CORE107_INST_EXPORT_2.zip'
-      - 'S4CORE107_INST_EXPORT_3.zip'
-      - 'S4CORE107_INST_EXPORT_4.zip'
-      - 'S4CORE107_INST_EXPORT_5.zip'
-      - 'S4CORE107_INST_EXPORT_6.zip'
-      - 'S4CORE107_INST_EXPORT_7.zip'
-      - 'S4CORE107_INST_EXPORT_8.zip'
-      - 'S4CORE107_INST_EXPORT_9.zip'
-      - 'S4CORE107_INST_EXPORT_10.zip'
-      - 'S4CORE107_INST_EXPORT_11.zip'
-      - 'S4CORE107_INST_EXPORT_12.zip'
-      - 'S4CORE107_INST_EXPORT_13.zip'
-      - 'S4CORE107_INST_EXPORT_14.zip'
-      - 'S4CORE107_INST_EXPORT_15.zip'
-      - 'S4CORE107_INST_EXPORT_16.zip'
-      - 'S4CORE107_INST_EXPORT_17.zip'
-      - 'S4CORE107_INST_EXPORT_18.zip'
-      - 'S4CORE107_INST_EXPORT_19.zip'
-      - 'S4CORE107_INST_EXPORT_20.zip'
-      - 'S4CORE107_INST_EXPORT_21.zip'
-      - 'S4CORE107_INST_EXPORT_22.zip'
-      - 'S4CORE107_INST_EXPORT_23.zip'
-      - 'S4CORE107_INST_EXPORT_24.zip'
-      - 'S4CORE107_INST_EXPORT_25.zip'
-      - 'S4CORE107_INST_EXPORT_26.zip'
-      - 'S4CORE107_INST_EXPORT_27.zip'
-      - 'S4CORE107_INST_EXPORT_28.zip'
-      - 'S4CORE107_INST_EXPORT_29.zip'
-      - 'S4CORE107_INST_EXPORT_30.zip'
-      - 'S4HANAOP107_ERP_LANG_EN.SAR'
-      # - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
-      # - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
+      - 'igsexe_4-70005417.sar' # IGS 7.81
       # - 'SAPPAAPL4_2203_2-80004547.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_51-70006667.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006666.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
-      - 'S4CORE107_INST_EXPORT_1.zip'
-      - 'S4CORE107_INST_EXPORT_2.zip'
-      - 'S4CORE107_INST_EXPORT_3.zip'
-      - 'S4CORE107_INST_EXPORT_4.zip'
-      - 'S4CORE107_INST_EXPORT_5.zip'
-      - 'S4CORE107_INST_EXPORT_6.zip'
-      - 'S4CORE107_INST_EXPORT_7.zip'
-      - 'S4CORE107_INST_EXPORT_8.zip'
-      - 'S4CORE107_INST_EXPORT_9.zip'
-      - 'S4CORE107_INST_EXPORT_10.zip'
-      - 'S4CORE107_INST_EXPORT_11.zip'
-      - 'S4CORE107_INST_EXPORT_12.zip'
-      - 'S4CORE107_INST_EXPORT_13.zip'
-      - 'S4CORE107_INST_EXPORT_14.zip'
-      - 'S4CORE107_INST_EXPORT_15.zip'
-      - 'S4CORE107_INST_EXPORT_16.zip'
-      - 'S4CORE107_INST_EXPORT_17.zip'
-      - 'S4CORE107_INST_EXPORT_18.zip'
-      - 'S4CORE107_INST_EXPORT_19.zip'
-      - 'S4CORE107_INST_EXPORT_20.zip'
-      - 'S4CORE107_INST_EXPORT_21.zip'
-      - 'S4CORE107_INST_EXPORT_22.zip'
-      - 'S4CORE107_INST_EXPORT_23.zip'
-      - 'S4CORE107_INST_EXPORT_24.zip'
-      - 'S4CORE107_INST_EXPORT_25.zip'
-      - 'S4CORE107_INST_EXPORT_26.zip'
-      - 'S4CORE107_INST_EXPORT_27.zip'
-      - 'S4CORE107_INST_EXPORT_28.zip'
-      - 'S4CORE107_INST_EXPORT_29.zip'
-      - 'S4CORE107_INST_EXPORT_30.zip'
-      - 'S4HANAOP107_ERP_LANG_EN.SAR'
-      # - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
-      # - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
+      - 'igsexe_4-70005446.sar' # IGS 7.81
       # - 'SAPPAAPL4_2203_2-80004546.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
       # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
 
   sap_s4hana_2021_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2021.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE106_INST_EXPORT_1.zip'
+      - 'S4CORE106_INST_EXPORT_2.zip'
+      - 'S4CORE106_INST_EXPORT_3.zip'
+      - 'S4CORE106_INST_EXPORT_4.zip'
+      - 'S4CORE106_INST_EXPORT_5.zip'
+      - 'S4CORE106_INST_EXPORT_6.zip'
+      - 'S4CORE106_INST_EXPORT_7.zip'
+      - 'S4CORE106_INST_EXPORT_8.zip'
+      - 'S4CORE106_INST_EXPORT_9.zip'
+      - 'S4CORE106_INST_EXPORT_10.zip'
+      - 'S4CORE106_INST_EXPORT_11.zip'
+      - 'S4CORE106_INST_EXPORT_12.zip'
+      - 'S4CORE106_INST_EXPORT_13.zip'
+      - 'S4CORE106_INST_EXPORT_14.zip'
+      - 'S4CORE106_INST_EXPORT_15.zip'
+      - 'S4CORE106_INST_EXPORT_16.zip'
+      - 'S4CORE106_INST_EXPORT_17.zip'
+      - 'S4CORE106_INST_EXPORT_18.zip'
+      - 'S4CORE106_INST_EXPORT_19.zip'
+      - 'S4CORE106_INST_EXPORT_20.zip'
+      - 'S4CORE106_INST_EXPORT_21.zip'
+      - 'S4CORE106_INST_EXPORT_22.zip'
+      - 'S4CORE106_INST_EXPORT_23.zip'
+      - 'S4CORE106_INST_EXPORT_24.zip'
+      - 'S4CORE106_INST_EXPORT_25.zip'
+      - 'S4CORE106_INST_EXPORT_26.zip'
+      - 'S4CORE106_INST_EXPORT_27.zip'
+      - 'S4CORE106_INST_EXPORT_28.zip'
+      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004822.SAR'
-      - 'S4CORE106_INST_EXPORT_1.zip'
-      - 'S4CORE106_INST_EXPORT_2.zip'
-      - 'S4CORE106_INST_EXPORT_3.zip'
-      - 'S4CORE106_INST_EXPORT_4.zip'
-      - 'S4CORE106_INST_EXPORT_5.zip'
-      - 'S4CORE106_INST_EXPORT_6.zip'
-      - 'S4CORE106_INST_EXPORT_7.zip'
-      - 'S4CORE106_INST_EXPORT_8.zip'
-      - 'S4CORE106_INST_EXPORT_9.zip'
-      - 'S4CORE106_INST_EXPORT_10.zip'
-      - 'S4CORE106_INST_EXPORT_11.zip'
-      - 'S4CORE106_INST_EXPORT_12.zip'
-      - 'S4CORE106_INST_EXPORT_13.zip'
-      - 'S4CORE106_INST_EXPORT_14.zip'
-      - 'S4CORE106_INST_EXPORT_15.zip'
-      - 'S4CORE106_INST_EXPORT_16.zip'
-      - 'S4CORE106_INST_EXPORT_17.zip'
-      - 'S4CORE106_INST_EXPORT_18.zip'
-      - 'S4CORE106_INST_EXPORT_19.zip'
-      - 'S4CORE106_INST_EXPORT_20.zip'
-      - 'S4CORE106_INST_EXPORT_21.zip'
-      - 'S4CORE106_INST_EXPORT_22.zip'
-      - 'S4CORE106_INST_EXPORT_23.zip'
-      - 'S4CORE106_INST_EXPORT_24.zip'
-      - 'S4CORE106_INST_EXPORT_25.zip'
-      - 'S4CORE106_INST_EXPORT_26.zip'
-      - 'S4CORE106_INST_EXPORT_27.zip'
-      - 'S4CORE106_INST_EXPORT_28.zip'
-      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004831.SAR'
-      - 'S4CORE106_INST_EXPORT_1.zip'
-      - 'S4CORE106_INST_EXPORT_2.zip'
-      - 'S4CORE106_INST_EXPORT_3.zip'
-      - 'S4CORE106_INST_EXPORT_4.zip'
-      - 'S4CORE106_INST_EXPORT_5.zip'
-      - 'S4CORE106_INST_EXPORT_6.zip'
-      - 'S4CORE106_INST_EXPORT_7.zip'
-      - 'S4CORE106_INST_EXPORT_8.zip'
-      - 'S4CORE106_INST_EXPORT_9.zip'
-      - 'S4CORE106_INST_EXPORT_10.zip'
-      - 'S4CORE106_INST_EXPORT_11.zip'
-      - 'S4CORE106_INST_EXPORT_12.zip'
-      - 'S4CORE106_INST_EXPORT_13.zip'
-      - 'S4CORE106_INST_EXPORT_14.zip'
-      - 'S4CORE106_INST_EXPORT_15.zip'
-      - 'S4CORE106_INST_EXPORT_16.zip'
-      - 'S4CORE106_INST_EXPORT_17.zip'
-      - 'S4CORE106_INST_EXPORT_18.zip'
-      - 'S4CORE106_INST_EXPORT_19.zip'
-      - 'S4CORE106_INST_EXPORT_20.zip'
-      - 'S4CORE106_INST_EXPORT_21.zip'
-      - 'S4CORE106_INST_EXPORT_22.zip'
-      - 'S4CORE106_INST_EXPORT_23.zip'
-      - 'S4CORE106_INST_EXPORT_24.zip'
-      - 'S4CORE106_INST_EXPORT_25.zip'
-      - 'S4CORE106_INST_EXPORT_26.zip'
-      - 'S4CORE106_INST_EXPORT_27.zip'
-      - 'S4CORE106_INST_EXPORT_28.zip'
-      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
 
   sap_s4hana_2020_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2020.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE105_INST_EXPORT_1.zip'
+      - 'S4CORE105_INST_EXPORT_2.zip'
+      - 'S4CORE105_INST_EXPORT_3.zip'
+      - 'S4CORE105_INST_EXPORT_4.zip'
+      - 'S4CORE105_INST_EXPORT_5.zip'
+      - 'S4CORE105_INST_EXPORT_6.zip'
+      - 'S4CORE105_INST_EXPORT_7.zip'
+      - 'S4CORE105_INST_EXPORT_8.zip'
+      - 'S4CORE105_INST_EXPORT_9.zip'
+      - 'S4CORE105_INST_EXPORT_10.zip'
+      - 'S4CORE105_INST_EXPORT_11.zip'
+      - 'S4CORE105_INST_EXPORT_12.zip'
+      - 'S4CORE105_INST_EXPORT_13.zip'
+      - 'S4CORE105_INST_EXPORT_14.zip'
+      - 'S4CORE105_INST_EXPORT_15.zip'
+      - 'S4CORE105_INST_EXPORT_16.zip'
+      - 'S4CORE105_INST_EXPORT_17.zip'
+      - 'S4CORE105_INST_EXPORT_18.zip'
+      - 'S4CORE105_INST_EXPORT_19.zip'
+      - 'S4CORE105_INST_EXPORT_20.zip'
+      - 'S4CORE105_INST_EXPORT_21.zip'
+      - 'S4CORE105_INST_EXPORT_22.zip'
+      - 'S4CORE105_INST_EXPORT_23.zip'
+      - 'S4CORE105_INST_EXPORT_24.zip'
+      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004822.SAR'
-      - 'S4CORE105_INST_EXPORT_1.zip'
-      - 'S4CORE105_INST_EXPORT_2.zip'
-      - 'S4CORE105_INST_EXPORT_3.zip'
-      - 'S4CORE105_INST_EXPORT_4.zip'
-      - 'S4CORE105_INST_EXPORT_5.zip'
-      - 'S4CORE105_INST_EXPORT_6.zip'
-      - 'S4CORE105_INST_EXPORT_7.zip'
-      - 'S4CORE105_INST_EXPORT_8.zip'
-      - 'S4CORE105_INST_EXPORT_9.zip'
-      - 'S4CORE105_INST_EXPORT_10.zip'
-      - 'S4CORE105_INST_EXPORT_11.zip'
-      - 'S4CORE105_INST_EXPORT_12.zip'
-      - 'S4CORE105_INST_EXPORT_13.zip'
-      - 'S4CORE105_INST_EXPORT_14.zip'
-      - 'S4CORE105_INST_EXPORT_15.zip'
-      - 'S4CORE105_INST_EXPORT_16.zip'
-      - 'S4CORE105_INST_EXPORT_17.zip'
-      - 'S4CORE105_INST_EXPORT_18.zip'
-      - 'S4CORE105_INST_EXPORT_19.zip'
-      - 'S4CORE105_INST_EXPORT_20.zip'
-      - 'S4CORE105_INST_EXPORT_21.zip'
-      - 'S4CORE105_INST_EXPORT_22.zip'
-      - 'S4CORE105_INST_EXPORT_23.zip'
-      - 'S4CORE105_INST_EXPORT_24.zip'
-      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004831.SAR'
-      - 'S4CORE105_INST_EXPORT_1.zip'
-      - 'S4CORE105_INST_EXPORT_2.zip'
-      - 'S4CORE105_INST_EXPORT_3.zip'
-      - 'S4CORE105_INST_EXPORT_4.zip'
-      - 'S4CORE105_INST_EXPORT_5.zip'
-      - 'S4CORE105_INST_EXPORT_6.zip'
-      - 'S4CORE105_INST_EXPORT_7.zip'
-      - 'S4CORE105_INST_EXPORT_8.zip'
-      - 'S4CORE105_INST_EXPORT_9.zip'
-      - 'S4CORE105_INST_EXPORT_10.zip'
-      - 'S4CORE105_INST_EXPORT_11.zip'
-      - 'S4CORE105_INST_EXPORT_12.zip'
-      - 'S4CORE105_INST_EXPORT_13.zip'
-      - 'S4CORE105_INST_EXPORT_14.zip'
-      - 'S4CORE105_INST_EXPORT_15.zip'
-      - 'S4CORE105_INST_EXPORT_16.zip'
-      - 'S4CORE105_INST_EXPORT_17.zip'
-      - 'S4CORE105_INST_EXPORT_18.zip'
-      - 'S4CORE105_INST_EXPORT_19.zip'
-      - 'S4CORE105_INST_EXPORT_20.zip'
-      - 'S4CORE105_INST_EXPORT_21.zip'
-      - 'S4CORE105_INST_EXPORT_22.zip'
-      - 'S4CORE105_INST_EXPORT_23.zip'
-      - 'S4CORE105_INST_EXPORT_24.zip'
-      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
+
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  standard:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
+
+# Dictionary of lists for software filename wildcard patterns that is used during rsync operations.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_software_wildcards:
+  hana:
+    - 'SAPCAR*'
+    - 'IMDB_*'
+    - 'SAPHOSTAGENT*'

--- a/deploy_scenarios/sap_s4hana_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_standard/ansible_playbook.yml
@@ -270,8 +270,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
@@ -279,7 +280,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['software_files_hana_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['sap_software_files_hana_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_hana_install_media_files
 

--- a/deploy_scenarios/sap_s4hana_standard/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_standard/optional/ansible_extravars_interactive.yml
@@ -41,180 +41,106 @@ sap_software_install_dictionary:
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.CORE.HDB.ABAP
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
-    softwarecenter_search_list_x86_64:
-      # Database
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Media
+      - 'S4HANAOP109_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_INST_EXPORT_2.zip'
+      - 'S4HANAOP109_INST_EXPORT_3.zip'
+      - 'S4HANAOP109_INST_EXPORT_4.zip'
+      - 'S4HANAOP109_INST_EXPORT_5.zip'
+      - 'S4HANAOP109_INST_EXPORT_6.zip'
+      - 'S4HANAOP109_INST_EXPORT_7.zip'
+      - 'S4HANAOP109_INST_EXPORT_8.zip'
+      - 'S4HANAOP109_INST_EXPORT_9.zip'
+      - 'S4HANAOP109_INST_EXPORT_10.zip'
+      - 'S4HANAOP109_INST_EXPORT_11.zip'
+      - 'S4HANAOP109_INST_EXPORT_12.zip'
+      - 'S4HANAOP109_INST_EXPORT_13.zip'
+      - 'S4HANAOP109_INST_EXPORT_14.zip'
+      - 'S4HANAOP109_INST_EXPORT_15.zip'
+      - 'S4HANAOP109_INST_EXPORT_16.zip'
+      - 'S4HANAOP109_INST_EXPORT_17.zip'
+      - 'S4HANAOP109_INST_EXPORT_18.zip'
+      - 'S4HANAOP109_INST_EXPORT_19.zip'
+      - 'S4HANAOP109_INST_EXPORT_20.zip'
+      - 'S4HANAOP109_INST_EXPORT_21.zip'
+      - 'S4HANAOP109_INST_EXPORT_22.zip'
+      - 'S4HANAOP109_INST_EXPORT_23.zip'
+      - 'S4HANAOP109_INST_EXPORT_24.zip'
+      - 'S4HANAOP109_INST_EXPORT_25.zip'
+      - 'S4HANAOP109_INST_EXPORT_26.zip'
+      - 'S4HANAOP109_INST_EXPORT_27.zip'
+      - 'S4HANAOP109_INST_EXPORT_28.zip'
+      - 'S4HANAOP109_INST_EXPORT_29.zip'
+      - 'S4HANAOP109_INST_EXPORT_30.zip'
+      - 'S4HANAOP109_INST_EXPORT_31.zip'
+      - 'S4HANAOP109_INST_EXPORT_32.zip'
+      - 'S4HANAOP109_INST_EXPORT_33.zip'
+      - 'S4HANAOP109_INST_EXPORT_34.zip'
+      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
+      - 'S4HANAOP109_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
+      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
+      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
+      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
+      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
+      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
+      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
+      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80001894.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
       - 'SAPPAAPL4_2405_0-80004547.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
-      # Media
-      - 'S4HANAOP109_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_INST_EXPORT_2.zip'
-      - 'S4HANAOP109_INST_EXPORT_3.zip'
-      - 'S4HANAOP109_INST_EXPORT_4.zip'
-      - 'S4HANAOP109_INST_EXPORT_5.zip'
-      - 'S4HANAOP109_INST_EXPORT_6.zip'
-      - 'S4HANAOP109_INST_EXPORT_7.zip'
-      - 'S4HANAOP109_INST_EXPORT_8.zip'
-      - 'S4HANAOP109_INST_EXPORT_9.zip'
-      - 'S4HANAOP109_INST_EXPORT_10.zip'
-      - 'S4HANAOP109_INST_EXPORT_11.zip'
-      - 'S4HANAOP109_INST_EXPORT_12.zip'
-      - 'S4HANAOP109_INST_EXPORT_13.zip'
-      - 'S4HANAOP109_INST_EXPORT_14.zip'
-      - 'S4HANAOP109_INST_EXPORT_15.zip'
-      - 'S4HANAOP109_INST_EXPORT_16.zip'
-      - 'S4HANAOP109_INST_EXPORT_17.zip'
-      - 'S4HANAOP109_INST_EXPORT_18.zip'
-      - 'S4HANAOP109_INST_EXPORT_19.zip'
-      - 'S4HANAOP109_INST_EXPORT_20.zip'
-      - 'S4HANAOP109_INST_EXPORT_21.zip'
-      - 'S4HANAOP109_INST_EXPORT_22.zip'
-      - 'S4HANAOP109_INST_EXPORT_23.zip'
-      - 'S4HANAOP109_INST_EXPORT_24.zip'
-      - 'S4HANAOP109_INST_EXPORT_25.zip'
-      - 'S4HANAOP109_INST_EXPORT_26.zip'
-      - 'S4HANAOP109_INST_EXPORT_27.zip'
-      - 'S4HANAOP109_INST_EXPORT_28.zip'
-      - 'S4HANAOP109_INST_EXPORT_29.zip'
-      - 'S4HANAOP109_INST_EXPORT_30.zip'
-      - 'S4HANAOP109_INST_EXPORT_31.zip'
-      - 'S4HANAOP109_INST_EXPORT_32.zip'
-      - 'S4HANAOP109_INST_EXPORT_33.zip'
-      - 'S4HANAOP109_INST_EXPORT_34.zip'
-      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_ERP_LANG_EN.SAR'
       - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007716.EXE'
       - 'SWPM20SP23_2-80003424.SAR'
       # - 'SUM20SP25_4-80002456.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
-      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
-      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_LCAPPS_2089P_101-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 89.01 Build 101.24 PL 003
       - 'IMDB_AFL20_089P_100-80002045.SAR'  # SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
       - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
       - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
       - 'SAPPAAPL4_2405_0-80004546.ZIP'  # Predi. Analy. APL 2405 for SAP HANA 2.0 SPS03 and beyond
-      # Media
-      - 'S4HANAOP109_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_INST_EXPORT_2.zip'
-      - 'S4HANAOP109_INST_EXPORT_3.zip'
-      - 'S4HANAOP109_INST_EXPORT_4.zip'
-      - 'S4HANAOP109_INST_EXPORT_5.zip'
-      - 'S4HANAOP109_INST_EXPORT_6.zip'
-      - 'S4HANAOP109_INST_EXPORT_7.zip'
-      - 'S4HANAOP109_INST_EXPORT_8.zip'
-      - 'S4HANAOP109_INST_EXPORT_9.zip'
-      - 'S4HANAOP109_INST_EXPORT_10.zip'
-      - 'S4HANAOP109_INST_EXPORT_11.zip'
-      - 'S4HANAOP109_INST_EXPORT_12.zip'
-      - 'S4HANAOP109_INST_EXPORT_13.zip'
-      - 'S4HANAOP109_INST_EXPORT_14.zip'
-      - 'S4HANAOP109_INST_EXPORT_15.zip'
-      - 'S4HANAOP109_INST_EXPORT_16.zip'
-      - 'S4HANAOP109_INST_EXPORT_17.zip'
-      - 'S4HANAOP109_INST_EXPORT_18.zip'
-      - 'S4HANAOP109_INST_EXPORT_19.zip'
-      - 'S4HANAOP109_INST_EXPORT_20.zip'
-      - 'S4HANAOP109_INST_EXPORT_21.zip'
-      - 'S4HANAOP109_INST_EXPORT_22.zip'
-      - 'S4HANAOP109_INST_EXPORT_23.zip'
-      - 'S4HANAOP109_INST_EXPORT_24.zip'
-      - 'S4HANAOP109_INST_EXPORT_25.zip'
-      - 'S4HANAOP109_INST_EXPORT_26.zip'
-      - 'S4HANAOP109_INST_EXPORT_27.zip'
-      - 'S4HANAOP109_INST_EXPORT_28.zip'
-      - 'S4HANAOP109_INST_EXPORT_29.zip'
-      - 'S4HANAOP109_INST_EXPORT_30.zip'
-      - 'S4HANAOP109_INST_EXPORT_31.zip'
-      - 'S4HANAOP109_INST_EXPORT_32.zip'
-      - 'S4HANAOP109_INST_EXPORT_33.zip'
-      - 'S4HANAOP109_INST_EXPORT_34.zip'
-      - 'S4HANAOP109_PRC_INST_EXPORT_1.zip'
-      - 'S4HANAOP109_ERP_LANG_EN.SAR'
       - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
-      - 'igshelper_17-10010245.sar'  # SAP IGS Fonts and Textures
       # Tools
       - 'SAPCAR_1400-70007726.EXE'
       - 'SWPM20SP23_2-80003426.SAR'
-      # - 'SUM20SP25_4-80002470.SAR' # SUM 2.0
-      # Unavailable - Following media are shown in Maintenance Plan, but cannot be downloaded directly, only through Maintenance Planner.
-      # - 'ST-PI740.SAR'  # Attribute Change Package 65 for ST-PI 740
-      # - 'K-74031INSTPI.SAR'  # ST-PI 740: SP 0031
-      # - 'K-74032INSTPI.SAR'  # ST-PI 740: SP 0032
-      # - 'K-74033INSTPI.SAR'  # ST-PI 740: SP 0033
-      # - 'GBX01HR5605.SAR'  # Attribute Change Package 29 for GBX01HR5 605
-      # - 'KITABCA.SAR'  # Servicetools for SAP Basis 731 and higher
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    # This list assigned from shared dictionary, because it is same with other products or host types.
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
 
   sap_s4hana_2023_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2023.CORE.HDB.ABAP
 
-    # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
-    softwarecenter_search_list_x86_64:
-      # Database
-      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
-      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
-      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
-      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
-      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
-      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
-      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+    sap_software_list_independent:
+      # Application Media
       - 'S4CORE108_INST_EXPORT_1.zip'
       - 'S4CORE108_INST_EXPORT_2.zip'
       - 'S4CORE108_INST_EXPORT_3.zip'
@@ -247,397 +173,294 @@ sap_software_install_dictionary:
       - 'S4CORE108_INST_EXPORT_30.zip'
       - 'S4HANAOP108_ERP_LANG_EN.SAR'
       # - 'KD75886.SAR' # SPAM/SAINT Update - Version 758/0086
-      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Application Server
       - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
+      - 'IMDB_SERVER20_079_8-80002031.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
+      - 'IMDB_LCAPPS_2079P_801-20010426.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
+      - 'IMDB_AFL20_079P_800-80001894.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
+      - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
+      - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
+      - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
+      - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+      - 'igsexe_4-70005417.sar' # IGS 7.81
       # Tools
       - 'SAPCAR_1300-70007716.EXE'
       - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
-    softwarecenter_search_list_ppc64le:
-      # Database
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_079_8-80002046.SAR'  # Revision 2.00.079.8 (SPS07) for HANA DB 2.0
       - 'IMDB_LCAPPS_2079P_801-80002183.SAR'  # LCAPPS for HANA 2.0 Rev 79.08 Build 101.24 PL 001
       - 'IMDB_AFL20_079P_800-80002045.SAR'  # SAP HANA AFL Rev 79.800 only for HANA 2.0 Rev 79.08
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
-      # Application
+      # Application Server
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
-      - 'S4CORE108_INST_EXPORT_1.zip'
-      - 'S4CORE108_INST_EXPORT_2.zip'
-      - 'S4CORE108_INST_EXPORT_3.zip'
-      - 'S4CORE108_INST_EXPORT_4.zip'
-      - 'S4CORE108_INST_EXPORT_5.zip'
-      - 'S4CORE108_INST_EXPORT_6.zip'
-      - 'S4CORE108_INST_EXPORT_7.zip'
-      - 'S4CORE108_INST_EXPORT_8.zip'
-      - 'S4CORE108_INST_EXPORT_9.zip'
-      - 'S4CORE108_INST_EXPORT_10.zip'
-      - 'S4CORE108_INST_EXPORT_11.zip'
-      - 'S4CORE108_INST_EXPORT_12.zip'
-      - 'S4CORE108_INST_EXPORT_13.zip'
-      - 'S4CORE108_INST_EXPORT_14.zip'
-      - 'S4CORE108_INST_EXPORT_15.zip'
-      - 'S4CORE108_INST_EXPORT_16.zip'
-      - 'S4CORE108_INST_EXPORT_17.zip'
-      - 'S4CORE108_INST_EXPORT_18.zip'
-      - 'S4CORE108_INST_EXPORT_19.zip'
-      - 'S4CORE108_INST_EXPORT_20.zip'
-      - 'S4CORE108_INST_EXPORT_21.zip'
-      - 'S4CORE108_INST_EXPORT_22.zip'
-      - 'S4CORE108_INST_EXPORT_23.zip'
-      - 'S4CORE108_INST_EXPORT_24.zip'
-      - 'S4CORE108_INST_EXPORT_25.zip'
-      - 'S4CORE108_INST_EXPORT_26.zip'
-      - 'S4CORE108_INST_EXPORT_27.zip'
-      - 'S4CORE108_INST_EXPORT_28.zip'
-      - 'S4CORE108_INST_EXPORT_29.zip'
-      - 'S4CORE108_INST_EXPORT_30.zip'
-      - 'S4HANAOP108_ERP_LANG_EN.SAR'
-      # - 'KD75886.SAR' # SPAM/SAINT Update - Version 757/0083
       - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
       # Tools
       - 'SAPCAR_1300-70007726.EXE'
       - 'SWPM20SP20_1-80003426.SAR'
       # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
 
   sap_s4hana_2022_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2022.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE107_INST_EXPORT_1.zip'
+      - 'S4CORE107_INST_EXPORT_2.zip'
+      - 'S4CORE107_INST_EXPORT_3.zip'
+      - 'S4CORE107_INST_EXPORT_4.zip'
+      - 'S4CORE107_INST_EXPORT_5.zip'
+      - 'S4CORE107_INST_EXPORT_6.zip'
+      - 'S4CORE107_INST_EXPORT_7.zip'
+      - 'S4CORE107_INST_EXPORT_8.zip'
+      - 'S4CORE107_INST_EXPORT_9.zip'
+      - 'S4CORE107_INST_EXPORT_10.zip'
+      - 'S4CORE107_INST_EXPORT_11.zip'
+      - 'S4CORE107_INST_EXPORT_12.zip'
+      - 'S4CORE107_INST_EXPORT_13.zip'
+      - 'S4CORE107_INST_EXPORT_14.zip'
+      - 'S4CORE107_INST_EXPORT_15.zip'
+      - 'S4CORE107_INST_EXPORT_16.zip'
+      - 'S4CORE107_INST_EXPORT_17.zip'
+      - 'S4CORE107_INST_EXPORT_18.zip'
+      - 'S4CORE107_INST_EXPORT_19.zip'
+      - 'S4CORE107_INST_EXPORT_20.zip'
+      - 'S4CORE107_INST_EXPORT_21.zip'
+      - 'S4CORE107_INST_EXPORT_22.zip'
+      - 'S4CORE107_INST_EXPORT_23.zip'
+      - 'S4CORE107_INST_EXPORT_24.zip'
+      - 'S4CORE107_INST_EXPORT_25.zip'
+      - 'S4CORE107_INST_EXPORT_26.zip'
+      - 'S4CORE107_INST_EXPORT_27.zip'
+      - 'S4CORE107_INST_EXPORT_28.zip'
+      - 'S4CORE107_INST_EXPORT_29.zip'
+      - 'S4CORE107_INST_EXPORT_30.zip'
+      - 'S4HANAOP107_ERP_LANG_EN.SAR'
+      # - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
+      # - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_51-70006642.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006641.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
-      - 'S4CORE107_INST_EXPORT_1.zip'
-      - 'S4CORE107_INST_EXPORT_2.zip'
-      - 'S4CORE107_INST_EXPORT_3.zip'
-      - 'S4CORE107_INST_EXPORT_4.zip'
-      - 'S4CORE107_INST_EXPORT_5.zip'
-      - 'S4CORE107_INST_EXPORT_6.zip'
-      - 'S4CORE107_INST_EXPORT_7.zip'
-      - 'S4CORE107_INST_EXPORT_8.zip'
-      - 'S4CORE107_INST_EXPORT_9.zip'
-      - 'S4CORE107_INST_EXPORT_10.zip'
-      - 'S4CORE107_INST_EXPORT_11.zip'
-      - 'S4CORE107_INST_EXPORT_12.zip'
-      - 'S4CORE107_INST_EXPORT_13.zip'
-      - 'S4CORE107_INST_EXPORT_14.zip'
-      - 'S4CORE107_INST_EXPORT_15.zip'
-      - 'S4CORE107_INST_EXPORT_16.zip'
-      - 'S4CORE107_INST_EXPORT_17.zip'
-      - 'S4CORE107_INST_EXPORT_18.zip'
-      - 'S4CORE107_INST_EXPORT_19.zip'
-      - 'S4CORE107_INST_EXPORT_20.zip'
-      - 'S4CORE107_INST_EXPORT_21.zip'
-      - 'S4CORE107_INST_EXPORT_22.zip'
-      - 'S4CORE107_INST_EXPORT_23.zip'
-      - 'S4CORE107_INST_EXPORT_24.zip'
-      - 'S4CORE107_INST_EXPORT_25.zip'
-      - 'S4CORE107_INST_EXPORT_26.zip'
-      - 'S4CORE107_INST_EXPORT_27.zip'
-      - 'S4CORE107_INST_EXPORT_28.zip'
-      - 'S4CORE107_INST_EXPORT_29.zip'
-      - 'S4CORE107_INST_EXPORT_30.zip'
-      - 'S4HANAOP107_ERP_LANG_EN.SAR'
-      # - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
-      # - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
+      - 'igsexe_4-70005417.sar' # IGS 7.81
       # - 'SAPPAAPL4_2203_2-80004547.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
       # - 'SUM20SP22_3-80002456.SAR' # SUM 2.0
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_51-70006667.SAR' # Kernel Part I (789)
       - 'SAPEXEDB_51-70006666.SAR' # Kernel Part II (789)
       - 'SAPHOSTAGENT61_61-80004831.SAR' # SAP Host Agent 7.22
-      - 'S4CORE107_INST_EXPORT_1.zip'
-      - 'S4CORE107_INST_EXPORT_2.zip'
-      - 'S4CORE107_INST_EXPORT_3.zip'
-      - 'S4CORE107_INST_EXPORT_4.zip'
-      - 'S4CORE107_INST_EXPORT_5.zip'
-      - 'S4CORE107_INST_EXPORT_6.zip'
-      - 'S4CORE107_INST_EXPORT_7.zip'
-      - 'S4CORE107_INST_EXPORT_8.zip'
-      - 'S4CORE107_INST_EXPORT_9.zip'
-      - 'S4CORE107_INST_EXPORT_10.zip'
-      - 'S4CORE107_INST_EXPORT_11.zip'
-      - 'S4CORE107_INST_EXPORT_12.zip'
-      - 'S4CORE107_INST_EXPORT_13.zip'
-      - 'S4CORE107_INST_EXPORT_14.zip'
-      - 'S4CORE107_INST_EXPORT_15.zip'
-      - 'S4CORE107_INST_EXPORT_16.zip'
-      - 'S4CORE107_INST_EXPORT_17.zip'
-      - 'S4CORE107_INST_EXPORT_18.zip'
-      - 'S4CORE107_INST_EXPORT_19.zip'
-      - 'S4CORE107_INST_EXPORT_20.zip'
-      - 'S4CORE107_INST_EXPORT_21.zip'
-      - 'S4CORE107_INST_EXPORT_22.zip'
-      - 'S4CORE107_INST_EXPORT_23.zip'
-      - 'S4CORE107_INST_EXPORT_24.zip'
-      - 'S4CORE107_INST_EXPORT_25.zip'
-      - 'S4CORE107_INST_EXPORT_26.zip'
-      - 'S4CORE107_INST_EXPORT_27.zip'
-      - 'S4CORE107_INST_EXPORT_28.zip'
-      - 'S4CORE107_INST_EXPORT_29.zip'
-      - 'S4CORE107_INST_EXPORT_30.zip'
-      - 'S4HANAOP107_ERP_LANG_EN.SAR'
-      # - 'HANAUMML12_6-70001054.ZIP' # UMML4HANA 1 SP12
-      # - 'KD75783.SAR' # SPAM/SAINT Update - Version 757/0083
+      - 'igsexe_4-70005446.sar' # IGS 7.81
       # - 'SAPPAAPL4_2203_2-80004546.ZIP' # Predictive Analytics APL 2203 for SAP HANA 2.0 SPS03 and beyond
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
       # - 'SUM20SP22_3-80002470.SAR' # SUM 2.0
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
 
   sap_s4hana_2021_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2021.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE106_INST_EXPORT_1.zip'
+      - 'S4CORE106_INST_EXPORT_2.zip'
+      - 'S4CORE106_INST_EXPORT_3.zip'
+      - 'S4CORE106_INST_EXPORT_4.zip'
+      - 'S4CORE106_INST_EXPORT_5.zip'
+      - 'S4CORE106_INST_EXPORT_6.zip'
+      - 'S4CORE106_INST_EXPORT_7.zip'
+      - 'S4CORE106_INST_EXPORT_8.zip'
+      - 'S4CORE106_INST_EXPORT_9.zip'
+      - 'S4CORE106_INST_EXPORT_10.zip'
+      - 'S4CORE106_INST_EXPORT_11.zip'
+      - 'S4CORE106_INST_EXPORT_12.zip'
+      - 'S4CORE106_INST_EXPORT_13.zip'
+      - 'S4CORE106_INST_EXPORT_14.zip'
+      - 'S4CORE106_INST_EXPORT_15.zip'
+      - 'S4CORE106_INST_EXPORT_16.zip'
+      - 'S4CORE106_INST_EXPORT_17.zip'
+      - 'S4CORE106_INST_EXPORT_18.zip'
+      - 'S4CORE106_INST_EXPORT_19.zip'
+      - 'S4CORE106_INST_EXPORT_20.zip'
+      - 'S4CORE106_INST_EXPORT_21.zip'
+      - 'S4CORE106_INST_EXPORT_22.zip'
+      - 'S4CORE106_INST_EXPORT_23.zip'
+      - 'S4CORE106_INST_EXPORT_24.zip'
+      - 'S4CORE106_INST_EXPORT_25.zip'
+      - 'S4CORE106_INST_EXPORT_26.zip'
+      - 'S4CORE106_INST_EXPORT_27.zip'
+      - 'S4CORE106_INST_EXPORT_28.zip'
+      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004822.SAR'
-      - 'S4CORE106_INST_EXPORT_1.zip'
-      - 'S4CORE106_INST_EXPORT_2.zip'
-      - 'S4CORE106_INST_EXPORT_3.zip'
-      - 'S4CORE106_INST_EXPORT_4.zip'
-      - 'S4CORE106_INST_EXPORT_5.zip'
-      - 'S4CORE106_INST_EXPORT_6.zip'
-      - 'S4CORE106_INST_EXPORT_7.zip'
-      - 'S4CORE106_INST_EXPORT_8.zip'
-      - 'S4CORE106_INST_EXPORT_9.zip'
-      - 'S4CORE106_INST_EXPORT_10.zip'
-      - 'S4CORE106_INST_EXPORT_11.zip'
-      - 'S4CORE106_INST_EXPORT_12.zip'
-      - 'S4CORE106_INST_EXPORT_13.zip'
-      - 'S4CORE106_INST_EXPORT_14.zip'
-      - 'S4CORE106_INST_EXPORT_15.zip'
-      - 'S4CORE106_INST_EXPORT_16.zip'
-      - 'S4CORE106_INST_EXPORT_17.zip'
-      - 'S4CORE106_INST_EXPORT_18.zip'
-      - 'S4CORE106_INST_EXPORT_19.zip'
-      - 'S4CORE106_INST_EXPORT_20.zip'
-      - 'S4CORE106_INST_EXPORT_21.zip'
-      - 'S4CORE106_INST_EXPORT_22.zip'
-      - 'S4CORE106_INST_EXPORT_23.zip'
-      - 'S4CORE106_INST_EXPORT_24.zip'
-      - 'S4CORE106_INST_EXPORT_25.zip'
-      - 'S4CORE106_INST_EXPORT_26.zip'
-      - 'S4CORE106_INST_EXPORT_27.zip'
-      - 'S4CORE106_INST_EXPORT_28.zip'
-      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004831.SAR'
-      - 'S4CORE106_INST_EXPORT_1.zip'
-      - 'S4CORE106_INST_EXPORT_2.zip'
-      - 'S4CORE106_INST_EXPORT_3.zip'
-      - 'S4CORE106_INST_EXPORT_4.zip'
-      - 'S4CORE106_INST_EXPORT_5.zip'
-      - 'S4CORE106_INST_EXPORT_6.zip'
-      - 'S4CORE106_INST_EXPORT_7.zip'
-      - 'S4CORE106_INST_EXPORT_8.zip'
-      - 'S4CORE106_INST_EXPORT_9.zip'
-      - 'S4CORE106_INST_EXPORT_10.zip'
-      - 'S4CORE106_INST_EXPORT_11.zip'
-      - 'S4CORE106_INST_EXPORT_12.zip'
-      - 'S4CORE106_INST_EXPORT_13.zip'
-      - 'S4CORE106_INST_EXPORT_14.zip'
-      - 'S4CORE106_INST_EXPORT_15.zip'
-      - 'S4CORE106_INST_EXPORT_16.zip'
-      - 'S4CORE106_INST_EXPORT_17.zip'
-      - 'S4CORE106_INST_EXPORT_18.zip'
-      - 'S4CORE106_INST_EXPORT_19.zip'
-      - 'S4CORE106_INST_EXPORT_20.zip'
-      - 'S4CORE106_INST_EXPORT_21.zip'
-      - 'S4CORE106_INST_EXPORT_22.zip'
-      - 'S4CORE106_INST_EXPORT_23.zip'
-      - 'S4CORE106_INST_EXPORT_24.zip'
-      - 'S4CORE106_INST_EXPORT_25.zip'
-      - 'S4CORE106_INST_EXPORT_26.zip'
-      - 'S4CORE106_INST_EXPORT_27.zip'
-      - 'S4CORE106_INST_EXPORT_28.zip'
-      - 'S4HANAOP106_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
 
   sap_s4hana_2020_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2020.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_independent:
+      # Application Media
+      - 'S4CORE105_INST_EXPORT_1.zip'
+      - 'S4CORE105_INST_EXPORT_2.zip'
+      - 'S4CORE105_INST_EXPORT_3.zip'
+      - 'S4CORE105_INST_EXPORT_4.zip'
+      - 'S4CORE105_INST_EXPORT_5.zip'
+      - 'S4CORE105_INST_EXPORT_6.zip'
+      - 'S4CORE105_INST_EXPORT_7.zip'
+      - 'S4CORE105_INST_EXPORT_8.zip'
+      - 'S4CORE105_INST_EXPORT_9.zip'
+      - 'S4CORE105_INST_EXPORT_10.zip'
+      - 'S4CORE105_INST_EXPORT_11.zip'
+      - 'S4CORE105_INST_EXPORT_12.zip'
+      - 'S4CORE105_INST_EXPORT_13.zip'
+      - 'S4CORE105_INST_EXPORT_14.zip'
+      - 'S4CORE105_INST_EXPORT_15.zip'
+      - 'S4CORE105_INST_EXPORT_16.zip'
+      - 'S4CORE105_INST_EXPORT_17.zip'
+      - 'S4CORE105_INST_EXPORT_18.zip'
+      - 'S4CORE105_INST_EXPORT_19.zip'
+      - 'S4CORE105_INST_EXPORT_20.zip'
+      - 'S4CORE105_INST_EXPORT_21.zip'
+      - 'S4CORE105_INST_EXPORT_22.zip'
+      - 'S4CORE105_INST_EXPORT_23.zip'
+      - 'S4CORE105_INST_EXPORT_24.zip'
+      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002031.SAR'
       - 'IMDB_LCAPPS_2067P_400-20010426.SAR'
       - 'IMDB_AFL20_067P_400-80001894.SAR'
-      - 'IMDB_CLIENT20_021_31-80002082.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002082.SAR'
+      # Application Server
       - 'SAPEXE_100-80005374.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005373.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004822.SAR'
-      - 'S4CORE105_INST_EXPORT_1.zip'
-      - 'S4CORE105_INST_EXPORT_2.zip'
-      - 'S4CORE105_INST_EXPORT_3.zip'
-      - 'S4CORE105_INST_EXPORT_4.zip'
-      - 'S4CORE105_INST_EXPORT_5.zip'
-      - 'S4CORE105_INST_EXPORT_6.zip'
-      - 'S4CORE105_INST_EXPORT_7.zip'
-      - 'S4CORE105_INST_EXPORT_8.zip'
-      - 'S4CORE105_INST_EXPORT_9.zip'
-      - 'S4CORE105_INST_EXPORT_10.zip'
-      - 'S4CORE105_INST_EXPORT_11.zip'
-      - 'S4CORE105_INST_EXPORT_12.zip'
-      - 'S4CORE105_INST_EXPORT_13.zip'
-      - 'S4CORE105_INST_EXPORT_14.zip'
-      - 'S4CORE105_INST_EXPORT_15.zip'
-      - 'S4CORE105_INST_EXPORT_16.zip'
-      - 'S4CORE105_INST_EXPORT_17.zip'
-      - 'S4CORE105_INST_EXPORT_18.zip'
-      - 'S4CORE105_INST_EXPORT_19.zip'
-      - 'S4CORE105_INST_EXPORT_20.zip'
-      - 'S4CORE105_INST_EXPORT_21.zip'
-      - 'S4CORE105_INST_EXPORT_22.zip'
-      - 'S4CORE105_INST_EXPORT_23.zip'
-      - 'S4CORE105_INST_EXPORT_24.zip'
-      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_067_4-80002046.SAR'
       - 'IMDB_LCAPPS_2067P_400-80002183.SAR'
       - 'IMDB_AFL20_067P_400-80002045.SAR'
-      - 'IMDB_CLIENT20_021_31-80002095.SAR' # SAP HANA Client
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+      - 'IMDB_CLIENT20_021_31-80002095.SAR'
+      # Application Server
       - 'SAPEXE_100-80005509.SAR' # Kernel Part I (785)
       - 'SAPEXEDB_100-80005508.SAR' # Kernel Part II (785)
       - 'SAPHOSTAGENT61_61-80004831.SAR'
-      - 'S4CORE105_INST_EXPORT_1.zip'
-      - 'S4CORE105_INST_EXPORT_2.zip'
-      - 'S4CORE105_INST_EXPORT_3.zip'
-      - 'S4CORE105_INST_EXPORT_4.zip'
-      - 'S4CORE105_INST_EXPORT_5.zip'
-      - 'S4CORE105_INST_EXPORT_6.zip'
-      - 'S4CORE105_INST_EXPORT_7.zip'
-      - 'S4CORE105_INST_EXPORT_8.zip'
-      - 'S4CORE105_INST_EXPORT_9.zip'
-      - 'S4CORE105_INST_EXPORT_10.zip'
-      - 'S4CORE105_INST_EXPORT_11.zip'
-      - 'S4CORE105_INST_EXPORT_12.zip'
-      - 'S4CORE105_INST_EXPORT_13.zip'
-      - 'S4CORE105_INST_EXPORT_14.zip'
-      - 'S4CORE105_INST_EXPORT_15.zip'
-      - 'S4CORE105_INST_EXPORT_16.zip'
-      - 'S4CORE105_INST_EXPORT_17.zip'
-      - 'S4CORE105_INST_EXPORT_18.zip'
-      - 'S4CORE105_INST_EXPORT_19.zip'
-      - 'S4CORE105_INST_EXPORT_20.zip'
-      - 'S4CORE105_INST_EXPORT_21.zip'
-      - 'S4CORE105_INST_EXPORT_22.zip'
-      - 'S4CORE105_INST_EXPORT_23.zip'
-      - 'S4CORE105_INST_EXPORT_24.zip'
-      - 'S4HANAOP105_ERP_LANG_EN.SAR'
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
+
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  standard:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
+
+# Dictionary of lists for software filename wildcard patterns that is used during rsync operations.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_software_wildcards:
+  hana:
+    - 'SAPCAR*'
+    - 'IMDB_*'
+    - 'SAPHOSTAGENT*'
 
 
 #### Interactive Prompt Control Variables ####

--- a/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_extravars.yml
@@ -30,7 +30,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -132,41 +132,30 @@ sap_software_install_dictionary:
 
   sap_s4hana_2025_standard:
 
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
+    sap_software_list_x86_64:
       - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
       - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    # This list assigned from shared dictionary, because it is same with other products or host types.
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.CORE.HDB.ABAP
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
-      - maintenance_plan_stack_tms_config
-      - maintenance_plan_stack_spam_config
-      - maintenance_plan_stack_sum_config
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
     sap_swpm_inifile_dictionary:
-
       # SAP SWPM using SAP Maintenance Planner Stack XML
       # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
       sap_swpm_configure_tms: true
@@ -177,42 +166,25 @@ sap_software_install_dictionary:
 
 
   sap_s4hana_2023_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
+
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
-    # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2023.CORE.HDB.ABAP
 
-    # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
-      - maintenance_plan_stack_tms_config
-      - maintenance_plan_stack_spam_config
-      - maintenance_plan_stack_sum_config
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
     sap_swpm_inifile_dictionary:
-
       # SAP SWPM using SAP Maintenance Planner Stack XML
       # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
       sap_swpm_configure_tms: true
@@ -223,41 +195,25 @@ sap_software_install_dictionary:
 
 
   sap_s4hana_2022_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
+
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2022.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
-      - maintenance_plan_stack_tms_config
-      - maintenance_plan_stack_spam_config
-      - maintenance_plan_stack_sum_config
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
     sap_swpm_inifile_dictionary:
-
       # SAP SWPM using SAP Maintenance Planner Stack XML
       # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
       sap_swpm_configure_tms: true
@@ -268,41 +224,25 @@ sap_software_install_dictionary:
 
 
   sap_s4hana_2021_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
+
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2021.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
-      - maintenance_plan_stack_tms_config
-      - maintenance_plan_stack_spam_config
-      - maintenance_plan_stack_sum_config
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
     sap_swpm_inifile_dictionary:
-
       # SAP SWPM using SAP Maintenance Planner Stack XML
       # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
       sap_swpm_configure_tms: true
@@ -310,3 +250,34 @@ sap_software_install_dictionary:
       sap_swpm_spam_update: false
       sap_swpm_sum_prepare: true
       sap_swpm_sum_start: true
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  standard:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
+    - maintenance_plan_stack_tms_config
+    - maintenance_plan_stack_spam_config
+    - maintenance_plan_stack_sum_config
+
+# Dictionary of lists for software filename wildcard patterns that is used during rsync operations.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_software_wildcards:
+  hana:
+    - 'SAPCAR*'
+    - 'IMDB_*'
+    - 'SAPHOSTAGENT*'

--- a/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_playbook.yml
@@ -270,8 +270,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
         sap_software_download_mp_transaction: "{{ sap_maintenance_planner_transaction_name }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
@@ -279,7 +280,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['software_files_hana_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['sap_software_files_hana_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_hana_install_media_files
 

--- a/deploy_scenarios/sap_s4hana_standard_maintplan/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_s4hana_standard_maintplan/optional/ansible_extravars_interactive.yml
@@ -43,41 +43,30 @@ sap_software_install_dictionary:
 
   sap_s4hana_2025_standard:
 
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
+    sap_software_list_x86_64:
       - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
       - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    # This list assigned from shared dictionary, because it is same with other products or host types.
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
     # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2025.CORE.HDB.ABAP
 
     # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
-      - maintenance_plan_stack_tms_config
-      - maintenance_plan_stack_spam_config
-      - maintenance_plan_stack_sum_config
+    # This list assigned from dictionary below, because it is same with other products or host types.
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
     sap_swpm_inifile_dictionary:
-
       # SAP SWPM using SAP Maintenance Planner Stack XML
       # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
       sap_swpm_configure_tms: true
@@ -88,42 +77,25 @@ sap_software_install_dictionary:
 
 
   sap_s4hana_2023_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
+
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
-    # SWPM product catalog ID for the installation (String).
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2023.CORE.HDB.ABAP
 
-    # List of INI file sections to generate using sap_install.sap_swpm role (List).
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
-      - maintenance_plan_stack_tms_config
-      - maintenance_plan_stack_spam_config
-      - maintenance_plan_stack_sum_config
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
     sap_swpm_inifile_dictionary:
-
       # SAP SWPM using SAP Maintenance Planner Stack XML
       # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
       sap_swpm_configure_tms: true
@@ -134,41 +106,25 @@ sap_software_install_dictionary:
 
 
   sap_s4hana_2022_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
+
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2022.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
-      - maintenance_plan_stack_tms_config
-      - maintenance_plan_stack_spam_config
-      - maintenance_plan_stack_sum_config
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
     sap_swpm_inifile_dictionary:
-
       # SAP SWPM using SAP Maintenance Planner Stack XML
       # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
       sap_swpm_configure_tms: true
@@ -179,41 +135,25 @@ sap_software_install_dictionary:
 
 
   sap_s4hana_2021_standard:
+    # For detailed comments on each defined parameter, see first product in 'sap_software_install_dictionary'.
+
+    # Independent files are not used, because download uses Maintenance Plan.
+    sap_software_list_independent: []
 
     # SAP SWPM may not be included in the Maintenance Planner stack generated, please check and if not included then append to list
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
+    sap_software_list_x86_64:
+      - 'SAPCAR_1400-70007716.EXE'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
+    sap_software_list_ppc64le:
+      - 'SAPCAR_1400-70007726.EXE'
 
-    software_files_hana_wildcard_list:
-      - 'SAPCAR*'
-      - 'IMDB_*'
-      - 'SAPHOSTAGENT*'
+    sap_software_files_hana_wildcard_list: "{{ sap_playbook_software_wildcards['hana'] }}"
 
-    # Product ID for New Installation
     sap_swpm_product_catalog_id: NW_ABAP_OneHost:S4HANA2021.CORE.HDB.ABAP
 
-    sap_swpm_inifile_sections_list:
-      - swpm_installation_media
-      - swpm_installation_media_swpm2_hana
-      - credentials
-      - credentials_hana
-      - db_config_hana
-      - db_connection_nw_hana
-      - nw_config_other
-      - nw_config_central_services_abap
-      - nw_config_primary_application_server_instance
-      - nw_config_ports
-      - nw_config_host_agent
-      - sap_os_linux_user
-      - maintenance_plan_stack_tms_config
-      - maintenance_plan_stack_spam_config
-      - maintenance_plan_stack_sum_config
+    sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['standard'] }}"
 
     sap_swpm_inifile_dictionary:
-
       # SAP SWPM using SAP Maintenance Planner Stack XML
       # sap_swpm_mp_stack_path: "" # This triggers search of MP Stack XML and alters SAP SWPM execution, use sap_install_media_detect to identify instead
       sap_swpm_configure_tms: true
@@ -221,6 +161,37 @@ sap_software_install_dictionary:
       sap_swpm_spam_update: false
       sap_swpm_sum_prepare: true
       sap_swpm_sum_start: true
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  standard:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana
+    - db_config_hana
+    - db_connection_nw_hana
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_primary_application_server_instance
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
+    - maintenance_plan_stack_tms_config
+    - maintenance_plan_stack_spam_config
+    - maintenance_plan_stack_sum_config
+
+# Dictionary of lists for software filename wildcard patterns that is used during rsync operations.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_software_wildcards:
+  hana:
+    - 'SAPCAR*'
+    - 'IMDB_*'
+    - 'SAPHOSTAGENT*'
 
 
 #### Interactive Prompt Control Variables ####

--- a/deploy_scenarios/sap_solman_sapase_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_solman_sapase_sandbox/ansible_extravars.yml
@@ -32,7 +32,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -91,37 +91,38 @@ sap_software_install_dictionary:
 
   sap_solman_72_sr2_sapase_sandbox:
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SWPM10SP43_2-20009701.SAR'
-      - 'igsexe_13-80003187.sar' # IGS 7.53
-      - 'igshelper_17-10010245.sar'
-      - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
-      # SAP Solution Manager 7.2 SR2 Installation Export I, ZIP. Contains:
-      # EXP1, EXP2 (SAP:SOLMAN:SR27.2:DVD_EXPORT(1/2):SAP SOLUTION MANAGER 7.2 SR2 Installation Export DVD 1/2:Dxxxxxxxx_1)
-      - '51054655_1'
-      # SAP Solution Manager 7.2 SR2 Installation Export II, ZIP. Contains:
-      # EXP3, EXP4 (SAP:SOLMAN:SR27.2:DVD_EXPORT(2/2):SAP SOLUTION MANAGER 7.2 SR2 Installation Export DVD 2/2:Dxxxxxxxx_2)
-      - '51054655_2'
-      # - '51054655_3' # SAP Solution Manager 7.2 SR2 Language, ZIP. (SAP:SAP:SAP:MM:SAP:Dxxxxxxxx_3)
+    # List of product specific software files that are architecture independent.
+    # Independent files are not used, because it is not available for IBM Power Little Endian (ppc64le).
+    sap_software_list_independent: []
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - '51057961_1' # SAP ASE 16.0.04.06 HF1 RDBMS Linux on x86_64 64bit
       - 'ASEBC16004P_5-20012477.SAR' # SAP ASE 16.0 SP04 (160-04) FOR BUS. SUITE DBCLIENT with Patch (P_*)
-      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
-      - 'SAPEXEDB_1000-80002616.SAR' # Kernel Part II (753), SAP ASE 16.0 FOR BUS. SUITE
+      # Application Server
+      - '51054655_1'  # SAP Solution Manager 7.2 SR2 Installation Export I
+      - '51054655_2'  # SAP Solution Manager 7.2 SR2 Installation Export II
+      # - '51054655_3'  # SAP Solution Manager 7.2 SR2 Language
+      - '51054655_4'  # SAP Solution Manager 7.2 SR2 - Java
       # - '51051806_1' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 1/2, RAR
       # - '51051806_2' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 2/2, RAR
-      # JAVA specific
-      # - 'SAPJVM8_90-80000202.SAR' # SAP JVM 8.1 PL 90
+      - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
+      - 'SAPEXEDB_1000-80002616.SAR' # Kernel Part II (753), SAP ASE 16.0 FOR BUS. SUITE
+      - 'SAPHOSTAGENT61_61-80004822.SAR' # SAP Host Agent 7.22
+      - 'igsexe_13-80003187.sar' # IGS 7.53
+      - 'igshelper_17-10010245.sar'
       # SAP JVM 8.1 PL 63. See SAP Note 1680045 for 3 updates on SEP 17, 2020 related to SAP NetWeaver 7.5 JAVA before SP22
       # "SAPJVM 8.1 archive you use has a patch level of 63 or lower"
       - 'SAPJVM8_63-80000202.SAR'
-      # SAP Solution Manager 7.2 SR2 - Java, ZIP. Uses SAP Netweaver 7.5 SP19 JAVA. Contains:
-      # SOLMAN72_JAVA_UT (SAP:UT_SOLMAN:SR2SOLMAN72:SP00:*:*), JAVA_EXPORT (SAP:JEXPORT:SR2_72SOLMAN_2020S4:*:*:*),
-      # JAVA_EXPORT_JDMP (SAP:JDMP:SR2_72SOLMAN_2020S4:*:*:*), JAVA_J2EE_OSINDEP (SAP:J2EE-CD:SR2_72SOLMAN_2020S4:J2EE-CD:j2ee-cd:*),
-      # JAVA_J2EE_OSINDEP_J2EE_INST (SAP:J2EE-INST:SR2_72SOLMAN_2020S4:*:*:*), JAVA_J2EE_OSINDEP_UT (SAP:UT:SR2_72SOLMAN_2020S4:*:*:*)
-      - '51054655_4'
+      # - 'SAPJVM8_90-80000202.SAR' # SAP JVM 8.1 PL 90
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_2-20009701.SAR'
 
-    softwarecenter_search_list_ppc64le:
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    # Not available for IBM Power Little Endian (ppc64le), leave code to keep similarity of code structure across all Ansible Playbooks for SAP
+    sap_software_list_ppc64le:
       - 'SAPCAR_1300-70007726.EXE'
 
     # SAP Solution Manager 7.2 Support Release 2 > SAP Solution Manager 7.2 ABAP Support Release 2

--- a/deploy_scenarios/sap_solman_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_solman_sapase_sandbox/ansible_playbook.yml
@@ -206,8 +206,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 

--- a/deploy_scenarios/sap_solman_saphana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_solman_saphana_sandbox/ansible_extravars.yml
@@ -33,7 +33,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -129,61 +129,52 @@ sap_software_install_dictionary:
 
   sap_solman_72_sr2_saphana_sandbox:
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SWPM10SP43_3-20009701.SAR'
-      - 'igsexe_5-80007786.sar' # IGS 7.54
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Media
+      - '51054655_1'  # SAP Solution Manager 7.2 SR2 Installation Export I
+      - '51054655_2'  # SAP Solution Manager 7.2 SR2 Installation Export II
+      # - '51054655_3'  # SAP Solution Manager 7.2 SR2 Language
+      - '51054655_4'  # SAP Solution Manager 7.2 SR2 - Java
+      # Application Server
       - 'igshelper_17-10010245.sar'
-      - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP HOST AGENT 7.22 SP67
-      # SAP Solution Manager 7.2 SR2 Installation Export I, ZIP. Contains:
-      # EXP1, EXP2 (SAP:SOLMAN:SR27.2:DVD_EXPORT(1/2):SAP SOLUTION MANAGER 7.2 SR2 Installation Export DVD 1/2:Dxxxxxxxx_1)
-      - '51054655_1'
-      # SAP Solution Manager 7.2 SR2 Installation Export II, ZIP. Contains:
-      # EXP3, EXP4 (SAP:SOLMAN:SR27.2:DVD_EXPORT(2/2):SAP SOLUTION MANAGER 7.2 SR2 Installation Export DVD 2/2:Dxxxxxxxx_2)
-      - '51054655_2'
-      # - '51054655_3' # SAP Solution Manager 7.2 SR2 Language, ZIP. (SAP:SAP:SAP:MM:SAP:Dxxxxxxxx_3)
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002031.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002082.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
       - 'SAPEXE_500-80007612.SAR'  # Kernel Part I (754)
       - 'SAPEXEDB_500-80007611.SAR'  # Kernel Part II (754)
-      # JAVA specific
-      # - 'SAPJVM8_90-80000202.SAR' # SAP JVM 8.1 PL 90
+      - 'SAPHOSTAGENT67_67-80004822.SAR'  # SAP HOST AGENT 7.22 SP67
+      - 'igsexe_5-80007786.sar' # IGS 7.54
       # SAP JVM 8.1 PL 63. See SAP Note 1680045 for 3 updates on SEP 17, 2020 related to SAP NetWeaver 7.5 JAVA before SP22
       # "SAPJVM 8.1 archive you use has a patch level of 63 or lower"
       - 'SAPJVM8_63-80000202.SAR'
-      # SAP Solution Manager 7.2 SR2 - Java, ZIP. Uses SAP Netweaver 7.5 SP19 JAVA. Contains:
-      # SOLMAN72_JAVA_UT (SAP:UT_SOLMAN:SR2SOLMAN72:SP00:*:*), JAVA_EXPORT (SAP:JEXPORT:SR2_72SOLMAN_2020S4:*:*:*),
-      # JAVA_EXPORT_JDMP (SAP:JDMP:SR2_72SOLMAN_2020S4:*:*:*), JAVA_J2EE_OSINDEP (SAP:J2EE-CD:SR2_72SOLMAN_2020S4:J2EE-CD:j2ee-cd:*),
-      # JAVA_J2EE_OSINDEP_J2EE_INST (SAP:J2EE-INST:SR2_72SOLMAN_2020S4:*:*:*), JAVA_J2EE_OSINDEP_UT (SAP:UT:SR2_72SOLMAN_2020S4:*:*:*)
-      - '51054655_4'
+      # - 'SAPJVM8_90-80000202.SAR' # SAP JVM 8.1 PL 90
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM10SP43_3-20009701.SAR'
 
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
-      - 'SWPM10SP43_3-70002492.SAR'
-      - 'igsexe_5-80007795.sar' # IGS 7.54
-      - 'igshelper_17-10010245.sar'
-      - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP HOST AGENT 7.22 SP67
-      # SAP Solution Manager 7.2 SR2 Installation Export I, ZIP. Contains:
-      # EXP1, EXP2 (SAP:SOLMAN:SR27.2:DVD_EXPORT(1/2):SAP SOLUTION MANAGER 7.2 SR2 Installation Export DVD 1/2:Dxxxxxxxx_1)
-      - '51054655_1'
-      # SAP Solution Manager 7.2 SR2 Installation Export II, ZIP. Contains:
-      # EXP3, EXP4 (SAP:SOLMAN:SR27.2:DVD_EXPORT(2/2):SAP SOLUTION MANAGER 7.2 SR2 Installation Export DVD 2/2:Dxxxxxxxx_2)
-      - '51054655_2'
-      # - '51054655_3' # SAP Solution Manager 7.2 SR2 Language, ZIP. (SAP:SAP:SAP:MM:SAP:Dxxxxxxxx_3)
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Database Server
       - 'IMDB_SERVER20_089_1-80002046.SAR'  # Revision 2.00.089.1 (SPS08) for HANA DB 2.0
       - 'IMDB_CLIENT20_028_17-80002095.SAR'  # SAP HANA CLIENT Version 2.28
+      # Application Server
       - 'SAPEXE_500-80007669.SAR' # Kernel Part I (754)
       - 'SAPEXEDB_500-80007668.SAR' # Kernel Part II (754), SAP HANA
-      # JAVA specific
-      # - 'SAPJVM8_90-80000202.SAR' # SAP JVM 8.1 PL 90
+      - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP HOST AGENT 7.22 SP67
+      - 'igsexe_5-80007795.sar' # IGS 7.54
       # # SAP JVM 8.1 PL 63. See SAP Note 1680045 for 3 updates on SEP 17, 2020 related to SAP NetWeaver 7.5 JAVA before SP22
       # "SAPJVM 8.1 archive you use has a patch level of 63 or lower"
       - 'SAPJVM8_63-70001621.SAR'
-      # SAP Solution Manager 7.2 SR2 - Java, ZIP. Uses SAP Netweaver 7.5 SP19 JAVA. Contains:
-      # SOLMAN72_JAVA_UT (SAP:UT_SOLMAN:SR2SOLMAN72:SP00:*:*), JAVA_EXPORT (SAP:JEXPORT:SR2_72SOLMAN_2020S4:*:*:*),
-      # JAVA_EXPORT_JDMP (SAP:JDMP:SR2_72SOLMAN_2020S4:*:*:*), JAVA_J2EE_OSINDEP (SAP:J2EE-CD:SR2_72SOLMAN_2020S4:J2EE-CD:j2ee-cd:*),
-      # JAVA_J2EE_OSINDEP_J2EE_INST (SAP:J2EE-INST:SR2_72SOLMAN_2020S4:*:*:*), JAVA_J2EE_OSINDEP_UT (SAP:UT:SR2_72SOLMAN_2020S4:*:*:*)
-      - '51054655_4'
+      # - 'SAPJVM8_90-80000202.SAR' # SAP JVM 8.1 PL 90
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM10SP43_3-70002492.SAR'
+
 
     # SAP Solution Manager 7.2 Support Release 2 > SAP Solution Manager 7.2 ABAP Support Release 2
     # > SAP HANA > Installation > Application Server ABAP > Standard System > Standard System

--- a/deploy_scenarios/sap_solman_saphana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_solman_saphana_sandbox/ansible_playbook.yml
@@ -207,8 +207,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 

--- a/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_extravars.yml
+++ b/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_extravars.yml
@@ -33,7 +33,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -121,24 +121,32 @@ sap_software_install_dictionary:
 
   sap_s4hana_2023_distributed:
 
-    softwarecenter_search_list_x86_64:
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SWPM20SP20_1-80003424.SAR'
-      - 'igsexe_4-70005417.sar' # IGS 7.81
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Server
       - 'igshelper_17-10010245.sar'
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Application Server
       - 'SAPEXE_51-70007807.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007806.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
+      - 'igsexe_4-70005417.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007716.EXE'
+      - 'SWPM20SP20_1-80003424.SAR'
 
-
-    softwarecenter_search_list_ppc64le:
-      - 'SAPCAR_1300-70007726.EXE'
-      - 'SWPM20SP20_1-80003426.SAR'
-      - 'igsexe_4-70005446.sar' # IGS 7.81
-      - 'igshelper_17-10010245.sar'
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Application Server
       - 'SAPEXE_51-70007832.SAR' # Kernel Part I (793)
       - 'SAPEXEDB_51-70007831.SAR' # Kernel Part II (793)
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
+      - 'igsexe_4-70005446.sar' # IGS 7.81
+      # Tools
+      - 'SAPCAR_1300-70007726.EXE'
+      - 'SWPM20SP20_1-80003426.SAR'
 
     nwas_ascs_ha:
 
@@ -157,7 +165,7 @@ sap_software_install_dictionary:
         - nw_config_host_agent
         - sap_os_linux_user
 
-      software_files_wildcard_list:
+      sap_software_files_wildcard_list:
         - 'SAPCAR*'
         - 'SWPM20*'
         - 'igsexe_*'
@@ -178,7 +186,7 @@ sap_software_install_dictionary:
         - nw_config_ers
         - sap_os_linux_user
 
-      software_files_wildcard_list:
+      sap_software_files_wildcard_list:
         - 'SAPCAR*'
         - 'SWPM20*'
         - 'igsexe_*'

--- a/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_extravars_ibmpowervm_vm_base.yml
+++ b/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_extravars_ibmpowervm_vm_base.yml
@@ -13,5 +13,5 @@ sap_vm_provision_nfs_mount_point_opts: "ENTER_STRING_VALUE_HERE"  # NFS Mount op
 sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host: "ENTER_STRING_VALUE_HERE"
 sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_port: "ENTER_STRING_VALUE_HERE" # Default, 22 for SSH
 sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_login: "ENTER_STRING_VALUE_HERE"
-sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_login_password: "ENTER_STRING_VALUE_HERE"
+sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_login_password: ''
 sap_ha_pacemaker_cluster_ibmpower_vm_hmc_host_version: "4"

--- a/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_playbook.yml
+++ b/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_playbook.yml
@@ -208,8 +208,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
-          ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
+        sap_software_download_files: "{{ (
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
+          sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 
 
@@ -217,7 +218,7 @@
       ansible.builtin.find:
         paths:
           - "{{ sap_install_media_detect_source_directory }}"
-        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_ers_ha']['software_files_wildcard_list'] }}"
+        patterns: "{{ sap_software_install_dictionary[sap_software_product]['nwas_ers_ha']['sap_software_files_wildcard_list'] }}"
         recurse: true
       register: __sap_playbook_register_sap_nwas_ers_install_media_files
 

--- a/special_actions/sap_webdispatcher_standalone/ansible_extravars.yml
+++ b/special_actions/sap_webdispatcher_standalone/ansible_extravars.yml
@@ -31,7 +31,7 @@ sap_software_product: "ENTER_STRING_VALUE_HERE"
 ## Required for download using community.sap_launchpad
 # SAP ONE Support Launchpad credentials
 sap_id_user: "ENTER_STRING_VALUE_HERE"  # Your SAP S-user ID (String).
-sap_id_user_password: 'ENTER_STRING_VALUE_HERE'  # Your SAP S-user password (String).
+sap_id_user_password: ''  # Your SAP S-user password (String).
 
 # Directory with SAP installation media (e.g. /software) (String)
 sap_install_media_detect_source_directory: "ENTER_STRING_VALUE_HERE"
@@ -96,7 +96,7 @@ sap_playbook_webdispatcher_version: "ENTER_STRING_VALUE_HERE" # sap_webdispatche
 #   https://me.sap.com/softwarecenter/template/products/ENR=01200314690100001804&EVENT=TREE&NE=NAVIGATE&V=MAINT
 # Maintenance Software Component (Archive View) Category
 #   https://me.sap.com/softwarecenter/template/products/ENR=01200314690100001804&EVENT=TREE&NE=NAVIGATE&V=MAINT&TA=ARCHIVE
-softwarecenter_search_list_x86_64:
+sap_software_dict_x86_64:
 
   sap_webdispatcher_7_20ext:
     - 'sapwebdisp_718-20008610.sar'  # SAP Web Dispatcher 7.20 EXT Linux
@@ -173,6 +173,9 @@ softwarecenter_search_list_x86_64:
     - 'igsexe_13-80003187.sar' # IGS 7.53
     - 'igshelper_17-10010245.sar'
     - 'SAPWEBDISP_SP_68-80008274.SAR'  # SAP Web Dispatcher 7.93 Linux, original release 06-2023. Released for SAP S/4HANA 2023
+
+# There is no defined dictionary of lists for ppc64le and playbook will fail.
+sap_software_dict_ppc64le: {}
 
 
 #### Shared Ansible Facts ####

--- a/special_actions/sap_webdispatcher_standalone/ansible_playbook.yml
+++ b/special_actions/sap_webdispatcher_standalone/ansible_playbook.yml
@@ -118,9 +118,9 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: first
-        sap_software_download_files: "{{ softwarecenter_search_list_x86_64[sap_playbook_webdispatcher_version]
+        sap_software_download_files: "{{ sap_software_dict_x86_64[sap_playbook_webdispatcher_version]
           if ansible_facts['architecture'] == 'x86_64'
-          else (softwarecenter_search_list_ppc64le[sap_playbook_webdispatcher_version]
+          else (sap_software_dict_ppc64le[sap_playbook_webdispatcher_version]
             if ansible_facts['architecture'] == 'ppc64le' else '') }}"
       when: __sap_playbook_register_collection_list_output.stdout_lines | select('search', 'community.sap_launchpad') | length > 0
 


### PR DESCRIPTION
## Changes

### 1. Reuse architecture independent files
All scenarios (with few exceptions in special_actions) were split into new software lists, splitting SAP files into architecture dependent and not. This removes duplicated installation exports.
```yaml
sap_software_list_independent
sap_software_list_x86_64
sap_software_list_ppc64le
``` 
Based on https://github.com/sap-linuxlab/ansible.playbooks_for_sap/issues/104

### 2. Reuse wildcard and swpm_inifile lists for distributed systems
Existing dictionary contained duplicated lists for each product and host type and this simplifies them into dictionary which is called with: 
```yaml
sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs_pas'] }}"
sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['netweaver'] }}"
```

Based on https://github.com/sap-linuxlab/ansible.playbooks_for_sap/issues/105

### 3. Remove placeholder values for sap_id_user_password
Password placeholder values were removed previously for all preset passwords, but placeholders with `ENTER_STRING_VALUE_HERE` were not touched. This remediated leftovers.

Based on https://github.com/sap-linuxlab/ansible.playbooks_for_sap/issues/100

### 4. Start of variable simplification
Software lists were renamed to go along with `sap_` prefix from previous `softwarecenter_search_list_`, but it is not complete move to playbook variables `sap_playbook_`.

New dictionaries were already added with new names, but rest of variables will have to come as separate PR.
```yaml
sap_playbook_swpm_inifile_sections
sap_playbook_swpm_inifile_sections
```

### Tests
Playbooks were tested on SLES_SAP 16.0 on AWS to ensure they pass `sap_launchpad` execution and RSYNC.
Remaining code was unchanged so further testing was not completed.
