### PR TITLE
all: Add conditional rsync hostname delegate and update sap_launchpad parameters

### DIFF
--- a/common_fragments/vars/platform_vars_gcp_ce_vm.yml
+++ b/common_fragments/vars/platform_vars_gcp_ce_vm.yml
@@ -8,7 +8,7 @@ sap_vm_provision_bastion_ssh_port: "ENTER_STRING_VALUE_HERE"  # Bastion user pas
 sap_vm_provision_bastion_public_ip: "ENTER_STRING_VALUE_HERE"  # Public IP of the bastion server (String).
 sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion server's SSH private key on the execution node (String).
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to target host's SSH private key on the execution node (String).
-sap_vm_provision_ssh_host_public_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion public host key on execution node (String).
+sap_vm_provision_ssh_host_public_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to target host's SSH public key on execution node (String).
 
 #### Infrastructure platform variables ####
 sap_vm_provision_iac_platform: "gcp_ce_vm"  # Name of the provisioning platform (String).

--- a/deploy_scenarios/sap_bw4hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_bw4hana_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_bw4hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_bw4hana_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml
@@ -273,6 +273,24 @@
   max_fail_percentage: 0
   tasks:
 
+    - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts  # noqa: no-tabs
+      ansible.builtin.import_role:
+        name: community.sap_install.sap_maintain_etc_hosts
+      vars:
+        sap_maintain_etc_hosts_delimiter: "\t"
+        sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+        sap_maintain_etc_hosts_list: >-
+          {%- set my_list = [] -%}
+          {%- for host in ansible_play_hosts_all -%}
+            {%- if hostvars[host] is defined and hostvars[host]['ansible_host'] is defined -%}
+              {%- set _ = my_list.append({'node_name': host, 'node_ip': hostvars[host]['ansible_host']}) -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {{ my_list }}
+      when:
+        - sap_vm_provision_iac_platform == 'existing_hosts'
+        - sap_domain | d('') | length > 0 or ansible_facts['domain'] | d('') | length > 0
+
     - name: Install rsync
       ansible.builtin.package:
         name: rsync
@@ -304,7 +322,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -336,7 +354,7 @@
   tasks:
 
     - name: Transfer SAP HANA installation media to SAP HANA hosts
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml
@@ -323,6 +323,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ecc_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_hana_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ecc_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_hana_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_playbook.yml
@@ -238,6 +238,24 @@
   max_fail_percentage: 0
   tasks:
 
+    - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts  # noqa: no-tabs
+      ansible.builtin.import_role:
+        name: community.sap_install.sap_maintain_etc_hosts
+      vars:
+        sap_maintain_etc_hosts_delimiter: "\t"
+        sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+        sap_maintain_etc_hosts_list: >-
+          {%- set my_list = [] -%}
+          {%- for host in ansible_play_hosts_all -%}
+            {%- if hostvars[host] is defined and hostvars[host]['ansible_host'] is defined -%}
+              {%- set _ = my_list.append({'node_name': host, 'node_ip': hostvars[host]['ansible_host']}) -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {{ my_list }}
+      when:
+        - sap_vm_provision_iac_platform == 'existing_hosts'
+        - sap_domain | d('') | length > 0 or ansible_facts['domain'] | d('') | length > 0
+
     - name: Install rsync
       ansible.builtin.package:
         name: rsync
@@ -269,7 +287,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -309,7 +327,7 @@
   tasks:
 
     - name: Transfer all installation media to AnyDB Database Instance Primary
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ sap_install_media_detect_source_directory }}/" # trailing slash to copy items in the directory, not the directory itself
@@ -333,7 +351,7 @@
   tasks:
 
     - name: Transfer SAP NetWeaver ASCS installation media to host
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -360,7 +378,7 @@
   tasks:
 
     - name: Transfer SAP NetWeaver AAS installation media to host
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_playbook.yml
@@ -288,6 +288,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_playbook.yml
@@ -240,6 +240,41 @@
   max_fail_percentage: 0
   tasks:
 
+    - name: Block to prepare /etc/hosts entries for all hosts
+      when:
+        - sap_vm_provision_iac_platform == 'existing_hosts'
+        - sap_domain | d('') | length > 0 or ansible_facts['domain'] | d('') | length > 0
+      block:
+
+        - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts  # noqa: no-tabs
+          ansible.builtin.import_role:
+            name: community.sap_install.sap_maintain_etc_hosts
+          vars:
+            sap_maintain_etc_hosts_delimiter: "\t"
+            sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+            sap_maintain_etc_hosts_list: >-
+              {%- set my_list = [] -%}
+              {%- for host in ansible_play_hosts_all -%}
+                {%- if hostvars[host] is defined and hostvars[host]['ansible_host'] is defined -%}
+                  {%- set _ = my_list.append({'node_name': host, 'node_ip': hostvars[host]['ansible_host']}) -%}
+                {%- endif -%}
+              {%- endfor -%}
+              {{ my_list }}
+
+        - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts - HA  # noqa: no-tabs
+          ansible.builtin.import_role:
+            name: community.sap_install.sap_maintain_etc_hosts
+          vars:
+            sap_maintain_etc_hosts_delimiter: "\t"
+            sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+            sap_maintain_etc_hosts_list:
+              - node_name: "{{ sap_swpm_ascs_instance_hostname }}"
+                node_ip: "{{ sap_vm_provision_ha_vip_nwas_abap_ascs | regex_replace('/\\d+$', '') }}"
+              - node_name: "{{ sap_swpm_ers_instance_hostname }}"
+                node_ip: "{{ sap_vm_provision_ha_vip_nwas_abap_ers | regex_replace('/\\d+$', '') }}"
+              - node_name: "{{ sap_swpm_db_host }}"
+                node_ip: "{{ sap_vm_provision_ha_vip_anydb_primary | regex_replace('/\\d+$', '') }}"
+
     - name: Install rsync
       ansible.builtin.package:
         name: rsync
@@ -271,7 +306,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -319,7 +354,7 @@
   tasks:
 
     - name: Transfer all installation media to AnyDB Database Instance Primary
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ sap_install_media_detect_source_directory }}/" # trailing slash to copy items in the directory, not the directory itself
@@ -343,7 +378,7 @@
   tasks:
 
     - name: Transfer SAP AnyDB installation media to AnyDB Database Instance Secondary
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -370,7 +405,7 @@
   tasks:
 
     - name: Transfer SAP NetWeaver ASCS installation media to host
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -397,7 +432,7 @@
   tasks:
 
     - name: Transfer SAP NetWeaver AAS installation media to host
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -682,7 +717,7 @@
   tasks:
 
     - name: Transfer Database Backup file for SAP ECC Homogeneous System Copy to the AnyDB Database Instance Secondary
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ sap_install_media_detect_source_directory }}/db2_db_backup_anydb_primary_node" # no trailing slash to copy directory and the contents

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_playbook.yml
@@ -307,6 +307,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_hana/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana/ansible_playbook.yml
@@ -250,7 +250,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_hana/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana/ansible_playbook.yml
@@ -251,6 +251,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_hana_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana_ha/ansible_playbook.yml
@@ -300,6 +300,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_hana_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana_ha/ansible_playbook.yml
@@ -237,6 +237,37 @@
   max_fail_percentage: 0
   tasks:
 
+    - name: Block to prepare /etc/hosts entries for all hosts
+      when:
+        - sap_vm_provision_iac_platform == 'existing_hosts'
+        - sap_domain | d('') | length > 0 or ansible_facts['domain'] | d('') | length > 0
+      block:
+
+        - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts  # noqa: no-tabs
+          ansible.builtin.import_role:
+            name: community.sap_install.sap_maintain_etc_hosts
+          vars:
+            sap_maintain_etc_hosts_delimiter: "\t"
+            sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+            sap_maintain_etc_hosts_list: >-
+              {%- set my_list = [] -%}
+              {%- for host in ansible_play_hosts_all -%}
+                {%- if hostvars[host] is defined and hostvars[host]['ansible_host'] is defined -%}
+                  {%- set _ = my_list.append({'node_name': host, 'node_ip': hostvars[host]['ansible_host']}) -%}
+                {%- endif -%}
+              {%- endfor -%}
+              {{ my_list }}
+
+        - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts - HA  # noqa: no-tabs
+          ansible.builtin.import_role:
+            name: community.sap_install.sap_maintain_etc_hosts
+          vars:
+            sap_maintain_etc_hosts_delimiter: "\t"
+            sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+            sap_maintain_etc_hosts_list:
+              - node_name: "{{ sap_swpm_db_host }}"
+                node_ip: "{{ sap_vm_provision_ha_vip_hana_primary | regex_replace('/\\d+$', '') }}"
+
     - name: Install rsync
       ansible.builtin.package:
         name: rsync
@@ -268,7 +299,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -300,7 +331,7 @@
   tasks:
 
     - name: Transfer SAP HANA installation media to SAP HANA Primary and SAP HANA Secondary
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"

--- a/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml
@@ -287,7 +287,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml
@@ -288,6 +288,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_landscape_s4hana_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard/ansible_playbook.yml
@@ -177,6 +177,24 @@
   max_fail_percentage: 0
   tasks:
 
+    - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts  # noqa: no-tabs
+      ansible.builtin.import_role:
+        name: community.sap_install.sap_maintain_etc_hosts
+      vars:
+        sap_maintain_etc_hosts_delimiter: "\t"
+        sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+        sap_maintain_etc_hosts_list: >-
+          {%- set my_list = [] -%}
+          {%- for host in ansible_play_hosts_all -%}
+            {%- if hostvars[host] is defined and hostvars[host]['ansible_host'] is defined -%}
+              {%- set _ = my_list.append({'node_name': host, 'node_ip': hostvars[host]['ansible_host']}) -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {{ my_list }}
+      when:
+        - sap_vm_provision_iac_platform == 'existing_hosts'
+        - sap_domain | d('') | length > 0 or ansible_facts['domain'] | d('') | length > 0
+
     - name: Install rsync
       ansible.builtin.package:
         name: rsync
@@ -208,7 +226,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -298,7 +316,8 @@
   tasks:
 
     - name: Transfer SAP HANA installation media to SAP HANA Primary
-      delegate_to: "{{ sap_inventory_project_dev_nwas_pas_ip }}"
+      delegate_to: "{{ sap_inventory_project_dev_nwas_pas_ip
+        if sap_vm_provision_iac_platform != 'existing_hosts' else sap_inventory_project_dev_nwas_pas_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -326,7 +345,8 @@
   tasks:
 
     - name: Transfer SAP NetWeaver ASCS installation media to host
-      delegate_to: "{{ sap_inventory_project_dev_nwas_pas_ip }}"
+      delegate_to: "{{ sap_inventory_project_dev_nwas_pas_ip
+        if sap_vm_provision_iac_platform != 'existing_hosts' else sap_inventory_project_dev_nwas_pas_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"

--- a/deploy_scenarios/sap_landscape_s4hana_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard/ansible_playbook.yml
@@ -227,6 +227,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_playbook.yml
@@ -177,6 +177,24 @@
   max_fail_percentage: 0
   tasks:
 
+    - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts  # noqa: no-tabs
+      ansible.builtin.import_role:
+        name: community.sap_install.sap_maintain_etc_hosts
+      vars:
+        sap_maintain_etc_hosts_delimiter: "\t"
+        sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+        sap_maintain_etc_hosts_list: >-
+          {%- set my_list = [] -%}
+          {%- for host in ansible_play_hosts_all -%}
+            {%- if hostvars[host] is defined and hostvars[host]['ansible_host'] is defined -%}
+              {%- set _ = my_list.append({'node_name': host, 'node_ip': hostvars[host]['ansible_host']}) -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {{ my_list }}
+      when:
+        - sap_vm_provision_iac_platform == 'existing_hosts'
+        - sap_domain | d('') | length > 0 or ansible_facts['domain'] | d('') | length > 0
+
     - name: Install rsync
       ansible.builtin.package:
         name: rsync
@@ -208,7 +226,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -299,7 +317,8 @@
   tasks:
 
     - name: Transfer SAP HANA installation media to SAP HANA Primary
-      delegate_to: "{{ sap_inventory_project_dev_nwas_pas_ip }}"
+      delegate_to: "{{ sap_inventory_project_dev_nwas_pas_ip
+        if sap_vm_provision_iac_platform != 'existing_hosts' else sap_inventory_project_dev_nwas_pas_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -327,7 +346,8 @@
   tasks:
 
     - name: Transfer SAP NetWeaver ASCS installation media to host
-      delegate_to: "{{ sap_inventory_project_dev_nwas_pas_ip }}"
+      delegate_to: "{{ sap_inventory_project_dev_nwas_pas_ip
+        if sap_vm_provision_iac_platform != 'existing_hosts' else sap_inventory_project_dev_nwas_pas_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"

--- a/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_playbook.yml
@@ -227,6 +227,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_playbook.yml
@@ -256,7 +256,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_playbook.yml
@@ -257,6 +257,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_playbook.yml
@@ -256,7 +256,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_playbook.yml
@@ -257,6 +257,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_playbook.yml
@@ -256,7 +256,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_playbook.yml
@@ -257,6 +257,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_distributed/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed/ansible_playbook.yml
@@ -238,6 +238,24 @@
   max_fail_percentage: 0
   tasks:
 
+    - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts  # noqa: no-tabs
+      ansible.builtin.import_role:
+        name: community.sap_install.sap_maintain_etc_hosts
+      vars:
+        sap_maintain_etc_hosts_delimiter: "\t"
+        sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+        sap_maintain_etc_hosts_list: >-
+          {%- set my_list = [] -%}
+          {%- for host in ansible_play_hosts_all -%}
+            {%- if hostvars[host] is defined and hostvars[host]['ansible_host'] is defined -%}
+              {%- set _ = my_list.append({'node_name': host, 'node_ip': hostvars[host]['ansible_host']}) -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {{ my_list }}
+      when:
+        - sap_vm_provision_iac_platform == 'existing_hosts'
+        - sap_domain | d('') | length > 0 or ansible_facts['domain'] | d('') | length > 0
+
     - name: Install rsync
       ansible.builtin.package:
         name: rsync
@@ -269,7 +287,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -317,7 +335,7 @@
   tasks:
 
     - name: Transfer SAP HANA installation media to SAP HANA Primary
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -344,7 +362,7 @@
   tasks:
 
     - name: Transfer SAP NetWeaver ASCS installation media to host
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -371,7 +389,7 @@
   tasks:
 
     - name: Transfer SAP NetWeaver AAS installation media to host
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"

--- a/deploy_scenarios/sap_s4hana_distributed/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed/ansible_playbook.yml
@@ -288,6 +288,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_distributed_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/ansible_playbook.yml
@@ -244,6 +244,41 @@
   max_fail_percentage: 0
   tasks:
 
+    - name: Block to prepare /etc/hosts entries for all hosts
+      when:
+        - sap_vm_provision_iac_platform == 'existing_hosts'
+        - sap_domain | d('') | length > 0 or ansible_facts['domain'] | d('') | length > 0
+      block:
+
+        - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts  # noqa: no-tabs
+          ansible.builtin.import_role:
+            name: community.sap_install.sap_maintain_etc_hosts
+          vars:
+            sap_maintain_etc_hosts_delimiter: "\t"
+            sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+            sap_maintain_etc_hosts_list: >-
+              {%- set my_list = [] -%}
+              {%- for host in ansible_play_hosts_all -%}
+                {%- if hostvars[host] is defined and hostvars[host]['ansible_host'] is defined -%}
+                  {%- set _ = my_list.append({'node_name': host, 'node_ip': hostvars[host]['ansible_host']}) -%}
+                {%- endif -%}
+              {%- endfor -%}
+              {{ my_list }}
+
+        - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts - HA  # noqa: no-tabs
+          ansible.builtin.import_role:
+            name: community.sap_install.sap_maintain_etc_hosts
+          vars:
+            sap_maintain_etc_hosts_delimiter: "\t"
+            sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+            sap_maintain_etc_hosts_list:
+              - node_name: "{{ sap_swpm_ascs_instance_hostname }}"
+                node_ip: "{{ sap_vm_provision_ha_vip_nwas_abap_ascs | regex_replace('/\\d+$', '') }}"
+              - node_name: "{{ sap_swpm_ers_instance_hostname }}"
+                node_ip: "{{ sap_vm_provision_ha_vip_nwas_abap_ers | regex_replace('/\\d+$', '') }}"
+              - node_name: "{{ sap_swpm_db_host }}"
+                node_ip: "{{ sap_vm_provision_ha_vip_hana_primary | regex_replace('/\\d+$', '') }}"
+
     - name: Install rsync
       ansible.builtin.package:
         name: rsync
@@ -275,7 +310,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -331,7 +366,7 @@
   tasks:
 
     - name: Transfer SAP HANA installation media to SAP HANA Primary and SAP HANA Secondary
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -361,7 +396,7 @@
   tasks:
 
     - name: Transfer SAP NetWeaver ASCS installation media to host
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -391,7 +426,7 @@
   tasks:
 
     - name: Transfer SAP NetWeaver AAS installation media to host
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"

--- a/deploy_scenarios/sap_s4hana_distributed_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/ansible_playbook.yml
@@ -311,6 +311,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_playbook.yml
@@ -244,6 +244,41 @@
   max_fail_percentage: 0
   tasks:
 
+    - name: Block to prepare /etc/hosts entries for all hosts
+      when:
+        - sap_vm_provision_iac_platform == 'existing_hosts'
+        - sap_domain | d('') | length > 0 or ansible_facts['domain'] | d('') | length > 0
+      block:
+
+        - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts  # noqa: no-tabs
+          ansible.builtin.import_role:
+            name: community.sap_install.sap_maintain_etc_hosts
+          vars:
+            sap_maintain_etc_hosts_delimiter: "\t"
+            sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+            sap_maintain_etc_hosts_list: >-
+              {%- set my_list = [] -%}
+              {%- for host in ansible_play_hosts_all -%}
+                {%- if hostvars[host] is defined and hostvars[host]['ansible_host'] is defined -%}
+                  {%- set _ = my_list.append({'node_name': host, 'node_ip': hostvars[host]['ansible_host']}) -%}
+                {%- endif -%}
+              {%- endfor -%}
+              {{ my_list }}
+
+        - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts - HA  # noqa: no-tabs
+          ansible.builtin.import_role:
+            name: community.sap_install.sap_maintain_etc_hosts
+          vars:
+            sap_maintain_etc_hosts_delimiter: "\t"
+            sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+            sap_maintain_etc_hosts_list:
+              - node_name: "{{ sap_swpm_ascs_instance_hostname }}"
+                node_ip: "{{ sap_vm_provision_ha_vip_nwas_abap_ascs | regex_replace('/\\d+$', '') }}"
+              - node_name: "{{ sap_swpm_ers_instance_hostname }}"
+                node_ip: "{{ sap_vm_provision_ha_vip_nwas_abap_ers | regex_replace('/\\d+$', '') }}"
+              - node_name: "{{ sap_swpm_db_host }}"
+                node_ip: "{{ sap_vm_provision_ha_vip_hana_primary | regex_replace('/\\d+$', '') }}"
+
     - name: Install rsync
       ansible.builtin.package:
         name: rsync
@@ -275,7 +310,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -332,7 +367,7 @@
   tasks:
 
     - name: Transfer SAP HANA installation media to SAP HANA Primary and SAP HANA Secondary
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -362,7 +397,7 @@
   tasks:
 
     - name: Transfer SAP NetWeaver ASCS installation media to host
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -392,7 +427,7 @@
   tasks:
 
     - name: Transfer SAP NetWeaver AAS installation media to host
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_playbook.yml
@@ -311,6 +311,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_playbook.yml
@@ -238,6 +238,24 @@
   max_fail_percentage: 0
   tasks:
 
+    - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts  # noqa: no-tabs
+      ansible.builtin.import_role:
+        name: community.sap_install.sap_maintain_etc_hosts
+      vars:
+        sap_maintain_etc_hosts_delimiter: "\t"
+        sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+        sap_maintain_etc_hosts_list: >-
+          {%- set my_list = [] -%}
+          {%- for host in ansible_play_hosts_all -%}
+            {%- if hostvars[host] is defined and hostvars[host]['ansible_host'] is defined -%}
+              {%- set _ = my_list.append({'node_name': host, 'node_ip': hostvars[host]['ansible_host']}) -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {{ my_list }}
+      when:
+        - sap_vm_provision_iac_platform == 'existing_hosts'
+        - sap_domain | d('') | length > 0 or ansible_facts['domain'] | d('') | length > 0
+
     - name: Install rsync
       ansible.builtin.package:
         name: rsync
@@ -269,7 +287,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -318,7 +336,7 @@
   tasks:
 
     - name: Transfer SAP HANA installation media to SAP HANA Primary
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -345,7 +363,7 @@
   tasks:
 
     - name: Transfer SAP NetWeaver ASCS installation media to host
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -372,7 +390,7 @@
   tasks:
 
     - name: Transfer SAP NetWeaver AAS installation media to host
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"

--- a/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_playbook.yml
@@ -288,6 +288,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_foundation_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_standard/ansible_playbook.yml
@@ -238,6 +238,24 @@
   max_fail_percentage: 0
   tasks:
 
+    - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts  # noqa: no-tabs
+      ansible.builtin.import_role:
+        name: community.sap_install.sap_maintain_etc_hosts
+      vars:
+        sap_maintain_etc_hosts_delimiter: "\t"
+        sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+        sap_maintain_etc_hosts_list: >-
+          {%- set my_list = [] -%}
+          {%- for host in ansible_play_hosts_all -%}
+            {%- if hostvars[host] is defined and hostvars[host]['ansible_host'] is defined -%}
+              {%- set _ = my_list.append({'node_name': host, 'node_ip': hostvars[host]['ansible_host']}) -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {{ my_list }}
+      when:
+        - sap_vm_provision_iac_platform == 'existing_hosts'
+        - sap_domain | d('') | length > 0 or ansible_facts['domain'] | d('') | length > 0
+
     - name: Install rsync
       ansible.builtin.package:
         name: rsync
@@ -269,7 +287,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -301,7 +319,7 @@
   tasks:
 
     - name: Transfer SAP HANA installation media to SAP HANA Primary
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"

--- a/deploy_scenarios/sap_s4hana_foundation_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_standard/ansible_playbook.yml
@@ -288,6 +288,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_sandbox_syscopy/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_syscopy/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_sandbox_syscopy/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_syscopy/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_standard/ansible_playbook.yml
@@ -270,6 +270,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_standard/ansible_playbook.yml
@@ -269,7 +269,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -301,7 +301,7 @@
   tasks:
 
     - name: Transfer SAP HANA installation media to SAP HANA Primary
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"

--- a/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_playbook.yml
@@ -270,6 +270,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_playbook.yml
@@ -269,7 +269,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -301,7 +301,7 @@
   tasks:
 
     - name: Transfer SAP HANA installation media to SAP HANA Primary
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"

--- a/deploy_scenarios/sap_solman_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_solman_sapase_sandbox/ansible_playbook.yml
@@ -206,6 +206,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_solman_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_solman_sapase_sandbox/ansible_playbook.yml
@@ -205,7 +205,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_solman_saphana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_solman_saphana_sandbox/ansible_playbook.yml
@@ -207,6 +207,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_solman_saphana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_solman_saphana_sandbox/ansible_playbook.yml
@@ -206,7 +206,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/special_actions/sap_download_install_media/ansible_playbook.yml
+++ b/special_actions/sap_download_install_media/ansible_playbook.yml
@@ -85,7 +85,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_software_target_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ sap_software_install_dictionary[product_item]
           ['softwarecenter_search_list_' ~ sap_software_cpu_architecture] }}"
       loop: "{{ sap_software_product.split(',') }}"

--- a/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_extravars.yml
+++ b/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_extravars.yml
@@ -119,6 +119,55 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
 
+  sap_s4hana_2025_distributed:
+
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Application Server
+      - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      # Tools
+      - 'SAPCAR_1400-70007716.EXE'
+      - 'SWPM20SP23_2-80003424.SAR'
+
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Application Server
+      - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      # Tools
+      - 'SAPCAR_1400-70007726.EXE'
+      - 'SWPM20SP23_2-80003426.SAR'
+
+    nwas_ascs_ha:
+
+      # SWPM product catalog ID for the installation (String).
+      sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2025.CORE.HDB.ABAPHA
+
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs'] }}"
+
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['ascs_ers'] }}"
+
+    nwas_ers_ha:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_ERS:S4HANA2025.CORE.HDB.ABAPHA
+
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ers'] }}"
+
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['ascs_ers'] }}"
+
+
   sap_s4hana_2023_distributed:
 
     # List of product specific software files that are architecture independent.
@@ -134,8 +183,8 @@ sap_software_install_dictionary:
       - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
       - 'igsexe_4-70005417.sar' # IGS 7.81
       # Tools
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SWPM20SP20_1-80003424.SAR'
+      - 'SAPCAR_1400-70007716.EXE'
+      - 'SWPM20SP23_2-80003424.SAR'
 
     # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
     sap_software_list_ppc64le:
@@ -145,8 +194,8 @@ sap_software_install_dictionary:
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
       - 'igsexe_4-70005446.sar' # IGS 7.81
       # Tools
-      - 'SAPCAR_1300-70007726.EXE'
-      - 'SWPM20SP20_1-80003426.SAR'
+      - 'SAPCAR_1400-70007726.EXE'
+      - 'SWPM20SP23_2-80003426.SAR'
 
     nwas_ascs_ha:
 
@@ -154,43 +203,50 @@ sap_software_install_dictionary:
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2023.CORE.HDB.ABAPHA
 
       # List of INI file sections to generate using sap_install.sap_swpm role (List).
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana=
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs'] }}"
 
-      sap_software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SAPHOSTAGENT*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['ascs_ers'] }}"
 
     nwas_ers_ha:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ERS:S4HANA2023.CORE.HDB.ABAPHA
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - credentials
-        - nw_config_other
-        - nw_config_ers
-        - sap_os_linux_user
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ers'] }}"
 
-      sap_software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SAPHOSTAGENT*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['ascs_ers'] }}"
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  ascs:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana=
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
+  ers:
+    - swpm_installation_media
+    - credentials
+    - nw_config_other
+    - nw_config_ers
+    - sap_os_linux_user
+
+# Dictionary of lists for software filename wildcard patterns that is used during rsync operations.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_software_wildcards:
+  ascs_ers:
+    - 'SAPCAR*'
+    - 'SWPM20*'
+    - 'igsexe_*'
+    - 'igshelper_*'
+    - 'SAPEXE_*' # Kernel Part I (785)
+    - 'SAPEXEDB_*' # Kernel Part I (785)
+    - 'SAPHOSTAGENT*'

--- a/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_playbook.yml
+++ b/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_playbook.yml
@@ -176,6 +176,39 @@
   max_fail_percentage: 0
   tasks:
 
+    - name: Block to prepare /etc/hosts entries for all hosts
+      when:
+        - sap_vm_provision_iac_platform == 'existing_hosts'
+        - sap_domain | d('') | length > 0 or ansible_facts['domain'] | d('') | length > 0
+      block:
+
+        - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts  # noqa: no-tabs
+          ansible.builtin.import_role:
+            name: community.sap_install.sap_maintain_etc_hosts
+          vars:
+            sap_maintain_etc_hosts_delimiter: "\t"
+            sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+            sap_maintain_etc_hosts_list: >-
+              {%- set my_list = [] -%}
+              {%- for host in ansible_play_hosts_all -%}
+                {%- if hostvars[host] is defined and hostvars[host]['ansible_host'] is defined -%}
+                  {%- set _ = my_list.append({'node_name': host, 'node_ip': hostvars[host]['ansible_host']}) -%}
+                {%- endif -%}
+              {%- endfor -%}
+              {{ my_list }}
+
+        - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts - HA  # noqa: no-tabs
+          ansible.builtin.import_role:
+            name: community.sap_install.sap_maintain_etc_hosts
+          vars:
+            sap_maintain_etc_hosts_delimiter: "\t"
+            sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+            sap_maintain_etc_hosts_list:
+              - node_name: "{{ sap_swpm_ascs_instance_hostname }}"
+                node_ip: "{{ sap_vm_provision_ha_vip_nwas_abap_ascs | regex_replace('/\\d+$', '') }}"
+              - node_name: "{{ sap_swpm_ers_instance_hostname }}"
+                node_ip: "{{ sap_vm_provision_ha_vip_nwas_abap_ers | regex_replace('/\\d+$', '') }}"
+
     - name: Install rsync
       ansible.builtin.package:
         name: rsync
@@ -207,7 +240,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -239,7 +272,7 @@
   tasks:
 
     - name: Transfer SAP NetWeaver ERS installation media to host
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"

--- a/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_playbook.yml
+++ b/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_playbook.yml
@@ -241,6 +241,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/special_actions/sap_sda/ansible_playbook.yml
+++ b/special_actions/sap_sda/ansible_playbook.yml
@@ -112,7 +112,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
       when:

--- a/special_actions/sap_webdispatcher_standalone/ansible_playbook.yml
+++ b/special_actions/sap_webdispatcher_standalone/ansible_playbook.yml
@@ -117,7 +117,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ sap_software_dict_x86_64[sap_playbook_webdispatcher_version]
           if ansible_facts['architecture'] == 'x86_64'
           else (sap_software_dict_ppc64le[sap_playbook_webdispatcher_version]


### PR DESCRIPTION
## Changes

### Module `ansible.posix.synchronize` with hostname instead of IP
Ansible module `ansible.posix.synchronize` does not behave predictably when using `existing_hosts` and `software_source_ip`. This was observed when attempting RSYNC on existing SLES 15 and SLES 16 hosts.
```bash
Task failed: Failed to connect to the host via ssh: /usr/libexec/ssh/ssh-askpass: line 23: /usr/libexec/ssh/ksshaskpass: No such file or directory
            Host key verification failed.
```
This is caused by this module not applying SSH Arguments when host is in inventory with hostname and IP. Using hostname works correctly.

**Resolved by:**
1. Conditional switch between IP and Hostname
```yaml
delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
```
2. Execution of `community.sap_install.sap_maintain_etc_hosts` for `existing_hosts`, because `sap_vm_provision` will not do it.

### Update sap_launchpad parameters
Recently merged https://github.com/sap-linuxlab/community.sap_launchpad/pull/65 has exposed incorrect usage of deduplicate so playbooks need to be updated to use `last`.

Recently merged https://github.com/sap-linuxlab/community.sap_launchpad/pull/68 have introduced new handling for upgrade candidates which simplifies management of software files, so new parameters are applied.

## Tests
Tested on SLES_SAP 15 SP7 and SLES_SAP 16.0 on on-premise and AWS.