### PR TITLE
release: merge dev to stage for 1.4.1

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -3,9 +3,9 @@
 name: Ansible Lint
 
 on:
-  # Runs at 10:10 on every Monday
+  #  Friday at 02:17 UTC (~3:17 AM CET / 4:17 AM CEST). Actual start time depends on GitHub load.
   schedule:
-    - cron: '10 10 * * 1'
+    - cron: '17 2 * * 5'
 
   # Validate open pull requests
   pull_request:
@@ -41,9 +41,9 @@ jobs:
             echo "REQUIREMENTS_PATH=./common_fragments/ansible_requirements.yml" >> $GITHUB_ENV
           fi
 
-        # Use @v25 to automatically track the latest release from the year 2025.
-        # ansible-lint uses Calendar Versioning (e.g., v25.9.0 -> YYYY.MM.PATCH).
+        # Use @vXX to automatically track the latest release from the year 20XX. Example: @v26 for 2026.
+        # ansible-lint uses Calendar Versioning (e.g., v26.0.0 -> YYYY.MM.PATCH).
         # Avoid using @main, which can introduce breaking changes unexpectedly.
-      - uses: ansible/ansible-lint@v25
+      - uses: ansible/ansible-lint@v26
         with:
           requirements_file: ${{ env.REQUIREMENTS_PATH }}

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -24,7 +24,7 @@ For specific role maintainers, see the `README.md` file in the corresponding rol
 | Name | Commits | Lines Changed | Last Commit |
 | ---- | ------- | ------------- | ----------- |
 | [Sean Freeman](https://github.com/sean-freeman) | 144 | 241528 | 2025-06-20 |
-| [Marcel Mamula](https://github.com/marcelmamula) | 109 | 179364 | 2026-03-26 |
+| [Marcel Mamula](https://github.com/marcelmamula) | 114 | 180743 | 2026-07-15 |
 | Edmund Häfele | 1 | 7 | 2026-01-13 |
 | [Gabriele Puliti](https://github.com/Wabri) | 1 | 68 | 2024-06-12 |
 | [Janine Fuchs](https://github.com/ja9fuchs) | 1 | 4 | 2024-04-15 |

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ The Ansible Playbooks for SAP offer several key benefits:
 - **Corporate-Ready:** Licensed for corporate use by SAP Customers, SAP Service Partners, and SAP Technology Partners.
 
 
-## Supported Configurations
-### Supported Operating Systems
-- SUSE Linux Enterprise Server for SAP Applications (SLES4SAP)
-- Red Hat Enterprise Linux for SAP (RHEL4SAP)
+## Available Configurations
+### Compatible Operating Systems
+- Red Hat Enterprise Linux for SAP Solutions: 8.x, 9.x, 10.x
+- SUSE Linux Enterprise Server for SAP applications: 15 SP5, 15 SP6, 15 SP7, 16
 
-### Supported Infrastructure Platforms
+### Compatible Infrastructure Platforms
 - AWS EC2 Virtual Server instances
 - Google Cloud Compute Engine Virtual Machines
 - IBM Cloud, Intel Virtual Servers
@@ -43,7 +43,7 @@ The reliability issues with the Ansible Collection for Microsoft Azure are due t
 - MS Azure API behavior is not globally uniform or predictable. The same playbook and variables may yield different results across different MS Azure regions due to localized API versions or resource provider constraints.
   - This is specific to Ansible Modules from `azure.azcollection` calling MS Azure API and you can see different behavior when using Azure CLI.
 
-### Supported Deployment Scenarios
+### Available Deployment Scenarios
 | SAP Product | Versions | Deployment Topology | Database |
 | --- | --- | --- | --- |
 | SAP HANA | 2.0 SPS 08<br> 2.0 SPS 07<br> 2.0 SPS 06 | Sandbox<br> Scale-Out <br> Scale-Up High Availability | SAP HANA |
@@ -72,7 +72,7 @@ The explanation of Deployment Topologies:
 | Scale-Out | An Scale-Out system, that consists of an SAP Application instances running on a dedicated host, and an SAP HANA database server running as a scale-out cluster across multiple hosts. |
 
 
-### Supported Special Playbooks
+### Available Special Playbooks
 - SAP Web Dispatcher, Standalone (with SAP Kernel Part II for SAP HANA)
 - SAP SolMan Diagnostics Agent (SDA) `[Experimental]`
 - Download SAP Software installation media

--- a/common_fragments/tasks/interactive/README.md
+++ b/common_fragments/tasks/interactive/README.md
@@ -31,8 +31,8 @@ Changing these variables can result in execution without all required variables.
 - **Example:** `distributed_ha`
 
 
-## Supported scenarios
-This table lists the supported combinations of SAP products, databases, and layouts, along with the corresponding Ansible groups.
+## Available Scenarios
+This table lists the available scenarios that support interactive execution.
 
 | Scenario                               | Product    | Database   | Layout            | Ansible Groups |
 | -------------------------------------- | ---------- | ---------- | ----------------- | --- |

--- a/common_fragments/vars/platform_vars_gcp_ce_vm.yml
+++ b/common_fragments/vars/platform_vars_gcp_ce_vm.yml
@@ -8,7 +8,7 @@ sap_vm_provision_bastion_ssh_port: "ENTER_STRING_VALUE_HERE"  # Bastion user pas
 sap_vm_provision_bastion_public_ip: "ENTER_STRING_VALUE_HERE"  # Public IP of the bastion server (String).
 sap_vm_provision_ssh_bastion_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion server's SSH private key on the execution node (String).
 sap_vm_provision_ssh_host_private_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to target host's SSH private key on the execution node (String).
-sap_vm_provision_ssh_host_public_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to bastion public host key on execution node (String).
+sap_vm_provision_ssh_host_public_key_file_path: "ENTER_STRING_VALUE_HERE"  # Path to target host's SSH public key on execution node (String).
 
 #### Infrastructure platform variables ####
 sap_vm_provision_iac_platform: "gcp_ce_vm"  # Name of the provisioning platform (String).

--- a/deploy_scenarios/sap_bw4hana_sandbox/README.md
+++ b/deploy_scenarios/sap_bw4hana_sandbox/README.md
@@ -9,8 +9,8 @@ A single-host system, as defined by SAP, consolidates all SAP Database and SAP A
 This configuration, often referred to as a Two-Tier Architecture, OneHost, or Central System, is ideal for development, testing, and demonstration purposes.
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
@@ -18,16 +18,16 @@ This Ansible Playbook supports the deployment on the following infrastructure pl
 - IBM Cloud, IBM Power Virtual Servers
 - Microsoft Azure (MS Azure)
 - IBM PowerVM
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
 - SAP BW/4HANA 2023
 - SAP BW/4HANA 2021
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_bw4hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_bw4hana_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_bw4hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_bw4hana_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/README.md
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/README.md
@@ -9,8 +9,8 @@ An SAP BW/4HANA Standard (Scale-Out) system, as defined by SAP, consists of an S
 This configuration, often referred to as a Three-Tier Architecture or DualHost, is ideal for production environments, or for scenarios requiring high availability and scalability.
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
@@ -18,16 +18,16 @@ This Ansible Playbook supports the deployment on the following infrastructure pl
 - IBM Cloud, IBM Power Virtual Servers
 - Microsoft Azure (MS Azure)
 - IBM PowerVM
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
 - SAP BW/4HANA 2023
 - SAP BW/4HANA 2021
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml
@@ -273,6 +273,24 @@
   max_fail_percentage: 0
   tasks:
 
+    - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts  # noqa: no-tabs
+      ansible.builtin.import_role:
+        name: community.sap_install.sap_maintain_etc_hosts
+      vars:
+        sap_maintain_etc_hosts_delimiter: "\t"
+        sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+        sap_maintain_etc_hosts_list: >-
+          {%- set my_list = [] -%}
+          {%- for host in ansible_play_hosts_all -%}
+            {%- if hostvars[host] is defined and hostvars[host]['ansible_host'] is defined -%}
+              {%- set _ = my_list.append({'node_name': host, 'node_ip': hostvars[host]['ansible_host']}) -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {{ my_list }}
+      when:
+        - sap_vm_provision_iac_platform == 'existing_hosts'
+        - sap_domain | d('') | length > 0 or ansible_facts['domain'] | d('') | length > 0
+
     - name: Install rsync
       ansible.builtin.package:
         name: rsync
@@ -304,7 +322,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -336,7 +354,7 @@
   tasks:
 
     - name: Transfer SAP HANA installation media to SAP HANA hosts
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_playbook.yml
@@ -323,6 +323,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ecc_hana_sandbox/README.md
+++ b/deploy_scenarios/sap_ecc_hana_sandbox/README.md
@@ -9,8 +9,8 @@ A single-host system, as defined by SAP, consolidates all SAP Database and SAP N
 This configuration, often referred to as a Two-Tier Architecture, OneHost, or Central System, is ideal for development, testing, and demonstration purposes.  
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
@@ -18,16 +18,16 @@ This Ansible Playbook supports the deployment on the following infrastructure pl
 - IBM Cloud, IBM Power Virtual Servers
 - Microsoft Azure (MS Azure)
 - IBM PowerVM
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
 - EHP8 for SAP ERP 6.0
 - EHP7 for SAP ERP 6.0
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_ecc_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_hana_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ecc_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_hana_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed/README.md
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed/README.md
@@ -9,26 +9,26 @@ A distributed SAP system, as defined by SAP, separates the SAP NetWeaver Applica
 This configuration, often referred to as a Multi-Tier Architecture, is ideal for production environments, or for scenarios requiring scalability and resource separation.  
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
 - IBM Cloud
 - Microsoft Azure (MS Azure)
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 ### Considerations for ppc64le
 This Ansible Playbook is not available for IBM Power Little Endian (ppc64le).
 - All prior SAP Software without SAP HANA was for IBM Power Big Endian (ppc64) only.
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
 - EHP8 for SAP ERP 6.0
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_playbook.yml
@@ -238,6 +238,24 @@
   max_fail_percentage: 0
   tasks:
 
+    - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts  # noqa: no-tabs
+      ansible.builtin.import_role:
+        name: community.sap_install.sap_maintain_etc_hosts
+      vars:
+        sap_maintain_etc_hosts_delimiter: "\t"
+        sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+        sap_maintain_etc_hosts_list: >-
+          {%- set my_list = [] -%}
+          {%- for host in ansible_play_hosts_all -%}
+            {%- if hostvars[host] is defined and hostvars[host]['ansible_host'] is defined -%}
+              {%- set _ = my_list.append({'node_name': host, 'node_ip': hostvars[host]['ansible_host']}) -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {{ my_list }}
+      when:
+        - sap_vm_provision_iac_platform == 'existing_hosts'
+        - sap_domain | d('') | length > 0 or ansible_facts['domain'] | d('') | length > 0
+
     - name: Install rsync
       ansible.builtin.package:
         name: rsync
@@ -269,7 +287,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -309,7 +327,7 @@
   tasks:
 
     - name: Transfer all installation media to AnyDB Database Instance Primary
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ sap_install_media_detect_source_directory }}/" # trailing slash to copy items in the directory, not the directory itself
@@ -333,7 +351,7 @@
   tasks:
 
     - name: Transfer SAP NetWeaver ASCS installation media to host
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -360,7 +378,7 @@
   tasks:
 
     - name: Transfer SAP NetWeaver AAS installation media to host
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_playbook.yml
@@ -288,6 +288,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/README.md
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/README.md
@@ -17,8 +17,8 @@ This deployment incorporates the following High Availability features:
 This Ansible Playbook is using Ansible Roles in `experimental` state (`sap_ha_install_anydb_ibmdb2`).
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
@@ -30,11 +30,11 @@ This Ansible Playbook is not available for IBM Power Little Endian (ppc64le).
 - All prior SAP Software without SAP HANA was for IBM Power Big Endian (ppc64) only.
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
 - EHP8 for SAP ERP 6.0
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_playbook.yml
@@ -240,6 +240,41 @@
   max_fail_percentage: 0
   tasks:
 
+    - name: Block to prepare /etc/hosts entries for all hosts
+      when:
+        - sap_vm_provision_iac_platform == 'existing_hosts'
+        - sap_domain | d('') | length > 0 or ansible_facts['domain'] | d('') | length > 0
+      block:
+
+        - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts  # noqa: no-tabs
+          ansible.builtin.import_role:
+            name: community.sap_install.sap_maintain_etc_hosts
+          vars:
+            sap_maintain_etc_hosts_delimiter: "\t"
+            sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+            sap_maintain_etc_hosts_list: >-
+              {%- set my_list = [] -%}
+              {%- for host in ansible_play_hosts_all -%}
+                {%- if hostvars[host] is defined and hostvars[host]['ansible_host'] is defined -%}
+                  {%- set _ = my_list.append({'node_name': host, 'node_ip': hostvars[host]['ansible_host']}) -%}
+                {%- endif -%}
+              {%- endfor -%}
+              {{ my_list }}
+
+        - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts - HA  # noqa: no-tabs
+          ansible.builtin.import_role:
+            name: community.sap_install.sap_maintain_etc_hosts
+          vars:
+            sap_maintain_etc_hosts_delimiter: "\t"
+            sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+            sap_maintain_etc_hosts_list:
+              - node_name: "{{ sap_swpm_ascs_instance_hostname }}"
+                node_ip: "{{ sap_vm_provision_ha_vip_nwas_abap_ascs | regex_replace('/\\d+$', '') }}"
+              - node_name: "{{ sap_swpm_ers_instance_hostname }}"
+                node_ip: "{{ sap_vm_provision_ha_vip_nwas_abap_ers | regex_replace('/\\d+$', '') }}"
+              - node_name: "{{ sap_swpm_db_host }}"
+                node_ip: "{{ sap_vm_provision_ha_vip_anydb_primary | regex_replace('/\\d+$', '') }}"
+
     - name: Install rsync
       ansible.builtin.package:
         name: rsync
@@ -271,7 +306,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -319,7 +354,7 @@
   tasks:
 
     - name: Transfer all installation media to AnyDB Database Instance Primary
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ sap_install_media_detect_source_directory }}/" # trailing slash to copy items in the directory, not the directory itself
@@ -343,7 +378,7 @@
   tasks:
 
     - name: Transfer SAP AnyDB installation media to AnyDB Database Instance Secondary
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -370,7 +405,7 @@
   tasks:
 
     - name: Transfer SAP NetWeaver ASCS installation media to host
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -397,7 +432,7 @@
   tasks:
 
     - name: Transfer SAP NetWeaver AAS installation media to host
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -682,7 +717,7 @@
   tasks:
 
     - name: Transfer Database Backup file for SAP ECC Homogeneous System Copy to the AnyDB Database Instance Secondary
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ sap_install_media_detect_source_directory }}/db2_db_backup_anydb_primary_node" # no trailing slash to copy directory and the contents

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_playbook.yml
@@ -307,6 +307,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ecc_ibmdb2_sandbox/README.md
+++ b/deploy_scenarios/sap_ecc_ibmdb2_sandbox/README.md
@@ -9,26 +9,26 @@ A single-host system, as defined by SAP, consolidates all SAP Database and SAP N
 This configuration, often referred to as a Two-Tier Architecture, OneHost, or Central System, is ideal for development, testing, and demonstration purposes.  
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
 - IBM Cloud
 - Microsoft Azure (MS Azure)
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 ### Considerations for ppc64le
 This Ansible Playbook is not available for IBM Power Little Endian (ppc64le).
 - All prior SAP Software without SAP HANA was for IBM Power Big Endian (ppc64) only.
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
 - EHP8 for SAP ERP 6.0
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ecc_oracledb_sandbox/README.md
+++ b/deploy_scenarios/sap_ecc_oracledb_sandbox/README.md
@@ -9,26 +9,26 @@ A single-host system, as defined by SAP, consolidates all SAP Database and SAP N
 This configuration, often referred to as a Two-Tier Architecture, OneHost, or Central System, is ideal for development, testing, and demonstration purposes.  
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
 - IBM Cloud
 - Microsoft Azure (MS Azure)
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 ### Considerations for ppc64le
 This Ansible Playbook is not available for IBM Power Little Endian (ppc64le).
 - All prior SAP Software without SAP HANA was for IBM Power Big Endian (ppc64) only.
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
 - EHP8 for SAP ERP 6.0
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture
@@ -109,4 +109,4 @@ The playbook executes the following sequence of tasks:
 
 
 ## Limitations
-Single-host SAP Systems with Oracle Databases are not supported on SUSE.
+Single-host SAP Systems with Oracle Databases are not supported by SUSE.

--- a/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_extravars.yml
@@ -138,7 +138,7 @@ sap_software_install_dictionary:
       - '51053828'   # Oracle 19.0.0.0 RDBMS Linux on x86_64 64bit, ZIP. Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
       # - '51054219'   # Oracle Client 12.1.0.2. Compatible with RHEL 7.x and SLES 12.x
       # - '51054433'   # Oracle 12.2.0.1 Client V2 64bit (All), ZIP. Compatible with RHEL 7.x and SLES 12.x
-      - '51057419'   # Oracle 19.0.0.0 RDBMS Client 64bit (All), ZIP (AKA. Oracle Database 19c Base Release). Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
+      - '51059602'  # Oracle 19.0.0.0 RDBMS Client 64bit
 
       # Application Server
       - '51050708_1' # SAP ERP 6.0 EHP8 Installation Export 1/4, Self-extract RAR EXE

--- a/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ecc_oracledb_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_ecc_oracledb_sandbox/optional/ansible_extravars_interactive.yml
@@ -74,7 +74,7 @@ sap_software_install_dictionary:
       - '51053828'   # Oracle 19.0.0.0 RDBMS Linux on x86_64 64bit, ZIP. Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
       # - '51054219'   # Oracle Client 12.1.0.2. Compatible with RHEL 7.x and SLES 12.x
       # - '51054433'   # Oracle 12.2.0.1 Client V2 64bit (All), ZIP. Compatible with RHEL 7.x and SLES 12.x
-      - '51057419'   # Oracle 19.0.0.0 RDBMS Client 64bit (All), ZIP (AKA. Oracle Database 19c Base Release). Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
+      - '51059602'  # Oracle 19.0.0.0 RDBMS Client 64bit
 
       # Application Server
       - '51050708_1' # SAP ERP 6.0 EHP8 Installation Export 1/4, Self-extract RAR EXE

--- a/deploy_scenarios/sap_ecc_sapase_sandbox/README.md
+++ b/deploy_scenarios/sap_ecc_sapase_sandbox/README.md
@@ -9,26 +9,26 @@ A single-host system, as defined by SAP, consolidates all SAP Database and SAP N
 This configuration, often referred to as a Two-Tier Architecture, OneHost, or Central System, is ideal for development, testing, and demonstration purposes.  
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
 - IBM Cloud
 - Microsoft Azure (MS Azure)
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 ### Considerations for ppc64le
 This Ansible Playbook is not available for IBM Power Little Endian (ppc64le).
 - All prior SAP Software without SAP HANA was for IBM Power Big Endian (ppc64) only.
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
 - EHP8 for SAP ERP 6.0
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_extravars.yml
@@ -133,7 +133,7 @@ sap_software_install_dictionary:
       - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
       - 'SAPEXEDB_1000-80002616.SAR' # Kernel Part II (753), SAP ASE 16.0 FOR BUS. SUITE
       - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SYBCTRL_1440-80002616.SAR'
+      - 'SYBCTRL_1532-80002616.SAR'
       - 'igsexe_13-80003187.sar' # IGS 7.53
       - 'igshelper_17-10010245.sar'
       # Tools

--- a/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ecc_sapase_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_ecc_sapase_sandbox/optional/ansible_extravars_interactive.yml
@@ -77,7 +77,7 @@ sap_software_install_dictionary:
       - 'SAPEXE_1000-80002573.SAR' # Kernel Part I (753)
       - 'SAPEXEDB_1000-80002616.SAR' # Kernel Part II (753), SAP ASE 16.0 FOR BUS. SUITE
       - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
-      - 'SYBCTRL_1440-80002616.SAR'
+      - 'SYBCTRL_1532-80002616.SAR'
       - 'igsexe_13-80003187.sar' # IGS 7.53
       - 'igshelper_17-10010245.sar'
       # Tools

--- a/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/README.md
+++ b/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/README.md
@@ -9,26 +9,26 @@ A single-host system, as defined by SAP, consolidates all SAP Database and SAP N
 This configuration, often referred to as a Two-Tier Architecture, OneHost, or Central System, is ideal for development, testing, and demonstration purposes.  
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
 - IBM Cloud
 - Microsoft Azure (MS Azure)
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 ### Considerations for ppc64le
 This Ansible Playbook is not available for IBM Power Little Endian (ppc64le).
 - All prior SAP Software without SAP HANA was for IBM Power Big Endian (ppc64) only.
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
 - EHP8 for SAP ERP 6.0
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_extravars.yml
@@ -118,8 +118,8 @@ sap_software_install_dictionary:
     sap_software_list_x86_64:
       # Database Server
       # - '51054410_2' # CD Media for MaxDB 7.9 - SP10 Build 04 Linux on x86_64 64bit
-      - 'MAXDB7911_10-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
-      - 'MAXDBART7911_10-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
+      - 'MAXDB7911_15-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
+      - 'MAXDBART7911_15-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
       # Application Server
       - '51050708_1' # SAP ERP 6.0 EHP8 Installation Export 1/4, Self-extract RAR EXE
       - '51050708_2'

--- a/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/optional/ansible_extravars_interactive.yml
@@ -61,8 +61,8 @@ sap_software_install_dictionary:
     sap_software_list_x86_64:
       # Database Server
       # - '51054410_2' # CD Media for MaxDB 7.9 - SP10 Build 04 Linux on x86_64 64bit
-      - 'MAXDB7911_10-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
-      - 'MAXDBART7911_10-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
+      - 'MAXDB7911_15-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
+      - 'MAXDBART7911_15-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
       # Application Server
       - '51050708_1' # SAP ERP 6.0 EHP8 Installation Export 1/4, Self-extract RAR EXE
       - '51050708_2'

--- a/deploy_scenarios/sap_hana/README.md
+++ b/deploy_scenarios/sap_hana/README.md
@@ -7,8 +7,8 @@ This Ansible Playbook automates the deployment of an SAP HANA Sandbox Database i
 An SAP HANA Sandbox Database, as defined by SAP, consists of an SAP HANA Database server running on a single host.  
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
@@ -16,17 +16,18 @@ This Ansible Playbook supports the deployment on the following infrastructure pl
 - IBM Cloud, IBM Power Virtual Servers
 - Microsoft Azure (MS Azure)
 - IBM PowerVM
-- KubeVirt
-- OVirt
-- VMware
+- KubeVirt `Experimental`
+- OVirt `Experimental`
+- VMware `Experimental`
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
+- SAP HANA 2.0 SPS08
 - SAP HANA 2.0 SPS07
 - SAP HANA 2.0 SPS06
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_hana/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana/ansible_playbook.yml
@@ -250,7 +250,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_hana/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana/ansible_playbook.yml
@@ -251,6 +251,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_hana_ha/README.md
+++ b/deploy_scenarios/sap_hana_ha/README.md
@@ -9,8 +9,8 @@ A highly available SAP HANA Scale-Up system, as defined by SAP, consists of a pr
 This configuration provides high availability through SAP HANA System Replication and is ideal for production environments or scenarios requiring database-level redundancy and failover.
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
@@ -18,16 +18,17 @@ This Ansible Playbook supports the deployment on the following infrastructure pl
 - IBM Cloud, IBM Power Virtual Servers
 - Microsoft Azure (MS Azure)
 - IBM PowerVM
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
+- SAP HANA 2.0 SPS08
 - SAP HANA 2.0 SPS07
 - SAP HANA 2.0 SPS06
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_hana_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana_ha/ansible_playbook.yml
@@ -300,6 +300,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_hana_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana_ha/ansible_playbook.yml
@@ -237,6 +237,37 @@
   max_fail_percentage: 0
   tasks:
 
+    - name: Block to prepare /etc/hosts entries for all hosts
+      when:
+        - sap_vm_provision_iac_platform == 'existing_hosts'
+        - sap_domain | d('') | length > 0 or ansible_facts['domain'] | d('') | length > 0
+      block:
+
+        - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts  # noqa: no-tabs
+          ansible.builtin.import_role:
+            name: community.sap_install.sap_maintain_etc_hosts
+          vars:
+            sap_maintain_etc_hosts_delimiter: "\t"
+            sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+            sap_maintain_etc_hosts_list: >-
+              {%- set my_list = [] -%}
+              {%- for host in ansible_play_hosts_all -%}
+                {%- if hostvars[host] is defined and hostvars[host]['ansible_host'] is defined -%}
+                  {%- set _ = my_list.append({'node_name': host, 'node_ip': hostvars[host]['ansible_host']}) -%}
+                {%- endif -%}
+              {%- endfor -%}
+              {{ my_list }}
+
+        - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts - HA  # noqa: no-tabs
+          ansible.builtin.import_role:
+            name: community.sap_install.sap_maintain_etc_hosts
+          vars:
+            sap_maintain_etc_hosts_delimiter: "\t"
+            sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+            sap_maintain_etc_hosts_list:
+              - node_name: "{{ sap_swpm_db_host }}"
+                node_ip: "{{ sap_vm_provision_ha_vip_hana_primary | regex_replace('/\\d+$', '') }}"
+
     - name: Install rsync
       ansible.builtin.package:
         name: rsync
@@ -268,7 +299,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -300,7 +331,7 @@
   tasks:
 
     - name: Transfer SAP HANA installation media to SAP HANA Primary and SAP HANA Secondary
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ item }}"

--- a/deploy_scenarios/sap_hana_scaleout/README.md
+++ b/deploy_scenarios/sap_hana_scaleout/README.md
@@ -7,8 +7,8 @@ This Ansible Playbook automates the deployment of an SAP HANA Scale-Out Database
 An SAP HANA Scale-Out Database, as defined by SAP, consists of an SAP HANA database server running as a scale-out cluster across multiple hosts.  
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
@@ -16,16 +16,17 @@ This Ansible Playbook supports the deployment on the following infrastructure pl
 - IBM Cloud, IBM Power Virtual Servers
 - Microsoft Azure (MS Azure)
 - IBM PowerVM
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
+- SAP HANA 2.0 SPS08
 - SAP HANA 2.0 SPS07
 - SAP HANA 2.0 SPS06
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml
@@ -287,7 +287,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml
+++ b/deploy_scenarios/sap_hana_scaleout/ansible_playbook.yml
@@ -288,6 +288,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ides_ecc_hana_sandbox/README.md
+++ b/deploy_scenarios/sap_ides_ecc_hana_sandbox/README.md
@@ -9,8 +9,8 @@ A single-host system, as defined by SAP, consolidates all SAP Database and SAP N
 This configuration, often referred to as a Two-Tier Architecture, OneHost, or Central System, is ideal for development, testing, and demonstration purposes.  
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
@@ -18,15 +18,15 @@ This Ansible Playbook supports the deployment on the following infrastructure pl
 - IBM Cloud, IBM Power Virtual Servers
 - Microsoft Azure (MS Azure)
 - IBM PowerVM
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
 - EHP8 for SAP ERP 6.0
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/README.md
+++ b/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/README.md
@@ -9,27 +9,27 @@ A single-host system, as defined by SAP, consolidates all SAP Database and SAP N
 This configuration, often referred to as a Two-Tier Architecture, OneHost, or Central System, is ideal for development, testing, and demonstration purposes.  
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
 - IBM Cloud
 - Microsoft Azure (MS Azure)
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 ### Considerations for ppc64le
 This Ansible Playbook is not available for IBM Power Little Endian (ppc64le).
 - All prior SAP Software without SAP HANA was for IBM Power Big Endian (ppc64) only.
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
 - EHP8 for SAP ERP 6.0
 - EHP7 for SAP ERP 6.0
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_landscape_s4hana_standard/README.md
+++ b/deploy_scenarios/sap_landscape_s4hana_standard/README.md
@@ -11,8 +11,8 @@ This Single Track 3-System Landscape, as defined by SAP, is a standard configura
 Each system has its own dedicated pair of hosts, ensuring complete isolation and resource independence. This configuration is commonly referred to as a Three-Tier Architecture, and each system can also be known as DualHost.  
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
@@ -20,18 +20,19 @@ This Ansible Playbook supports the deployment on the following infrastructure pl
 - IBM Cloud, IBM Power Virtual Servers
 - Microsoft Azure (MS Azure)
 - IBM PowerVM
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
+- SAP S/4HANA 2025
 - SAP S/4HANA 2023
 - SAP S/4HANA 2022
 - SAP S/4HANA 2021
 - SAP S/4HANA 2020
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture
@@ -82,7 +83,7 @@ ansible-playbook ansible_playbook.yml \
 ```
 
 ### Interactive Execution
-This method is not supported due to complexity of this scenario.
+This method is not available due to complexity of this scenario.
 
 
 ## Deployment Process

--- a/deploy_scenarios/sap_landscape_s4hana_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard/ansible_playbook.yml
@@ -177,6 +177,24 @@
   max_fail_percentage: 0
   tasks:
 
+    - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts  # noqa: no-tabs
+      ansible.builtin.import_role:
+        name: community.sap_install.sap_maintain_etc_hosts
+      vars:
+        sap_maintain_etc_hosts_delimiter: "\t"
+        sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+        sap_maintain_etc_hosts_list: >-
+          {%- set my_list = [] -%}
+          {%- for host in ansible_play_hosts_all -%}
+            {%- if hostvars[host] is defined and hostvars[host]['ansible_host'] is defined -%}
+              {%- set _ = my_list.append({'node_name': host, 'node_ip': hostvars[host]['ansible_host']}) -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {{ my_list }}
+      when:
+        - sap_vm_provision_iac_platform == 'existing_hosts'
+        - sap_domain | d('') | length > 0 or ansible_facts['domain'] | d('') | length > 0
+
     - name: Install rsync
       ansible.builtin.package:
         name: rsync
@@ -208,7 +226,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -298,7 +316,8 @@
   tasks:
 
     - name: Transfer SAP HANA installation media to SAP HANA Primary
-      delegate_to: "{{ sap_inventory_project_dev_nwas_pas_ip }}"
+      delegate_to: "{{ sap_inventory_project_dev_nwas_pas_ip
+        if sap_vm_provision_iac_platform != 'existing_hosts' else sap_inventory_project_dev_nwas_pas_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -326,7 +345,8 @@
   tasks:
 
     - name: Transfer SAP NetWeaver ASCS installation media to host
-      delegate_to: "{{ sap_inventory_project_dev_nwas_pas_ip }}"
+      delegate_to: "{{ sap_inventory_project_dev_nwas_pas_ip
+        if sap_vm_provision_iac_platform != 'existing_hosts' else sap_inventory_project_dev_nwas_pas_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"

--- a/deploy_scenarios/sap_landscape_s4hana_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard/ansible_playbook.yml
@@ -227,6 +227,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/README.md
+++ b/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/README.md
@@ -13,8 +13,8 @@ Each system has its own dedicated pair of hosts, ensuring complete isolation and
 **NOTE:** A key distinction of this playbook is its use of the SAP Maintenance Planner to download SAP Installation Media, instead of a file list, as used in the `sap_landscape_s4hana_standard` scenario.  
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
@@ -22,17 +22,18 @@ This Ansible Playbook supports the deployment on the following infrastructure pl
 - IBM Cloud, IBM Power Virtual Servers
 - Microsoft Azure (MS Azure)
 - IBM PowerVM
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
+- SAP S/4HANA 2025
 - SAP S/4HANA 2023
 - SAP S/4HANA 2022
 - SAP S/4HANA 2021
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture
@@ -83,7 +84,7 @@ ansible-playbook ansible_playbook.yml \
 ```
 
 ### Interactive Execution
-This method is not supported due to complexity of this scenario.
+This method is not available due to complexity of this scenario.
 
 
 ## Deployment Process

--- a/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_playbook.yml
@@ -177,6 +177,24 @@
   max_fail_percentage: 0
   tasks:
 
+    - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts  # noqa: no-tabs
+      ansible.builtin.import_role:
+        name: community.sap_install.sap_maintain_etc_hosts
+      vars:
+        sap_maintain_etc_hosts_delimiter: "\t"
+        sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+        sap_maintain_etc_hosts_list: >-
+          {%- set my_list = [] -%}
+          {%- for host in ansible_play_hosts_all -%}
+            {%- if hostvars[host] is defined and hostvars[host]['ansible_host'] is defined -%}
+              {%- set _ = my_list.append({'node_name': host, 'node_ip': hostvars[host]['ansible_host']}) -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {{ my_list }}
+      when:
+        - sap_vm_provision_iac_platform == 'existing_hosts'
+        - sap_domain | d('') | length > 0 or ansible_facts['domain'] | d('') | length > 0
+
     - name: Install rsync
       ansible.builtin.package:
         name: rsync
@@ -208,7 +226,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -299,7 +317,8 @@
   tasks:
 
     - name: Transfer SAP HANA installation media to SAP HANA Primary
-      delegate_to: "{{ sap_inventory_project_dev_nwas_pas_ip }}"
+      delegate_to: "{{ sap_inventory_project_dev_nwas_pas_ip
+        if sap_vm_provision_iac_platform != 'existing_hosts' else sap_inventory_project_dev_nwas_pas_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -327,7 +346,8 @@
   tasks:
 
     - name: Transfer SAP NetWeaver ASCS installation media to host
-      delegate_to: "{{ sap_inventory_project_dev_nwas_pas_ip }}"
+      delegate_to: "{{ sap_inventory_project_dev_nwas_pas_ip
+        if sap_vm_provision_iac_platform != 'existing_hosts' else sap_inventory_project_dev_nwas_pas_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"

--- a/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_playbook.yml
@@ -227,6 +227,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_abap_hana_sandbox/README.md
+++ b/deploy_scenarios/sap_nwas_abap_hana_sandbox/README.md
@@ -9,8 +9,8 @@ A single-host system, as defined by SAP, consolidates all SAP Database and SAP N
 This configuration, often referred to as a Two-Tier Architecture, OneHost, or Central System, is ideal for development, testing, and demonstration purposes.  
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
@@ -18,16 +18,16 @@ This Ansible Playbook supports the deployment on the following infrastructure pl
 - IBM Cloud, IBM Power Virtual Servers
 - Microsoft Azure (MS Azure)
 - IBM PowerVM
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
 - SAP NetWeaver 7.52 SP00
 - SAP NetWeaver 7.50 SP00
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/README.md
+++ b/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/README.md
@@ -9,27 +9,27 @@ A single-host system, as defined by SAP, consolidates all SAP Database and SAP N
 This configuration, often referred to as a Two-Tier Architecture, OneHost, or Central System, is ideal for development, testing, and demonstration purposes.  
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
 - IBM Cloud
 - Microsoft Azure (MS Azure)
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 ### Considerations for ppc64le
 This Ansible Playbook is not available for IBM Power Little Endian (ppc64le).
 - All prior SAP Software without SAP HANA was for IBM Power Big Endian (ppc64) only.
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
 - SAP NetWeaver 7.52 SP00
 - SAP NetWeaver 7.50 SP00
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/README.md
+++ b/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/README.md
@@ -9,27 +9,27 @@ A single-host system, as defined by SAP, consolidates all SAP Database and SAP N
 This configuration, often referred to as a Two-Tier Architecture, OneHost, or Central System, is ideal for development, testing, and demonstration purposes.  
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
 - IBM Cloud
 - Microsoft Azure (MS Azure)
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 ### Considerations for ppc64le
 This Ansible Playbook is not available for IBM Power Little Endian (ppc64le).
 - All prior SAP Software without SAP HANA was for IBM Power Big Endian (ppc64) only.
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
 - SAP NetWeaver 7.52 SP00
 - SAP NetWeaver 7.50 SP00
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture
@@ -110,4 +110,4 @@ The playbook executes the following sequence of tasks:
 
 
 ## Limitations
-Single-host SAP Systems with Oracle Databases are not supported on SUSE.
+Single-host SAP Systems with Oracle Databases are not supported by SUSE.

--- a/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_extravars.yml
@@ -122,7 +122,7 @@ sap_software_install_dictionary:
       - '51053828'  # Oracle 19.0.0.0 RDBMS Linux on x86_64 64bit, ZIP. Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
       # - '51054219'  # Oracle Client 12.1.0.2. Compatible with RHEL 7.x and SLES 12.x
       # - '51054433'  # Oracle 12.2.0.1 Client V2 64bit (All), ZIP. Compatible with RHEL 7.x and SLES 12.x
-      - '51057419'  # Oracle 19.0.0.0 RDBMS Client 64bit (All), ZIP (AKA. Oracle Database 19c Base Release). Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
+      - '51059602'  # Oracle 19.0.0.0 RDBMS Client 64bit
 
       # Application Server
       - '51051806_1' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 1/2, RAR
@@ -165,7 +165,7 @@ sap_software_install_dictionary:
       - '51053828'   # Oracle 19.0.0.0 RDBMS Linux on x86_64 64bit, ZIP. Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
       # - '51054219'   # Oracle Client 12.1.0.2. Compatible with RHEL 7.x and SLES 12.x
       # - '51054433'   # Oracle 12.2.0.1 Client V2 64bit (All), ZIP. Compatible with RHEL 7.x and SLES 12.x
-      - '51057419'   # Oracle 19.0.0.0 RDBMS Client 64bit (All), ZIP (AKA. Oracle Database 19c Base Release). Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
+      - '51059602'  # Oracle 19.0.0.0 RDBMS Client 64bit
 
       # Application Server
       - '51050829_3' # SAP Netweaver 7.5 Installation Export, ZIP

--- a/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_playbook.yml
@@ -256,7 +256,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_playbook.yml
@@ -257,6 +257,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/optional/ansible_extravars_interactive.yml
@@ -58,7 +58,7 @@ sap_software_install_dictionary:
       - '51053828'  # Oracle 19.0.0.0 RDBMS Linux on x86_64 64bit, ZIP. Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
       # - '51054219'  # Oracle Client 12.1.0.2. Compatible with RHEL 7.x and SLES 12.x
       # - '51054433'  # Oracle 12.2.0.1 Client V2 64bit (All), ZIP. Compatible with RHEL 7.x and SLES 12.x
-      - '51057419'  # Oracle 19.0.0.0 RDBMS Client 64bit (All), ZIP (AKA. Oracle Database 19c Base Release). Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
+      - '51059602'  # Oracle 19.0.0.0 RDBMS Client 64bit
 
       # Application Server
       - '51051806_1' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 1/2, RAR
@@ -101,7 +101,7 @@ sap_software_install_dictionary:
       - '51053828'   # Oracle 19.0.0.0 RDBMS Linux on x86_64 64bit, ZIP. Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
       # - '51054219'   # Oracle Client 12.1.0.2. Compatible with RHEL 7.x and SLES 12.x
       # - '51054433'   # Oracle 12.2.0.1 Client V2 64bit (All), ZIP. Compatible with RHEL 7.x and SLES 12.x
-      - '51057419'   # Oracle 19.0.0.0 RDBMS Client 64bit (All), ZIP (AKA. Oracle Database 19c Base Release). Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
+      - '51059602'  # Oracle 19.0.0.0 RDBMS Client 64bit
 
       # Application Server
       - '51050829_3' # SAP Netweaver 7.5 Installation Export, ZIP

--- a/deploy_scenarios/sap_nwas_abap_sapase_sandbox/README.md
+++ b/deploy_scenarios/sap_nwas_abap_sapase_sandbox/README.md
@@ -9,27 +9,27 @@ A single-host system, as defined by SAP, consolidates all SAP Database and SAP N
 This configuration, often referred to as a Two-Tier Architecture, OneHost, or Central System, is ideal for development, testing, and demonstration purposes.  
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
 - IBM Cloud
 - Microsoft Azure (MS Azure)
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 ### Considerations for ppc64le
 This Ansible Playbook is not available for IBM Power Little Endian (ppc64le).
 - All prior SAP Software without SAP HANA was for IBM Power Big Endian (ppc64) only.
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
 - SAP NetWeaver 7.52 SP00
 - SAP NetWeaver 7.50 SP00
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_extravars.yml
@@ -111,7 +111,7 @@ sap_software_install_dictionary:
       - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
       - 'igsexe_13-80003187.sar' # IGS 7.53
       - 'igshelper_17-10010245.sar'
-      - 'SYBCTRL_1440-80002616.SAR'
+      - 'SYBCTRL_1532-80002616.SAR'
       # Tools
       - 'SAPCAR_1300-70007716.EXE'
       - 'SWPM10SP43_2-20009701.SAR'
@@ -150,7 +150,7 @@ sap_software_install_dictionary:
       - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
       - 'igsexe_13-80003187.sar' # IGS 7.53
       - 'igshelper_17-10010245.sar'
-      - 'SYBCTRL_1440-80002616.SAR'
+      - 'SYBCTRL_1532-80002616.SAR'
       # Tools
       - 'SAPCAR_1300-70007716.EXE'
       - 'SWPM10SP43_2-20009701.SAR'

--- a/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_playbook.yml
@@ -256,7 +256,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_playbook.yml
@@ -257,6 +257,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_abap_sapase_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapase_sandbox/optional/ansible_extravars_interactive.yml
@@ -55,7 +55,7 @@ sap_software_install_dictionary:
       - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
       - 'igsexe_13-80003187.sar' # IGS 7.53
       - 'igshelper_17-10010245.sar'
-      - 'SYBCTRL_1440-80002616.SAR'
+      - 'SYBCTRL_1532-80002616.SAR'
       # Tools
       - 'SAPCAR_1300-70007716.EXE'
       - 'SWPM10SP43_2-20009701.SAR'
@@ -94,7 +94,7 @@ sap_software_install_dictionary:
       - 'SAPHOSTAGENT51_51-20009394.SAR' # SAP Host Agent 7.21
       - 'igsexe_13-80003187.sar' # IGS 7.53
       - 'igshelper_17-10010245.sar'
-      - 'SYBCTRL_1440-80002616.SAR'
+      - 'SYBCTRL_1532-80002616.SAR'
       # Tools
       - 'SAPCAR_1300-70007716.EXE'
       - 'SWPM10SP43_2-20009701.SAR'

--- a/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/README.md
+++ b/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/README.md
@@ -9,27 +9,27 @@ A single-host system, as defined by SAP, consolidates all SAP Database and SAP N
 This configuration, often referred to as a Two-Tier Architecture, OneHost, or Central System, is ideal for development, testing, and demonstration purposes. 
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
 - IBM Cloud
 - Microsoft Azure (MS Azure)
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 ### Considerations for ppc64le
 This Ansible Playbook is not available for IBM Power Little Endian (ppc64le).
 - All prior SAP Software without SAP HANA was for IBM Power Big Endian (ppc64) only.
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
 - SAP NetWeaver 7.52 SP00
 - SAP NetWeaver 7.50 SP00
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_extravars.yml
@@ -103,8 +103,8 @@ sap_software_install_dictionary:
     sap_software_list_x86_64:
       # Database Server
       # - '51054410_2' # CD Media for MaxDB 7.9 - SP10 Build 04 Linux on x86_64 64bit
-      - 'MAXDB7911_10-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
-      - 'MAXDBART7911_10-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
+      - 'MAXDB7911_15-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
+      - 'MAXDBART7911_15-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
       # Application Server
       - '51051806_1' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 1/2, RAR
       - '51051806_2' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 2/2, RAR
@@ -137,8 +137,8 @@ sap_software_install_dictionary:
     sap_software_list_x86_64:
       # Database Server
       # - '51054410_2' # CD Media for MaxDB 7.9 - SP10 Build 04 Linux on x86_64 64bit
-      - 'MAXDB7911_10-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
-      - 'MAXDBART7911_10-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
+      - 'MAXDB7911_15-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
+      - 'MAXDBART7911_15-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
       # Application Server
       - '51050829_3' # SAP Netweaver 7.5 Installation Export, ZIP
       # - '51050829_4' # NW 7.5 Language 1/2

--- a/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_playbook.yml
@@ -256,7 +256,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_playbook.yml
@@ -257,6 +257,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/optional/ansible_extravars_interactive.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/optional/ansible_extravars_interactive.yml
@@ -46,8 +46,8 @@ sap_software_install_dictionary:
     sap_software_list_x86_64:
       # Database Server
       # - '51054410_2' # CD Media for MaxDB 7.9 - SP10 Build 04 Linux on x86_64 64bit
-      - 'MAXDB7911_10-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
-      - 'MAXDBART7911_10-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
+      - 'MAXDB7911_15-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
+      - 'MAXDBART7911_15-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
       # Application Server
       - '51051806_1' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 1/2, RAR
       - '51051806_2' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 2/2, RAR
@@ -80,8 +80,8 @@ sap_software_install_dictionary:
     sap_software_list_x86_64:
       # Database Server
       # - '51054410_2' # CD Media for MaxDB 7.9 - SP10 Build 04 Linux on x86_64 64bit
-      - 'MAXDB7911_10-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
-      - 'MAXDBART7911_10-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
+      - 'MAXDB7911_15-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
+      - 'MAXDBART7911_15-20009119.SAR'  # MAXDB 7.9 64-BIT Linux on x86_64 64bit
       # Application Server
       - '51050829_3' # SAP Netweaver 7.5 Installation Export, ZIP
       # - '51050829_4' # NW 7.5 Language 1/2

--- a/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/README.md
+++ b/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/README.md
@@ -9,26 +9,26 @@ A single-host system, as defined by SAP, consolidates all SAP Database and SAP N
 This configuration, often referred to as a Two-Tier Architecture, OneHost, or Central System, is ideal for development, testing, and demonstration purposes.  
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
 - IBM Cloud
 - Microsoft Azure (MS Azure)
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 ### Considerations for ppc64le
 This Ansible Playbook is not available for IBM Power Little Endian (ppc64le).
 - All prior SAP Software without SAP HANA was for IBM Power Big Endian (ppc64) only.
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
 - SAP NetWeaver 7.50 SP22
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_java_sapase_sandbox/README.md
+++ b/deploy_scenarios/sap_nwas_java_sapase_sandbox/README.md
@@ -8,26 +8,26 @@ A single-host system, as defined by SAP, consolidates all SAP Database and SAP N
 
 This configuration, often referred to as a Two-Tier Architecture, OneHost, or Central System, is ideal for development, testing, and demonstration purposes.  
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
 - IBM Cloud
 - Microsoft Azure (MS Azure)
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 ### Considerations for ppc64le
 This Ansible Playbook is not available for IBM Power Little Endian (ppc64le).
 - All prior SAP Software without SAP HANA was for IBM Power Big Endian (ppc64) only.
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
 - SAP NetWeaver 7.50 SP22
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_distributed/README.md
+++ b/deploy_scenarios/sap_s4hana_distributed/README.md
@@ -9,8 +9,8 @@ A distributed SAP system, as defined by SAP, separates the SAP ABAP Platform com
 This configuration, often referred to as a Multi-Tier Architecture, is ideal for production environments, or for scenarios requiring scalability and resource separation.
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
@@ -18,22 +18,23 @@ This Ansible Playbook supports the deployment on the following infrastructure pl
 - IBM Cloud, IBM Power Virtual Servers
 - Microsoft Azure (MS Azure)
 - IBM PowerVM
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 ### Considerations for ppc64le
 This Ansible Playbook is not available for IBM Power Little Endian (ppc64le).
 - All prior SAP Software without SAP HANA was for IBM Power Big Endian (ppc64) only.
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
+- SAP S/4HANA 2025
 - SAP S/4HANA 2023
 - SAP S/4HANA 2022
 - SAP S/4HANA 2021
 - SAP S/4HANA 2020
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_s4hana_distributed/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed/ansible_playbook.yml
@@ -238,6 +238,24 @@
   max_fail_percentage: 0
   tasks:
 
+    - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts  # noqa: no-tabs
+      ansible.builtin.import_role:
+        name: community.sap_install.sap_maintain_etc_hosts
+      vars:
+        sap_maintain_etc_hosts_delimiter: "\t"
+        sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+        sap_maintain_etc_hosts_list: >-
+          {%- set my_list = [] -%}
+          {%- for host in ansible_play_hosts_all -%}
+            {%- if hostvars[host] is defined and hostvars[host]['ansible_host'] is defined -%}
+              {%- set _ = my_list.append({'node_name': host, 'node_ip': hostvars[host]['ansible_host']}) -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {{ my_list }}
+      when:
+        - sap_vm_provision_iac_platform == 'existing_hosts'
+        - sap_domain | d('') | length > 0 or ansible_facts['domain'] | d('') | length > 0
+
     - name: Install rsync
       ansible.builtin.package:
         name: rsync
@@ -269,7 +287,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -317,7 +335,7 @@
   tasks:
 
     - name: Transfer SAP HANA installation media to SAP HANA Primary
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -344,7 +362,7 @@
   tasks:
 
     - name: Transfer SAP NetWeaver ASCS installation media to host
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -371,7 +389,7 @@
   tasks:
 
     - name: Transfer SAP NetWeaver AAS installation media to host
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"

--- a/deploy_scenarios/sap_s4hana_distributed/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed/ansible_playbook.yml
@@ -288,6 +288,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_distributed_ha/README.md
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/README.md
@@ -15,8 +15,8 @@ This deployment incorporates the following High Availability features:
 - A load balancer for virtual IP addresses and hostnames (when `sap_vm_provision_iac_type` is not `existing_hosts`).  
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
@@ -24,18 +24,19 @@ This Ansible Playbook supports the deployment on the following infrastructure pl
 - IBM Cloud, IBM Power Virtual Servers
 - Microsoft Azure (MS Azure)
 - IBM PowerVM
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
+- SAP S/4HANA 2025
 - SAP S/4HANA 2023
 - SAP S/4HANA 2022
 - SAP S/4HANA 2021
 - SAP S/4HANA 2020
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_s4hana_distributed_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/ansible_playbook.yml
@@ -244,6 +244,41 @@
   max_fail_percentage: 0
   tasks:
 
+    - name: Block to prepare /etc/hosts entries for all hosts
+      when:
+        - sap_vm_provision_iac_platform == 'existing_hosts'
+        - sap_domain | d('') | length > 0 or ansible_facts['domain'] | d('') | length > 0
+      block:
+
+        - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts  # noqa: no-tabs
+          ansible.builtin.import_role:
+            name: community.sap_install.sap_maintain_etc_hosts
+          vars:
+            sap_maintain_etc_hosts_delimiter: "\t"
+            sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+            sap_maintain_etc_hosts_list: >-
+              {%- set my_list = [] -%}
+              {%- for host in ansible_play_hosts_all -%}
+                {%- if hostvars[host] is defined and hostvars[host]['ansible_host'] is defined -%}
+                  {%- set _ = my_list.append({'node_name': host, 'node_ip': hostvars[host]['ansible_host']}) -%}
+                {%- endif -%}
+              {%- endfor -%}
+              {{ my_list }}
+
+        - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts - HA  # noqa: no-tabs
+          ansible.builtin.import_role:
+            name: community.sap_install.sap_maintain_etc_hosts
+          vars:
+            sap_maintain_etc_hosts_delimiter: "\t"
+            sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+            sap_maintain_etc_hosts_list:
+              - node_name: "{{ sap_swpm_ascs_instance_hostname }}"
+                node_ip: "{{ sap_vm_provision_ha_vip_nwas_abap_ascs | regex_replace('/\\d+$', '') }}"
+              - node_name: "{{ sap_swpm_ers_instance_hostname }}"
+                node_ip: "{{ sap_vm_provision_ha_vip_nwas_abap_ers | regex_replace('/\\d+$', '') }}"
+              - node_name: "{{ sap_swpm_db_host }}"
+                node_ip: "{{ sap_vm_provision_ha_vip_hana_primary | regex_replace('/\\d+$', '') }}"
+
     - name: Install rsync
       ansible.builtin.package:
         name: rsync
@@ -275,7 +310,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -331,7 +366,7 @@
   tasks:
 
     - name: Transfer SAP HANA installation media to SAP HANA Primary and SAP HANA Secondary
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -361,7 +396,7 @@
   tasks:
 
     - name: Transfer SAP NetWeaver ASCS installation media to host
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -391,7 +426,7 @@
   tasks:
 
     - name: Transfer SAP NetWeaver AAS installation media to host
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"

--- a/deploy_scenarios/sap_s4hana_distributed_ha/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/ansible_playbook.yml
@@ -311,6 +311,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/README.md
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/README.md
@@ -17,8 +17,8 @@ This deployment incorporates the following High Availability features:
 **NOTE:** A key distinction of this playbook is its use of the SAP Maintenance Planner to download SAP Installation Media, instead of a file list, as used in the `sap_s4hana_distributed_ha` scenario.  
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
@@ -26,17 +26,18 @@ This Ansible Playbook supports the deployment on the following infrastructure pl
 - IBM Cloud, IBM Power Virtual Servers
 - Microsoft Azure (MS Azure)
 - IBM PowerVM
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
+- SAP S/4HANA 2025
 - SAP S/4HANA 2023
 - SAP S/4HANA 2022
 - SAP S/4HANA 2021
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_playbook.yml
@@ -244,6 +244,41 @@
   max_fail_percentage: 0
   tasks:
 
+    - name: Block to prepare /etc/hosts entries for all hosts
+      when:
+        - sap_vm_provision_iac_platform == 'existing_hosts'
+        - sap_domain | d('') | length > 0 or ansible_facts['domain'] | d('') | length > 0
+      block:
+
+        - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts  # noqa: no-tabs
+          ansible.builtin.import_role:
+            name: community.sap_install.sap_maintain_etc_hosts
+          vars:
+            sap_maintain_etc_hosts_delimiter: "\t"
+            sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+            sap_maintain_etc_hosts_list: >-
+              {%- set my_list = [] -%}
+              {%- for host in ansible_play_hosts_all -%}
+                {%- if hostvars[host] is defined and hostvars[host]['ansible_host'] is defined -%}
+                  {%- set _ = my_list.append({'node_name': host, 'node_ip': hostvars[host]['ansible_host']}) -%}
+                {%- endif -%}
+              {%- endfor -%}
+              {{ my_list }}
+
+        - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts - HA  # noqa: no-tabs
+          ansible.builtin.import_role:
+            name: community.sap_install.sap_maintain_etc_hosts
+          vars:
+            sap_maintain_etc_hosts_delimiter: "\t"
+            sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+            sap_maintain_etc_hosts_list:
+              - node_name: "{{ sap_swpm_ascs_instance_hostname }}"
+                node_ip: "{{ sap_vm_provision_ha_vip_nwas_abap_ascs | regex_replace('/\\d+$', '') }}"
+              - node_name: "{{ sap_swpm_ers_instance_hostname }}"
+                node_ip: "{{ sap_vm_provision_ha_vip_nwas_abap_ers | regex_replace('/\\d+$', '') }}"
+              - node_name: "{{ sap_swpm_db_host }}"
+                node_ip: "{{ sap_vm_provision_ha_vip_hana_primary | regex_replace('/\\d+$', '') }}"
+
     - name: Install rsync
       ansible.builtin.package:
         name: rsync
@@ -275,7 +310,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -332,7 +367,7 @@
   tasks:
 
     - name: Transfer SAP HANA installation media to SAP HANA Primary and SAP HANA Secondary
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -362,7 +397,7 @@
   tasks:
 
     - name: Transfer SAP NetWeaver ASCS installation media to host
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -392,7 +427,7 @@
   tasks:
 
     - name: Transfer SAP NetWeaver AAS installation media to host
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_playbook.yml
@@ -311,6 +311,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_distributed_maintplan/README.md
+++ b/deploy_scenarios/sap_s4hana_distributed_maintplan/README.md
@@ -11,8 +11,8 @@ This configuration, often referred to as a Multi-Tier Architecture, is ideal for
 **NOTE:** A key distinction of this playbook is its use of the SAP Maintenance Planner to download SAP Installation Media, instead of a file list, as used in the `sap_s4hana_distributed` scenario.  
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
@@ -20,21 +20,22 @@ This Ansible Playbook supports the deployment on the following infrastructure pl
 - IBM Cloud, IBM Power Virtual Servers
 - Microsoft Azure (MS Azure)
 - IBM PowerVM
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 ### Considerations for ppc64le
 This Ansible Playbook is not available for IBM Power Little Endian (ppc64le).
 - All prior SAP Software without SAP HANA was for IBM Power Big Endian (ppc64) only.
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
+- SAP S/4HANA 2025
 - SAP S/4HANA 2023
 - SAP S/4HANA 2022
 - SAP S/4HANA 2021
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_playbook.yml
@@ -238,6 +238,24 @@
   max_fail_percentage: 0
   tasks:
 
+    - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts  # noqa: no-tabs
+      ansible.builtin.import_role:
+        name: community.sap_install.sap_maintain_etc_hosts
+      vars:
+        sap_maintain_etc_hosts_delimiter: "\t"
+        sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+        sap_maintain_etc_hosts_list: >-
+          {%- set my_list = [] -%}
+          {%- for host in ansible_play_hosts_all -%}
+            {%- if hostvars[host] is defined and hostvars[host]['ansible_host'] is defined -%}
+              {%- set _ = my_list.append({'node_name': host, 'node_ip': hostvars[host]['ansible_host']}) -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {{ my_list }}
+      when:
+        - sap_vm_provision_iac_platform == 'existing_hosts'
+        - sap_domain | d('') | length > 0 or ansible_facts['domain'] | d('') | length > 0
+
     - name: Install rsync
       ansible.builtin.package:
         name: rsync
@@ -269,7 +287,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -318,7 +336,7 @@
   tasks:
 
     - name: Transfer SAP HANA installation media to SAP HANA Primary
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -345,7 +363,7 @@
   tasks:
 
     - name: Transfer SAP NetWeaver ASCS installation media to host
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"
@@ -372,7 +390,7 @@
   tasks:
 
     - name: Transfer SAP NetWeaver AAS installation media to host
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"

--- a/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_playbook.yml
@@ -288,6 +288,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_foundation_sandbox/README.md
+++ b/deploy_scenarios/sap_s4hana_foundation_sandbox/README.md
@@ -14,8 +14,8 @@ It is not intended to be used as Standalone for custom ABAP development with the
 For full list of compatible and supported Add-Ons with SAP S/4HANA Foundation (**not including ADS or ESR**), [Please see SAP Note 3143630 - SAP S/4HANA FOUNDATION 2022: Release Information](https://me.sap.com/notes/3143630).
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
@@ -23,17 +23,18 @@ This Ansible Playbook supports the deployment on the following infrastructure pl
 - IBM Cloud, IBM Power Virtual Servers
 - Microsoft Azure (MS Azure)
 - IBM PowerVM
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
+- SAP S/4HANA Foundation 2025
 - SAP S/4HANA Foundation 2023
 - SAP S/4HANA Foundation 2022
 - SAP S/4HANA Foundation 2021
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_foundation_standard/README.md
+++ b/deploy_scenarios/sap_s4hana_foundation_standard/README.md
@@ -15,8 +15,8 @@ It is not intended to be used as Standalone for custom ABAP development with the
 For full list of compatible and supported Add-Ons with SAP S/4HANA Foundation (**not including ADS or ESR**), [Please see SAP Note 3143630 - SAP S/4HANA FOUNDATION 2022: Release Information](https://me.sap.com/notes/3143630).
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
@@ -24,18 +24,19 @@ This Ansible Playbook supports the deployment on the following infrastructure pl
 - IBM Cloud, IBM Power Virtual Servers
 - Microsoft Azure (MS Azure)
 - IBM PowerVM
-- KubeVirt
-- OVirt
-- VMware
+- KubeVirt `Experimental`
+- OVirt `Experimental`
+- VMware `Experimental`
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
+- SAP S/4HANA Foundation 2025
 - SAP S/4HANA Foundation 2023
 - SAP S/4HANA Foundation 2022
 - SAP S/4HANA Foundation 2021
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_s4hana_foundation_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_standard/ansible_playbook.yml
@@ -238,6 +238,24 @@
   max_fail_percentage: 0
   tasks:
 
+    - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts  # noqa: no-tabs
+      ansible.builtin.import_role:
+        name: community.sap_install.sap_maintain_etc_hosts
+      vars:
+        sap_maintain_etc_hosts_delimiter: "\t"
+        sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+        sap_maintain_etc_hosts_list: >-
+          {%- set my_list = [] -%}
+          {%- for host in ansible_play_hosts_all -%}
+            {%- if hostvars[host] is defined and hostvars[host]['ansible_host'] is defined -%}
+              {%- set _ = my_list.append({'node_name': host, 'node_ip': hostvars[host]['ansible_host']}) -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {{ my_list }}
+      when:
+        - sap_vm_provision_iac_platform == 'existing_hosts'
+        - sap_domain | d('') | length > 0 or ansible_facts['domain'] | d('') | length > 0
+
     - name: Install rsync
       ansible.builtin.package:
         name: rsync
@@ -269,7 +287,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -301,7 +319,7 @@
   tasks:
 
     - name: Transfer SAP HANA installation media to SAP HANA Primary
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"

--- a/deploy_scenarios/sap_s4hana_foundation_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_standard/ansible_playbook.yml
@@ -288,6 +288,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_sandbox/README.md
+++ b/deploy_scenarios/sap_s4hana_sandbox/README.md
@@ -8,8 +8,8 @@ A single-host system, as defined by SAP, consolidates all SAP Database and SAP A
 This configuration, often referred to as a Two-Tier Architecture, OneHost, or Central System, is ideal for development, testing, and demonstration purposes.
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
@@ -17,18 +17,19 @@ This Ansible Playbook supports the deployment on the following infrastructure pl
 - IBM Cloud, IBM Power Virtual Servers
 - Microsoft Azure (MS Azure)
 - IBM PowerVM
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
+- SAP S/4HANA 2025
 - SAP S/4HANA 2023
 - SAP S/4HANA 2022
 - SAP S/4HANA 2021
 - SAP S/4HANA 2020
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_s4hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_sandbox_maintplan/README.md
+++ b/deploy_scenarios/sap_s4hana_sandbox_maintplan/README.md
@@ -10,8 +10,8 @@ This configuration, often referred to as a Two-Tier Architecture, OneHost, or Ce
 **NOTE:** A key distinction of this playbook is its use of the SAP Maintenance Planner to download SAP Installation Media, instead of a file list, as used in the `sap_s4hana_sandbox` scenario.  
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
@@ -19,18 +19,18 @@ This Ansible Playbook supports the deployment on the following infrastructure pl
 - IBM Cloud, IBM Power Virtual Servers
 - Microsoft Azure (MS Azure)
 - IBM PowerVM
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
+- SAP S/4HANA 2025
 - SAP S/4HANA 2023
 - SAP S/4HANA 2022
 - SAP S/4HANA 2021
-- SAP S/4HANA 2020
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_sandbox_syscopy/README.md
+++ b/deploy_scenarios/sap_s4hana_sandbox_syscopy/README.md
@@ -10,8 +10,8 @@ This configuration, often referred to as a Two-Tier Architecture, OneHost, or Ce
 Installation with restore of a System Copy using SAP HANA complete data backup, further extends the usefulness for iterative testing (such as migration preparation) activities.
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
@@ -19,18 +19,19 @@ This Ansible Playbook supports the deployment on the following infrastructure pl
 - IBM Cloud, IBM Power Virtual Servers
 - Microsoft Azure (MS Azure)
 - IBM PowerVM
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
+- SAP S/4HANA 2025
 - SAP S/4HANA 2023
 - SAP S/4HANA 2022
 - SAP S/4HANA 2021
 - SAP S/4HANA 2020
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_s4hana_sandbox_syscopy/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_syscopy/ansible_playbook.yml
@@ -254,7 +254,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_sandbox_syscopy/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_syscopy/ansible_playbook.yml
@@ -255,6 +255,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_standard/README.md
+++ b/deploy_scenarios/sap_s4hana_standard/README.md
@@ -9,8 +9,8 @@ A standard system, as defined by SAP, consists of the SAP ABAP Platform running 
 This configuration, often referred to as a Three-Tier Architecture or DualHost, is ideal for production environments, or for scenarios requiring high availability and scalability.  
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
@@ -18,19 +18,20 @@ This Ansible Playbook supports the deployment on the following infrastructure pl
 - IBM Cloud, IBM Power Virtual Servers
 - Microsoft Azure (MS Azure)
 - IBM PowerVM
-- KubeVirt
-- OVirt
-- VMware
+- KubeVirt `Experimental`
+- OVirt `Experimental`
+- VMware `Experimental`
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
+- SAP S/4HANA 2025
 - SAP S/4HANA 2023
 - SAP S/4HANA 2022
 - SAP S/4HANA 2021
 - SAP S/4HANA 2020
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_s4hana_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_standard/ansible_playbook.yml
@@ -270,6 +270,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_standard/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_standard/ansible_playbook.yml
@@ -269,7 +269,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -301,7 +301,7 @@
   tasks:
 
     - name: Transfer SAP HANA installation media to SAP HANA Primary
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"

--- a/deploy_scenarios/sap_s4hana_standard_maintplan/README.md
+++ b/deploy_scenarios/sap_s4hana_standard_maintplan/README.md
@@ -11,8 +11,8 @@ This configuration, often referred to as a Three-Tier Architecture or DualHost, 
 **NOTE:** A key distinction of this playbook is its use of the SAP Maintenance Planner to download SAP Installation Media, instead of a file list, as used in the `sap_s4hana_standard` scenario.  
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
@@ -20,18 +20,19 @@ This Ansible Playbook supports the deployment on the following infrastructure pl
 - IBM Cloud, IBM Power Virtual Servers
 - Microsoft Azure (MS Azure)
 - IBM PowerVM
-- KubeVirt
-- OVirt
-- VMware
+- KubeVirt `Experimental`
+- OVirt `Experimental`
+- VMware `Experimental`
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
+- SAP S/4HANA 2025
 - SAP S/4HANA 2023
 - SAP S/4HANA 2022
 - SAP S/4HANA 2021
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_playbook.yml
@@ -270,6 +270,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_playbook.yml
+++ b/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_playbook.yml
@@ -269,7 +269,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -301,7 +301,7 @@
   tasks:
 
     - name: Transfer SAP HANA installation media to SAP HANA Primary
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"

--- a/deploy_scenarios/sap_solman_sapase_sandbox/README.md
+++ b/deploy_scenarios/sap_solman_sapase_sandbox/README.md
@@ -9,26 +9,26 @@ A single-host system, as defined by SAP, consolidates all SAP Database and SAP N
 This configuration, often referred to as a Two-Tier Architecture, OneHost, or Central System, is ideal for development, testing, and demonstration purposes.  
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
 - IBM Cloud
 - Microsoft Azure (MS Azure)
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 ### Considerations for ppc64le
 This Ansible Playbook is not available for IBM Power Little Endian (ppc64le).
 - All prior SAP Software without SAP HANA was for IBM Power Big Endian (ppc64) only.
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
 - SAP Solution Manager 7.2 SR2
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture
@@ -70,7 +70,7 @@ ansible-playbook ansible_playbook.yml \
 ```
 
 ### Interactive Execution
-This method is not supported due to complexity of this scenario.
+This method is not available due to complexity of this scenario.
 
 
 ## Deployment Process

--- a/deploy_scenarios/sap_solman_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_solman_sapase_sandbox/ansible_playbook.yml
@@ -206,6 +206,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_solman_sapase_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_solman_sapase_sandbox/ansible_playbook.yml
@@ -205,7 +205,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_solman_saphana_sandbox/README.md
+++ b/deploy_scenarios/sap_solman_saphana_sandbox/README.md
@@ -9,22 +9,22 @@ A single-host system, as defined by SAP, consolidates all SAP Database and SAP N
 This configuration, often referred to as a Two-Tier Architecture, OneHost, or Central System, is ideal for development, testing, and demonstration purposes.  
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
 - IBM Cloud
 - Microsoft Azure (MS Azure)
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
 - SAP Solution Manager 7.2 SR2
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture
@@ -66,7 +66,7 @@ ansible-playbook ansible_playbook.yml \
 ```
 
 ### Interactive Execution
-This method is not supported due to complexity of this scenario.
+This method is not available due to complexity of this scenario.
 
 
 ## Deployment Process

--- a/deploy_scenarios/sap_solman_saphana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_solman_saphana_sandbox/ansible_playbook.yml
@@ -207,6 +207,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/deploy_scenarios/sap_solman_saphana_sandbox/ansible_playbook.yml
+++ b/deploy_scenarios/sap_solman_saphana_sandbox/ansible_playbook.yml
@@ -206,7 +206,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/special_actions/sap_download_install_media/ansible_extravars.yml
+++ b/special_actions/sap_download_install_media/ansible_extravars.yml
@@ -767,7 +767,7 @@ sap_software_install_dictionary:
       - '51053828'   # Oracle 19.0.0.0 RDBMS Linux on x86_64 64bit, ZIP. Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
 #      - '51054219'   # Oracle Client 12.1.0.2. Compatible with RHEL 7.x and SLES 12.x
 #      - '51054433'   # Oracle 12.2.0.1 Client V2 64bit (All), ZIP. Compatible with RHEL 7.x and SLES 12.x
-      - '51057419'   # Oracle 19.0.0.0 RDBMS Client 64bit (All), ZIP (AKA. Oracle Database 19c Base Release). Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
+      - '51059602'  # Oracle 19.0.0.0 RDBMS Client 64bit
       - '51050708_1' # SAP ERP 6.0 EHP8 Installation Export 1/4, Self-extract RAR EXE
       - '51050708_2'
       - '51050708_3'
@@ -798,7 +798,7 @@ sap_software_install_dictionary:
       - 'SWPM10SP43_2-20009701.SAR'
       - 'igsexe_13-80003187.sar' # IGS 7.53
       - 'igshelper_17-10010245.sar'
-      - 'SYBCTRL_1440-80002616.SAR'
+      - 'SYBCTRL_1532-80002616.SAR'
       - '51057961_1' # SAP ASE 16.0.04.06 HF1 RDBMS Linux on x86_64 64bit
       - 'ASEBC16004P_5-20012477.SAR' # SAP ASE 16.0 SP04 (160-04) FOR BUS. SUITE DBCLIENT with Patch (P_*)
       - '51050708_1' # SAP ERP 6.0 EHP8 Installation Export 1/4, Self-extract RAR EXE
@@ -993,7 +993,7 @@ sap_software_install_dictionary:
       - '51053828'   # Oracle 19.0.0.0 RDBMS Linux on x86_64 64bit, ZIP. Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
 #      - '51054219'   # Oracle Client 12.1.0.2. Compatible with RHEL 7.x and SLES 12.x
 #      - '51054433'   # Oracle 12.2.0.1 Client V2 64bit (All), ZIP. Compatible with RHEL 7.x and SLES 12.x
-      - '51057419'   # Oracle 19.0.0.0 RDBMS Client 64bit (All), ZIP (AKA. Oracle Database 19c Base Release). Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
+      - '51059602'  # Oracle 19.0.0.0 RDBMS Client 64bit
       - '51051806_1' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 1/2, RAR
       - '51051806_2' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 2/2, RAR
 
@@ -1022,7 +1022,7 @@ sap_software_install_dictionary:
       - '51053828'   # Oracle 19.0.0.0 RDBMS Linux on x86_64 64bit, ZIP. Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
 #      - '51054219'   # Oracle Client 12.1.0.2. Compatible with RHEL 7.x and SLES 12.x
 #      - '51054433'   # Oracle 12.2.0.1 Client V2 64bit (All), ZIP. Compatible with RHEL 7.x and SLES 12.x
-      - '51057419'   # Oracle 19.0.0.0 RDBMS Client 64bit (All), ZIP (AKA. Oracle Database 19c Base Release). Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
+      - '51059602'  # Oracle 19.0.0.0 RDBMS Client 64bit
       - '51050829_3' # SAP Netweaver 7.5 Installation Export, ZIP
 #      - '51050829_4' # NW 7.5 Language 1/2
 #      - '51050829_5' # NW 7.5 Language 2/2
@@ -1047,7 +1047,7 @@ sap_software_install_dictionary:
       - 'SWPM10SP43_2-20009701.SAR'
       - 'igsexe_13-80003187.sar' # IGS 7.53
       - 'igshelper_17-10010245.sar'
-      - 'SYBCTRL_1440-80002616.SAR'
+      - 'SYBCTRL_1532-80002616.SAR'
       - '51057961_1' # SAP ASE 16.0.04.06 HF1 RDBMS Linux on x86_64 64bit
       - 'ASEBC16004P_5-20012477.SAR' # SAP ASE 16.0 SP04 (160-04) FOR BUS. SUITE DBCLIENT with Patch (P_*)
       - '51051806_1' # NetWeaver AS ABAP 7.52 Innovation Pkg - Installation Exp 1/2, RAR
@@ -1069,7 +1069,7 @@ sap_software_install_dictionary:
       - 'SWPM10SP43_2-20009701.SAR'
       - 'igsexe_13-80003187.sar' # IGS 7.53
       - 'igshelper_17-10010245.sar'
-      - 'SYBCTRL_1440-80002616.SAR'
+      - 'SYBCTRL_1532-80002616.SAR'
       - '51057961_1' # SAP ASE 16.0.04.06 HF1 RDBMS Linux on x86_64 64bit
       - 'ASEBC16004P_5-20012477.SAR' # SAP ASE 16.0 SP04 (160-04) FOR BUS. SUITE DBCLIENT with Patch (P_*)
       - '51050829_3' # SAP Netweaver 7.5 Installation Export, ZIP
@@ -1281,7 +1281,7 @@ sap_software_install_dictionary:
       - '51053828'   # Oracle 19.0.0.0 RDBMS Linux on x86_64 64bit, ZIP. Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
 #      - '51054219'   # Oracle Client 12.1.0.2. Compatible with RHEL 7.x and SLES 12.x
 #      - '51054433'   # Oracle 12.2.0.1 Client V2 64bit (All), ZIP. Compatible with RHEL 7.x and SLES 12.x
-      - '51057419'   # Oracle 19.0.0.0 RDBMS Client 64bit (All), ZIP (AKA. Oracle Database 19c Base Release). Compatible with RHEL 7.x/8.x and SLES 12.x/15.x
+      - '51059602'  # Oracle 19.0.0.0 RDBMS Client 64bit
       - '51053216_1' # IDES SAP ERP 6.0 EHP8 - INSTALL. EXP. (1/2) 1/22
       - '51053216_2'
       - '51053216_3'
@@ -1322,7 +1322,7 @@ sap_software_install_dictionary:
       - 'SWPM10SP43_2-20009701.SAR'
       - 'igsexe_13-80003187.sar' # IGS 7.53
       - 'igshelper_17-10010245.sar'
-      - 'SYBCTRL_1440-80002616.SAR'
+      - 'SYBCTRL_1532-80002616.SAR'
       - '51057961_1' # SAP ASE 16.0.04.06 HF1 RDBMS Linux on x86_64 64bit
       - 'ASEBC16004P_5-20012477.SAR' # SAP ASE 16.0 SP04 (160-04) FOR BUS. SUITE DBCLIENT with Patch (P_*)
       - '51053216_1' # IDES SAP ERP 6.0 EHP8 - INSTALL. EXP. (1/2) 1/22

--- a/special_actions/sap_download_install_media/ansible_playbook.yml
+++ b/special_actions/sap_download_install_media/ansible_playbook.yml
@@ -85,7 +85,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_software_target_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ sap_software_install_dictionary[product_item]
           ['softwarecenter_search_list_' ~ sap_software_cpu_architecture] }}"
       loop: "{{ sap_software_product.split(',') }}"

--- a/special_actions/sap_nwas_abap_ascs_ers_cluster/README.md
+++ b/special_actions/sap_nwas_abap_ascs_ers_cluster/README.md
@@ -12,8 +12,8 @@ This deployment incorporates the following High Availability features:
 **This Ansible Playbook does not install fully functional SAP System, but rather focuses on installation of SAP ASCS/ERS Cluster for testing purpose.**
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
@@ -21,15 +21,16 @@ This Ansible Playbook supports the deployment on the following infrastructure pl
 - IBM Cloud, IBM Power Virtual Servers
 - Microsoft Azure (MS Azure)
 - IBM PowerVM
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
+- SAP S/4HANA 2025
 - SAP S/4HANA 2023
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture

--- a/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_extravars.yml
+++ b/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_extravars.yml
@@ -119,6 +119,55 @@ sap_ip: "{{ ansible_facts['default_ipv4'].address }}"
 #### Ansible dictionary for SAP Installation Media ####
 sap_software_install_dictionary:
 
+  sap_s4hana_2025_distributed:
+
+    # List of product specific software files that are architecture independent.
+    sap_software_list_independent:
+      # Application Server
+      - 'igshelper_17-10010245.sar'
+
+    # List of product specific software files that are architecture dependent - Linux on x86_64 64bit.
+    sap_software_list_x86_64:
+      # Application Server
+      - 'SAPEXE_50-70008102.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008101.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004822.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'igsexe_0-70008564.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      # Tools
+      - 'SAPCAR_1400-70007716.EXE'
+      - 'SWPM20SP23_2-80003424.SAR'
+
+    # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
+    sap_software_list_ppc64le:
+      # Application Server
+      - 'SAPEXE_50-70008127.SAR' # Kernel Part I (916)
+      - 'SAPEXEDB_50-70008126.SAR' # Kernel Part II (916)
+      - 'SAPHOSTAGENT70_70-80004831.SAR' # SAP HOST AGENT 7.22 SP70
+      - 'igsexe_0-70008566.sar'  # Installation for SAP IGS integrated in SAP Kernel
+      # Tools
+      - 'SAPCAR_1400-70007726.EXE'
+      - 'SWPM20SP23_2-80003426.SAR'
+
+    nwas_ascs_ha:
+
+      # SWPM product catalog ID for the installation (String).
+      sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2025.CORE.HDB.ABAPHA
+
+      # List of INI file sections to generate using sap_install.sap_swpm role (List).
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs'] }}"
+
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['ascs_ers'] }}"
+
+    nwas_ers_ha:
+
+      # Product ID for New Installation
+      sap_swpm_product_catalog_id: NW_ERS:S4HANA2025.CORE.HDB.ABAPHA
+
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ers'] }}"
+
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['ascs_ers'] }}"
+
+
   sap_s4hana_2023_distributed:
 
     # List of product specific software files that are architecture independent.
@@ -134,8 +183,8 @@ sap_software_install_dictionary:
       - 'SAPHOSTAGENT67_67-80004822.SAR' # SAP Host Agent
       - 'igsexe_4-70005417.sar' # IGS 7.81
       # Tools
-      - 'SAPCAR_1300-70007716.EXE'
-      - 'SWPM20SP20_1-80003424.SAR'
+      - 'SAPCAR_1400-70007716.EXE'
+      - 'SWPM20SP23_2-80003424.SAR'
 
     # List of product specific software files that are architecture dependent - Linux on Power LE 64bit.
     sap_software_list_ppc64le:
@@ -145,8 +194,8 @@ sap_software_install_dictionary:
       - 'SAPHOSTAGENT67_67-80004831.SAR' # SAP Host Agent
       - 'igsexe_4-70005446.sar' # IGS 7.81
       # Tools
-      - 'SAPCAR_1300-70007726.EXE'
-      - 'SWPM20SP20_1-80003426.SAR'
+      - 'SAPCAR_1400-70007726.EXE'
+      - 'SWPM20SP23_2-80003426.SAR'
 
     nwas_ascs_ha:
 
@@ -154,43 +203,50 @@ sap_software_install_dictionary:
       sap_swpm_product_catalog_id: NW_ABAP_ASCS:S4HANA2023.CORE.HDB.ABAPHA
 
       # List of INI file sections to generate using sap_install.sap_swpm role (List).
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - swpm_installation_media_swpm2_hana
-        - credentials
-        - credentials_hana=
-        - nw_config_other
-        - nw_config_central_services_abap
-        - nw_config_ports
-        - nw_config_host_agent
-        - sap_os_linux_user
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ascs'] }}"
 
-      sap_software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SAPHOSTAGENT*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['ascs_ers'] }}"
 
     nwas_ers_ha:
 
       # Product ID for New Installation
       sap_swpm_product_catalog_id: NW_ERS:S4HANA2023.CORE.HDB.ABAPHA
 
-      sap_swpm_inifile_sections_list:
-        - swpm_installation_media
-        - credentials
-        - nw_config_other
-        - nw_config_ers
-        - sap_os_linux_user
+      sap_swpm_inifile_sections_list: "{{ sap_playbook_swpm_inifile_sections['ers'] }}"
 
-      sap_software_files_wildcard_list:
-        - 'SAPCAR*'
-        - 'SWPM20*'
-        - 'igsexe_*'
-        - 'igshelper_*'
-        - 'SAPEXE_*' # Kernel Part I (785)
-        - 'SAPEXEDB_*' # Kernel Part I (785)
-        - 'SAPHOSTAGENT*'
+      sap_software_files_wildcard_list: "{{ sap_playbook_software_wildcards['ascs_ers'] }}"
+
+
+### Reusable dictionaries for SAP Playbooks ###
+
+# Dictionary of lists for 'sap_swpm_inifile_sections' used across various products in 'sap_swpm' role.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_swpm_inifile_sections:
+  ascs:
+    - swpm_installation_media
+    - swpm_installation_media_swpm2_hana
+    - credentials
+    - credentials_hana=
+    - nw_config_other
+    - nw_config_central_services_abap
+    - nw_config_ports
+    - nw_config_host_agent
+    - sap_os_linux_user
+  ers:
+    - swpm_installation_media
+    - credentials
+    - nw_config_other
+    - nw_config_ers
+    - sap_os_linux_user
+
+# Dictionary of lists for software filename wildcard patterns that is used during rsync operations.
+# Customizations can be made here for all products or directly within a product's host type.
+sap_playbook_software_wildcards:
+  ascs_ers:
+    - 'SAPCAR*'
+    - 'SWPM20*'
+    - 'igsexe_*'
+    - 'igshelper_*'
+    - 'SAPEXE_*' # Kernel Part I (785)
+    - 'SAPEXEDB_*' # Kernel Part I (785)
+    - 'SAPHOSTAGENT*'

--- a/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_playbook.yml
+++ b/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_playbook.yml
@@ -176,6 +176,39 @@
   max_fail_percentage: 0
   tasks:
 
+    - name: Block to prepare /etc/hosts entries for all hosts
+      when:
+        - sap_vm_provision_iac_platform == 'existing_hosts'
+        - sap_domain | d('') | length > 0 or ansible_facts['domain'] | d('') | length > 0
+      block:
+
+        - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts  # noqa: no-tabs
+          ansible.builtin.import_role:
+            name: community.sap_install.sap_maintain_etc_hosts
+          vars:
+            sap_maintain_etc_hosts_delimiter: "\t"
+            sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+            sap_maintain_etc_hosts_list: >-
+              {%- set my_list = [] -%}
+              {%- for host in ansible_play_hosts_all -%}
+                {%- if hostvars[host] is defined and hostvars[host]['ansible_host'] is defined -%}
+                  {%- set _ = my_list.append({'node_name': host, 'node_ip': hostvars[host]['ansible_host']}) -%}
+                {%- endif -%}
+              {%- endfor -%}
+              {{ my_list }}
+
+        - name: Execute Ansible Role sap_maintain_etc_hosts for existing_hosts - HA  # noqa: no-tabs
+          ansible.builtin.import_role:
+            name: community.sap_install.sap_maintain_etc_hosts
+          vars:
+            sap_maintain_etc_hosts_delimiter: "\t"
+            sap_maintain_etc_hosts_domain: "{{ sap_domain }}"
+            sap_maintain_etc_hosts_list:
+              - node_name: "{{ sap_swpm_ascs_instance_hostname }}"
+                node_ip: "{{ sap_vm_provision_ha_vip_nwas_abap_ascs | regex_replace('/\\d+$', '') }}"
+              - node_name: "{{ sap_swpm_ers_instance_hostname }}"
+                node_ip: "{{ sap_vm_provision_ha_vip_nwas_abap_ers | regex_replace('/\\d+$', '') }}"
+
     - name: Install rsync
       ansible.builtin.package:
         name: rsync
@@ -207,7 +240,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"
@@ -239,7 +272,7 @@
   tasks:
 
     - name: Transfer SAP NetWeaver ERS installation media to host
-      delegate_to: "{{ software_source_ip }}"
+      delegate_to: "{{ software_source_ip if sap_vm_provision_iac_platform != 'existing_hosts' else software_source_hostname }}"
       remote_user: "root"
       ansible.posix.synchronize:
         src: "{{ file_item }}"

--- a/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_playbook.yml
+++ b/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_playbook.yml
@@ -241,6 +241,10 @@
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
         sap_software_download_deduplicate: last
+        # Enables broader search for known files, not just the bugfix versions.
+        # Example: Helps with downloading higher HANA revision version within same SPS level.
+        sap_software_download_find_upgrades: true
+        sap_software_download_upgrade_relationships: true
         sap_software_download_files: "{{ (
           sap_software_install_dictionary[sap_software_product]['sap_software_list_' ~ ansible_facts['architecture']] | d([]) +
           sap_software_install_dictionary[sap_software_product]['sap_software_list_independent'] | d([])) | unique }}"

--- a/special_actions/sap_sda/ansible_playbook.yml
+++ b/special_actions/sap_sda/ansible_playbook.yml
@@ -112,7 +112,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ sap_software_install_dictionary[sap_software_product]
           ['softwarecenter_search_list_' ~ ansible_facts['architecture']] }}"
       when:

--- a/special_actions/sap_webdispatcher_standalone/README.md
+++ b/special_actions/sap_webdispatcher_standalone/README.md
@@ -8,8 +8,8 @@ A single-host system, as defined by SAP, consolidates all SAP Database and SAP A
 This configuration, often referred to as a Two-Tier Architecture, OneHost, or Central System, is ideal for development, testing, and demonstration purposes.
 
 
-## Supported Infrastructure Platforms
-This Ansible Playbook supports the deployment on the following infrastructure platforms:
+## Compatible Infrastructure Platforms
+This Ansible Playbook is designed for and compatible with the following infrastructure platforms:
 
 - Amazon Web Services (AWS)
 - Google Cloud Platform (GCP)
@@ -17,15 +17,15 @@ This Ansible Playbook supports the deployment on the following infrastructure pl
 - IBM Cloud, IBM Power Virtual Servers
 - Microsoft Azure (MS Azure)
 - IBM PowerVM
-- OVirt
-- VMware
+- OVirt `Experimental`
+- VMware `Experimental`
 
 
-## Supported SAP Software
-This playbook includes support for the following software versions:
+## Included SAP Software Versions
+The playbook is pre-configured with the following SAP software versions:
 - Range of SAP Web Dispatcher versions from 7.20 to 7.89
 
-Additional versions can be supported by adding new entries to the `sap_software_install_dictionary` variable in the extravars file.
+> You can easily extend compatibility to other versions by adding new entries to the `sap_software_install_dictionary` variable in your extravars file.
 
 
 ## System Architecture
@@ -71,7 +71,7 @@ ansible-playbook ansible_playbook.yml \
 ```
 
 ### Interactive Execution
-This method is not supported due to complexity of this scenario.
+This method is not available due to complexity of this scenario.
 
 
 ## Deployment Process

--- a/special_actions/sap_webdispatcher_standalone/ansible_playbook.yml
+++ b/special_actions/sap_webdispatcher_standalone/ansible_playbook.yml
@@ -117,7 +117,7 @@
         sap_software_download_suser_id: "{{ sap_id_user }}"
         sap_software_download_suser_password: "{{ sap_id_user_password }}"
         sap_software_download_directory: "{{ sap_install_media_detect_source_directory }}"
-        sap_software_download_deduplicate: first
+        sap_software_download_deduplicate: last
         sap_software_download_files: "{{ sap_software_dict_x86_64[sap_playbook_webdispatcher_version]
           if ansible_facts['architecture'] == 'x86_64'
           else (sap_software_dict_ppc64le[sap_playbook_webdispatcher_version]


### PR DESCRIPTION
Bugfixes
---
- https://github.com/sap-linuxlab/ansible.playbooks_for_sap/pull/110
- https://github.com/sap-linuxlab/ansible.playbooks_for_sap/pull/111
- https://github.com/sap-linuxlab/ansible.playbooks_for_sap/pull/112

# Important
PR 112 contains update to linting workflow, but we cannot use it in current form.
Reason: Import of galaxy requirements runs forever and we need to find a way to maybe have dedicated short form requirements file, without all 3rd party collections. Using `--offline` like with local `ansible-lint` does not seem to be an option.