### PR TITLE
all: Make sap_swpm UID GID optional to pass pseudo idempotency checks

### DIFF
--- a/deploy_scenarios/sap_bw4hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_bw4hana_sandbox/ansible_extravars.yml
@@ -108,9 +108,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_extravars.yml
+++ b/deploy_scenarios/sap_bw4hana_standard_scaleout/ansible_extravars.yml
@@ -122,9 +122,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_ecc_hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_hana_sandbox/ansible_extravars.yml
@@ -108,9 +108,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed/ansible_extravars.yml
@@ -75,9 +75,9 @@ sap_swpm_pas_instance_hostname: "{{ hostvars[inventory_hostname].groups.nwas_pas
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_distributed_ha/ansible_extravars.yml
@@ -74,9 +74,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_ibmdb2_sandbox/ansible_extravars.yml
@@ -68,9 +68,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_oracledb_sandbox/ansible_extravars.yml
@@ -82,9 +82,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_sapase_sandbox/ansible_extravars.yml
@@ -68,9 +68,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ecc_sapmaxdb_sandbox/ansible_extravars.yml
@@ -69,9 +69,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ides_ecc_hana_sandbox/ansible_extravars.yml
@@ -108,9 +108,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_ides_ecc_ibmdb2_sandbox/ansible_extravars.yml
@@ -68,9 +68,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_landscape_s4hana_standard/ansible_extravars.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard/ansible_extravars.yml
@@ -97,9 +97,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_landscape_s4hana_standard_maintplan/ansible_extravars.yml
@@ -100,9 +100,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_abap_hana_sandbox/ansible_extravars.yml
@@ -108,9 +108,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_abap_ibmdb2_sandbox/ansible_extravars.yml
@@ -68,9 +68,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_abap_oracledb_sandbox/ansible_extravars.yml
@@ -82,9 +82,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapase_sandbox/ansible_extravars.yml
@@ -68,9 +68,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_abap_sapmaxdb_sandbox/ansible_extravars.yml
@@ -69,9 +69,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_java_ibmdb2_sandbox/ansible_extravars.yml
@@ -79,9 +79,9 @@ sap_swpm_ume_type: db # db, abap
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_nwas_java_sapase_sandbox/ansible_extravars.yml
@@ -78,9 +78,9 @@ sap_swpm_ume_type: db # db, abap
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_s4hana_distributed/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_distributed/ansible_extravars.yml
@@ -116,9 +116,9 @@ sap_swpm_pas_instance_hostname: "{{ hostvars[inventory_hostname].groups.nwas_pas
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_s4hana_distributed_ha/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha/ansible_extravars.yml
@@ -114,9 +114,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_ha_maintplan/ansible_extravars.yml
@@ -117,9 +117,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_distributed_maintplan/ansible_extravars.yml
@@ -119,9 +119,9 @@ sap_swpm_pas_instance_hostname: "{{ hostvars[inventory_hostname].groups.nwas_pas
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_sandbox/ansible_extravars.yml
@@ -108,9 +108,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_s4hana_foundation_standard/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_foundation_standard/ansible_extravars.yml
@@ -111,9 +111,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_s4hana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox/ansible_extravars.yml
@@ -108,9 +108,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_maintplan/ansible_extravars.yml
@@ -111,9 +111,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_s4hana_sandbox_syscopy/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_sandbox_syscopy/ansible_extravars.yml
@@ -118,9 +118,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_s4hana_standard/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_standard/ansible_extravars.yml
@@ -111,9 +111,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_extravars.yml
+++ b/deploy_scenarios/sap_s4hana_standard_maintplan/ansible_extravars.yml
@@ -114,9 +114,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_solman_sapase_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_solman_sapase_sandbox/ansible_extravars.yml
@@ -73,9 +73,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/deploy_scenarios/sap_solman_saphana_sandbox/ansible_extravars.yml
+++ b/deploy_scenarios/sap_solman_saphana_sandbox/ansible_extravars.yml
@@ -111,9 +111,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_extravars.yml
+++ b/special_actions/sap_nwas_abap_ascs_ers_cluster/ansible_extravars.yml
@@ -75,9 +75,9 @@ sap_swpm_fqdn: "{{ ansible_facts['domain'] }}"
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 

--- a/special_actions/sap_webdispatcher_standalone/ansible_extravars.yml
+++ b/special_actions/sap_webdispatcher_standalone/ansible_extravars.yml
@@ -78,9 +78,9 @@ sap_swpm_ume_j2ee_admin_password: '' # use ICM Auth Web Admin password
 
 #### SAP SWPM Installation - Optional variables ####
 ## Unix User ID
-sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
-sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
-sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
+# sap_swpm_sapadm_uid: '3000'  # Unix User ID for the sapadm user (String).
+# sap_swpm_sapsys_gid: '3001'  # Unix Group ID for the sapsys group (String).
+# sap_swpm_sidadm_uid: '3001'  # Unix User ID for the <sid>adm user (String).
 
 sap_swpm_update_etchosts: false  # Whether to update the /etc/hosts file during SWPM installation (String).
 


### PR DESCRIPTION
## Changes
Following [improvements in `sap_swpm` role](https://github.com/sap-linuxlab/community.sap_install/pull/1213), we need to comment out UID and GID variables, because they are now strictly validated.

Installing application using SWPM after DB is installed will always target `sapsys` group that has default ID, therefore validation will fail.

> **NOTE**: It could be re-interpreted in future if we are able to align pre-requisite roles like `sap_hana_install` and DB2/ORA to handle UID/GID in sync with SWPM role.

## Disclaimer
This would be part of open https://github.com/sap-linuxlab/ansible.playbooks_for_sap/pull/113